### PR TITLE
Add optional readme.txt support

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -85,6 +85,12 @@ The filename of the installer being created.  A reasonable default filename
 will determined by the `name`, `version`, platform and installer type.
 
 
+`readme_file`:
+----------------
+Path to a readme file, which, if provided, is being displayed by the installer
+during the install process.
+
+
 `license_file`:
 ----------------
 Path to the license file being displayed by the installer during the install

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -100,6 +100,11 @@ The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 '''),
 
+    ('readme_file',           False, str, '''
+Path to the readme file being displayed by the installer during the install
+process.
+    '''),
+
     ('license_file',           False, str, '''
 Path to the license file being displayed by the installer during the install
 process.

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -121,6 +121,12 @@ then
 
     echo "
 Welcome to __NAME__ __VERSION__"
+#if has_readme
+    echo "About __NAME__ __VERSION__:"
+    more <<EOF
+__README__
+EOF
+#endif
 #if has_license
     echo -n "
 In order to continue the installation process, please review the license

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -92,7 +92,8 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
         if key not in info:
             info[key] = info['name']
 
-    for key in ('license_file', 'welcome_image', 'header_image', 'icon_image',
+    for key in ('readme_file', 'license_file',
+                'welcome_image', 'header_image', 'icon_image',
                 'pre_install', 'post_install'):
         if key in info:
             info[key] = abspath(join(dir_path, info[key]))

--- a/constructor/nsis/MUI_EXTRAPAGES.nsh
+++ b/constructor/nsis/MUI_EXTRAPAGES.nsh
@@ -1,0 +1,79 @@
+# License:
+#  This header file is provided 'as-is', without any express or implied
+#  warranty. In no event will the author be held liable for any damages arising
+#  from the use of this header file.
+#
+#  Permission is granted to anyone to use this header file for any purpose,
+#  including commercial applications, and to alter it and redistribute it
+#  freely, subject to the following restrictions:
+#
+#   1. The origin of this header file must not be misrepresented; you must not
+#      claim that you wrote the original header file. If you use this header
+#      file a product, an acknowledgment in the product documentation would be
+#      appreciated but is not required.
+#   2. Altered versions must be plainly marked as such, and must not be
+#      misrepresented as being the original header file.
+#   3. This notice may not be removed or altered from any distribution.
+#
+# Source: http://nsis.sourceforge.net/Readme_Page_Based_on_MUI_License_Page
+
+#   MUI_EXTRAPAGES.nsh
+#   By Red Wine Jan 2007
+
+!verbose push
+!verbose 3
+
+!ifndef _MUI_EXTRAPAGES_NSH
+!define _MUI_EXTRAPAGES_NSH
+
+!ifmacrondef MUI_EXTRAPAGE_README & MUI_PAGE_README & MUI_UNPAGE_README & ReadmeLangStrings
+
+!macro MUI_EXTRAPAGE_README UN ReadmeFile
+!verbose push
+!verbose 3
+   !define MUI_PAGE_HEADER_TEXT "$(${UN}ReadmeHeader)"
+   !define MUI_PAGE_HEADER_SUBTEXT "$(${UN}ReadmeSubHeader)"
+   !define MUI_LICENSEPAGE_TEXT_TOP "$(${UN}ReadmeTextTop)"
+   !define MUI_LICENSEPAGE_TEXT_BOTTOM "$(${UN}ReadmeTextBottom)"
+   !define MUI_LICENSEPAGE_BUTTON "$(^NextBtn)"
+   !insertmacro MUI_${UN}PAGE_LICENSE "${ReadmeFile}"
+!verbose pop
+!macroend
+
+!define ReadmeRun "!insertmacro MUI_EXTRAPAGE_README"
+
+
+!macro MUI_PAGE_README ReadmeFile
+!verbose push
+!verbose 3
+    ${ReadmeRun} "" "${ReadmeFile}"
+!verbose pop
+!macroend
+
+
+!macro MUI_UNPAGE_README ReadmeFile
+!verbose push
+!verbose 3
+    ${ReadmeRun} "UN" "${ReadmeFile}"
+!verbose pop
+!macroend
+
+
+!macro ReadmeLangStrings UN MUI_LANG ReadmeHeader ReadmeSubHeader ReadmeTextTop ReadmeTextBottom
+!verbose push
+!verbose 3
+    LangString ${UN}ReadmeHeader     ${MUI_LANG} "${ReadmeHeader}"
+    LangString ${UN}ReadmeSubHeader  ${MUI_LANG} "${ReadmeSubHeader}"
+    LangString ${UN}ReadmeTextTop    ${MUI_LANG} "${ReadmeTextTop}"
+    LangString ${UN}ReadmeTextBottom ${MUI_LANG} "${ReadmeTextBottom}"
+!verbose pop
+!macroend
+
+!define ReadmeLanguage `!insertmacro ReadmeLangStrings ""`
+
+!define Un.ReadmeLanguage `!insertmacro ReadmeLangStrings "UN"`
+
+!endif
+!endif
+
+!verbose pop

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -21,6 +21,10 @@ Unicode "true"
 
 !include "Utils.nsh"
 
+#if has_readme
+!include "MUI_EXTRAPAGES.nsh"
+#endif
+
 !define NAME __NAME__
 !define VERSION __VERSION__
 !define COMPANY __COMPANY__
@@ -94,6 +98,9 @@ BrandingText /TRIMLEFT "${COMPANY}"
 !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipPageIfUACInnerInstance
 !insertmacro MUI_PAGE_WELCOME
 !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipPageIfUACInnerInstance
+#if has_readme
+!insertmacro MUI_PAGE_README __READMEFILE__
+#endif
 !insertmacro MUI_PAGE_LICENSE __LICENSEFILE__
 Page Custom InstModePage_Create InstModePage_Leave
 !define MUI_PAGE_CUSTOMFUNCTION_PRE DisableBackButtonIfUACInnerInstance
@@ -111,6 +118,15 @@ Page Custom mui_AnaCustomOptions_Show
 
 # Language
 !insertmacro MUI_LANGUAGE "English"
+#if has_readme
+# Source:
+# http://nsis.sourceforge.net/Readme_Page_Based_on_MUI_License_Page#Usage_Example
+${ReadmeLanguage} "${LANG_ENGLISH}" \
+    "Read Me" \
+    "Please review the following important information." \
+    "About $(^name):" \
+    "$\n  Click on scrollbar arrows or press Page Down to review the entire text."
+#endif
 
 Function SkipPageIfUACInnerInstance
     ${If} ${UAC_IsInnerInstance}

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -46,9 +46,11 @@ def get_header(tarball, info):
     dist0 = dists[0]
     assert name_dist(dist0) == 'python'
 
+    has_readme = bool('readme_file' in info)
     has_license = bool('license_file' in info)
     ppd = ns_platform(info['_platform'])
     ppd['keep_pkgs'] = bool(info.get('keep_pkgs'))
+    ppd['has_readme'] = has_readme
     ppd['has_license'] = has_license
     for key in 'pre_install', 'post_install':
         ppd['has_%s' % key] = bool(key in info)
@@ -69,6 +71,8 @@ def get_header(tarball, info):
         'INSTALL_COMMANDS': '\n'.join(install_lines),
         'pycache': '__pycache__',
     }
+    if has_readme:
+        replace['README'] = read_ascii_only(info['readme_file'])
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])
 
@@ -92,6 +96,8 @@ def create(info):
     preconda.write_files(info, tmp_dir)
     tarball = join(tmp_dir, 'tmp.tar')
     t = tarfile.open(tarball, 'w')
+    if 'readme_file' in info:
+        t.add(info['readme_file'], 'README.txt')
     if 'license_file' in info:
         t.add(info['license_file'], 'LICENSE.txt')
     for fn in preconda.files:

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -88,6 +88,7 @@ def make_nsi(info, dir_path):
     assert py_name == 'python'
     arch = int(info['_platform'].split('-')[1])
 
+    has_readme = bool('readme_file' in info)
     # these appear as __<key>__ in the template, and get escaped
     replace = {
         'NAME': name,
@@ -106,6 +107,8 @@ def make_nsi(info, dir_path):
             join('%LOCALAPPDATA%', 'Continuum', name.lower())
         ),
     }
+    if has_readme:
+        replace['READMEFILE'] = abspath(info.get('readme_file'))
     for key, fn in [('HEADERIMAGE', 'header.bmp'),
                     ('WELCOMEIMAGE', 'welcome.bmp'),
                     ('ICONFILE', 'icon.ico'),
@@ -121,6 +124,7 @@ def make_nsi(info, dir_path):
     ppd = ns_platform(info['_platform'])
     ppd['add_to_path_default'] = info.get('add_to_path_default', None)
     ppd['register_python_default'] = info.get('register_python_default', None)
+    ppd['has_readme'] = has_readme
     data = preprocess(data, ppd)
     data = fill_template(data, replace)
 

--- a/examples/grin/construct.yaml
+++ b/examples/grin/construct.yaml
@@ -46,6 +46,10 @@ installer_type: pkg                   [osx]
 # the `name`, (optional) `version`, OS and installer type)
 #installer_filename: grin.sh
 
+# an optional file with a readme text, which is shown during the install
+# process
+readme_file: install_readme.txt
+
 # a file with a license text, which is shown during the install process
 license_file: eula.txt
 

--- a/examples/grin/install_readme.txt
+++ b/examples/grin/install_readme.txt
@@ -1,0 +1,2 @@
+This Readme can hold arbitrary textual information about the installation.
+It is only included if 'readme_file' is included in 'construct.yaml'.


### PR DESCRIPTION
This adds the ability to show an included readme during installation, similar to how it's done with the license file.
The readme will only be included if the new key `readme_file` defined in `construct.yaml`.