### PR TITLE
Expansion of environment variables to occur at the time of install for Windows

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -373,7 +373,8 @@ Function .onInit
     ${If} $IsDomainUser = 0
         StrCpy $INSTDIR_JUSTME "$Profile\${NAME}"
     ${ElseIf} $IsDomainUser = 1
-        StrCpy $INSTDIR_JUSTME ${DEFAULT_PREFIX}
+        ExpandEnvStrings $0 ${DEFAULT_PREFIX}
+        StrCpy $INSTDIR_JUSTME $0
     ${Else}
         # Should never happen; indicates a logic error above.
         MessageBox MB_OK "Internal error: IsUserDomain not set properly!"

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -10,7 +10,7 @@ import os
 import sys
 import shutil
 import tempfile
-from os.path import abspath, dirname, isfile, join, expandvars
+from os.path import abspath, dirname, isfile, join
 from subprocess import check_call
 
 from constructor.construct import ns_platform
@@ -89,10 +89,10 @@ def make_nsi(info, dir_path):
         'OUTFILE': info['_outpath'],
         'LICENSEFILE': abspath(info.get('license_file',
                                join(NSIS_DIR, 'placeholder_license.txt'))),
-        'DEFAULT_PREFIX': expandvars(info.get(
+        'DEFAULT_PREFIX': info.get(
             'default_prefix',
             join('%LOCALAPPDATA%', 'Continuum', name.lower())
-        )),
+        ),
     }
     for key, fn in [('HEADERIMAGE', 'header.bmp'),
                     ('WELCOMEIMAGE', 'welcome.bmp'),


### PR DESCRIPTION
This is a fix for [the pull request](https://github.com/conda/constructor/pull/7) I submitted several days ago which added the ability to use the `default_prefix` key in a `construct.yaml` file on Windows platforms.

## Description of bug

Since the python file `constructor/winexe.py` uses `os.path.expandvars` when populating the NSIS script `constructor/nsis/main.nsi.tmpl`, environment variables in the `default_prefix` variable pulled from the `construct.yaml` file would be expanded when the installer was built, not when the installer was run.

Today I noticed that the way it had been implemented meant that environment variables expanded when the installer was built, not when the installer was run.  This means that if user jdoe built the `.exe` with a default prefix of `%LOCALAPPDATA%\Company\name` then it would point at `C:\Users\jdoe\AppData\Local\Company\name` by default when installed by any user.

## Solution

This bug was fixed by removing the call to `os.path.expandvars` from `constructor.winexe`, and by adding the call `ExpandEnvStrings $0 ${DEFAULT_PREFIX}` inside the NSIS function `.onInit`.  This value is then copied into the variable `INSTDIR_JUSTME` instead of pulling directly from `DEFAULT_PREFIX`.

## Testing performed

I tested this functionality by building a simple installer from the `construct.yaml` file:
```yaml
name: basic
version: "0.0.0.1"

specs:
  - python

default_prefix: '%LOCALAPPDATA%\Company\basic'
```
Then ran this installer both locally and on another user's computer.  The default install path was correctly evaluated on both computers.  I also tested it with `default_prefix: '%FOOBAR%\Company\basic` and noted that the default install path was then changed to `%FOOBAR%\Company\basic` as that environment variable was not defined.  I'm of the opinion that this is an acceptable behavior for right now, but in the future it may be worth the effort to sanitize this variable a little bit more to ensure that all environment variables are defined to prevent potential errors.