### PR TITLE
Add default_prefix support for Windows

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -28,6 +28,7 @@
 !define PY_VER __PY_VER__
 !define PYVERSION_JUSTDIGITS __PYVERSION_JUSTDIGITS__
 !define PYVERSION __PYVERSION__
+!define DEFAULT_PREFIX __DEFAULT_PREFIX__
 !define PRODUCT_NAME "${NAME} ${VERSION} (${ARCH})"
 !define UNINSTALL_NAME "Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})"
 !define UNINSTREG "Software\Microsoft\Windows\CurrentVersion\
@@ -372,7 +373,7 @@ Function .onInit
     ${If} $IsDomainUser = 0
         StrCpy $INSTDIR_JUSTME "$Profile\${NAME}"
     ${ElseIf} $IsDomainUser = 1
-        StrCpy $INSTDIR_JUSTME "$LocalAppData\Continuum\${NAME}"
+        StrCpy $INSTDIR_JUSTME ${DEFAULT_PREFIX}
     ${Else}
         # Should never happen; indicates a logic error above.
         MessageBox MB_OK "Internal error: IsUserDomain not set properly!"

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -10,7 +10,7 @@ import os
 import sys
 import shutil
 import tempfile
-from os.path import abspath, dirname, isfile, join
+from os.path import abspath, dirname, isfile, join, expandvars
 from subprocess import check_call
 
 from constructor.construct import ns_platform
@@ -89,6 +89,10 @@ def make_nsi(info, dir_path):
         'OUTFILE': info['_outpath'],
         'LICENSEFILE': abspath(info.get('license_file',
                                join(NSIS_DIR, 'placeholder_license.txt'))),
+        'DEFAULT_PREFIX': expandvars(info.get(
+            'default_prefix',
+            join('%LOCALAPPDATA%', 'Continuum', name.lower())
+        )),
     }
     for key, fn in [('HEADERIMAGE', 'header.bmp'),
                     ('WELCOMEIMAGE', 'welcome.bmp'),


### PR DESCRIPTION
I modified winexe.py and main.nsi.tmpl slightly to allow the construct.yaml file to specify the `default_prefix` key to be used to customize the installation location.  I believe it should have the same behavior as in shar.py for unix based systems, but I don't have access to one right now to confirm.  This change calls `os.path.expandvars` on the value of `default_prefix` instead of relying on the NSIS `$LocalAppData` variable to expand the path.  This should also make the feature as powerful as for unix installers since variables other than `$HOME`/`%LOCALAPPDATA%` could be used in the prefix.

An example usage is:

```yaml
name: test
version: "1.0.0.0"

channels:
  - http://repo.continuum.io/pkgs/free/

specs:
  - python

default_prefix: "%LOCALAPPDATA%\Company ABC\test"
```

This would build a minimal installer which when installed with "Just for me" on Windows would point at `C:\Users\username\AppData\Local\Company ABC\test`.  If you see any problems with it let me know and I'll get them fixed.