### PR TITLE
Include urls.txt in the constructor package

### DIFF
--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -93,6 +93,7 @@ def create(info):
     t = tarfile.open(tarball, 'w')
     if 'license_file' in info:
         t.add(info['license_file'], 'LICENSE.txt')
+    t.add(join(info['_download_dir'], 'urls.txt'), 'pkgs/' + 'urls.txt')
     for fn in info['_dists']:
         t.add(join(info['_download_dir'], fn), 'pkgs/' + fn)
     t.add(join(conda.install.__file__.rstrip('co')), 'pkgs/install.py')


### PR DESCRIPTION
See the discussion in #24. To understand the motivation, consider building the Maxiconda package, installing it, and running `conda update --all`. I get the following result:
```
The following NEW packages will be INSTALLED:

    pyqt:              4.11.4-py35_3                     
    qt:                4.8.7-3                           
    sip:               4.16.9-py35_0                     

The following packages will be UPDATED:

    appnope:           0.1.0-py35_0             <unknown> --> 0.1.0-py35_0            
    backports:         1.0-py35_0               <unknown> --> 1.0-py35_0              
    conda:             4.1.2-py35_0             <unknown> --> 4.1.2-py35_0            
    conda-env:         2.5.1-py35_0             <unknown> --> 2.5.1-py35_0            
    cycler:            0.10.0-py35_0            <unknown> --> 0.10.0-py35_0           
    decorator:         4.0.10-py35_0            <unknown> --> 4.0.10-py35_0           
    entrypoints:       0.2-py35_1               <unknown> --> 0.2-py35_1              
    freetype:          2.5.5-1                  <unknown> --> 2.5.5-1                 
    get_terminal_size: 1.0.0-py35_0             <unknown> --> 1.0.0-py35_0            
    ipykernel:         4.3.1-py35_0             <unknown> --> 4.3.1-py35_0            
    ipython:           4.2.0-py35_1             <unknown> --> 4.2.0-py35_1            
    ipython_genutils:  0.1.0-py35_0             <unknown> --> 0.1.0-py35_0            
    jinja2:            2.8-py35_1               <unknown> --> 2.8-py35_1              
    jsonschema:        2.5.1-py35_0             <unknown> --> 2.5.1-py35_0            
    jupyter_client:    4.2.2-py35_0             <unknown> --> 4.2.2-py35_0            
    jupyter_core:      4.1.0-py35_0             <unknown> --> 4.1.0-py35_0            
    libpng:            1.6.22-0                 <unknown> --> 1.6.22-0                
    lighttpd:          1.4.39-0                 <unknown> --> 1.4.39-0                
    markupsafe:        0.23-py35_2              <unknown> --> 0.23-py35_2             
    matplotlib:        1.5.1-np111py35_0        <unknown> --> 1.5.1-np111py35_0       
    mistune:           0.7.2-py35_1             <unknown> --> 0.7.2-py35_1            
    nbconvert:         4.2.0-py35_0             <unknown> --> 4.2.0-py35_0            
    nbformat:          4.0.1-py35_0             <unknown> --> 4.0.1-py35_0            
    nomkl:             1.0-0                    <unknown> --> 1.0-0                   
    notebook:          4.2.1-py35_0             <unknown> --> 4.2.1-py35_0            
    numpy:             1.11.0-py35_nomkl_1      <unknown> [nomkl] --> 1.11.0-py35_nomkl_1      [nomkl]
    openssl:           1.0.2h-1                 <unknown> --> 1.0.2h-1                
    pandas:            0.18.1-np111py35_0       <unknown> --> 0.18.1-np111py35_0      
    path.py:           8.2.1-py35_0             <unknown> --> 8.2.1-py35_0            
    pexpect:           4.0.1-py35_0             <unknown> --> 4.0.1-py35_0            
    pickleshare:       0.7.2-py35_0             <unknown> --> 0.7.2-py35_0            
    pip:               8.1.2-py35_0             <unknown> --> 8.1.2-py35_0            
    ptyprocess:        0.5.1-py35_0             <unknown> --> 0.5.1-py35_0            
    pycosat:           0.6.1-py35_1             <unknown> --> 0.6.1-py35_1            
    pygments:          2.1.3-py35_0             <unknown> --> 2.1.3-py35_0            
    pyparsing:         2.1.4-py35_0             <unknown> --> 2.1.4-py35_0            
    python:            3.5.1-0                  <unknown> --> 3.5.1-0                 
    python-dateutil:   2.5.3-py35_0             <unknown> --> 2.5.3-py35_0            
    python.app:        1.2-py35_4               <unknown> --> 1.2-py35_4              
    pytz:              2016.4-py35_0            <unknown> --> 2016.4-py35_0           
    pyyaml:            3.11-py35_4              <unknown> --> 3.11-py35_4             
    pyzmq:             15.2.0-py35_1            <unknown> --> 15.2.0-py35_1           
    readline:          6.2-2                    <unknown> --> 6.2-2                   
    requests:          2.10.0-py35_0            <unknown> --> 2.10.0-py35_0           
    ruamel_yaml:       0.11.7-py35_0            <unknown> --> 0.11.7-py35_0           
    scipy:             0.17.1-np111py35_nomkl_0 <unknown> [nomkl] --> 0.17.1-np111py35_nomkl_0 [nomkl]
    setuptools:        23.0.0-py35_0            <unknown> --> 23.0.0-py35_0           
    simplegeneric:     0.8.1-py35_1             <unknown> --> 0.8.1-py35_1            
    six:               1.10.0-py35_0            <unknown> --> 1.10.0-py35_0           
    sqlite:            3.13.0-0                 <unknown> --> 3.13.0-0                
    terminado:         0.6-py35_0               <unknown> --> 0.6-py35_0              
    tk:                8.5.18-0                 <unknown> --> 8.5.18-0                
    tornado:           4.3-py35_1               <unknown> --> 4.3-py35_1              
    traitlets:         4.2.1-py35_0             <unknown> --> 4.2.1-py35_0            
    wheel:             0.29.0-py35_0            <unknown> --> 0.29.0-py35_0           
    xz:                5.0.5-1                  <unknown> --> 5.0.5-1                 
    yaml:              0.1.6-0                  <unknown> --> 0.1.6-0                 
    zlib:              1.2.8-3                  <unknown> --> 1.2.8-3                 
```
The reason this occurs is that `conda` doesn't realize that the packages are identical, because they are coming from different channels; and because it assigns the `defaults` channel a higher priority, it believes the packages should be replaced. 

With `urls.txt` included, none of the updates occur, and we're left only with the three new installs, which is the proper result.