### PR TITLE
Don't install menus if menuinst raises an OSError on import.

### DIFF
--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -66,7 +66,7 @@ def create_conda_meta():
 def mk_menus(remove=False):
     try:
         import menuinst
-    except ImportError:
+    except (ImportError, OSError):
         return
     menu_dir = join(sys.prefix, 'Menu')
     if os.path.exists(menu_dir):


### PR DESCRIPTION
This can happen when, on Windows, menuinst can't find all the system
directories it needs in order to install the menus.
When running in an environment unable to displa a GUI interface,
an uncaught exception like this can result in a frozen install with
no visible debug info available on the command line.