### PR TITLE
Use get_index, handle conda 4.1 channels

### DIFF
--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -6,6 +6,8 @@
 
 import re
 import sys
+from conda.install import name_dist, dist2filename
+from conda.config import url2dist
 
 
 def fill_template(data, d):
@@ -16,10 +18,6 @@ def fill_template(data, d):
         return d[key]
 
     return pat.sub(replace, data)
-
-
-def name_dist(dist):
-    return dist.rsplit('-', 2)[0]
 
 
 def read_ascii_only(path):

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -7,7 +7,7 @@
 import re
 import sys
 from conda.install import name_dist, dist2filename
-from conda.config import url2dist
+from conda.config import url_channel
 
 
 def fill_template(data, d):
@@ -28,6 +28,12 @@ def read_ascii_only(path):
             sys.exit("Error: unexpected non-ASCII character '%s' in: %s" %
                      (c, path))
     return data
+
+
+def url2dist(url):
+    fn = url.rsplit('/', 1)[-1]
+    _, schannel = url_channel(url)
+    return fn if schannel == 'defaults' else schannel + '::' + fn
 
 
 if_pat = re.compile(r'^#if ([ \S]+)$\n'

--- a/examples/newchan/construct.yaml
+++ b/examples/newchan/construct.yaml
@@ -1,0 +1,15 @@
+name: Funnychan
+version: 2.5.5
+
+channels:
+  - http://repo.continuum.io/pkgs/free/
+  - https://conda.anaconda.org/ilan
+
+# specifications
+specs:
+  - python
+  - grin
+  - sample
+
+license_file: eula.txt
+

--- a/examples/newchan/eula.txt
+++ b/examples/newchan/eula.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2016, ...
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of ... nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ... BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
I'm using a single call to `api.get_index` in order to get all the repodata. This has one consequence that you may wish me to reverse: it includes any channels explicitly listed in the `packages` list in the channel index that is used to resolve `specs`.