### PR TITLE
Unlink files prior to writing with a new prefix

### DIFF
--- a/constructor/install.py
+++ b/constructor/install.py
@@ -188,6 +188,7 @@ def update_prefix(path, new_prefix, placeholder, mode):
     if new_data == data:
         return
     st = os.lstat(path)
+    os.unlink(path)     # unlink in case the file is memory mapped
     with exp_backoff_fn(open, path, 'wb') as fo:
         fo.write(new_data)
     os.chmod(path, stat.S_IMODE(st.st_mode))


### PR DESCRIPTION
When performing prefix replacement during an install it may be possible that
the file being updated is memory mapped, for example binary files associated
with the Python package.  Performing an in-place update on a memory mapped file
can result in a bus error.  To prevent this the file is unlinked prior to
writing the file with the new prefix.

closes #57 