### PR TITLE
Add customization for welcome and header image texts

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -133,6 +133,18 @@ used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
 The default is `blue`.
 
 
+`welcome_image_text`:
+----------------
+If `welcome_image` is not provided, use this text when generating the image
+(Windows only). Defaults to `name`.
+
+
+`header_image_text`:
+----------------
+If `header_image` is not provided, use this text when generating the image
+(Windows only). Defaults to `name`.
+
+
 `add_to_path_default`:
 ----------------
 Default choice for whether to add the installation to the PATH environment

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -142,6 +142,16 @@ used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
 The default is `blue`.
 '''),
 
+    ('welcome_image_text',     False, str, '''
+If `welcome_image` is not provided, use this text when generating the image
+(Windows only). Defaults to `name`.
+'''),
+
+    ('header_image_text',      False, str, '''
+If `header_image` is not provided, use this text when generating the image
+(Windows only). Defaults to `name`.
+'''),
+
     ('add_to_path_default',    False, bool, '''
 Default choice for whether to add the installation to the PATH environment
 variable. The user is still able to change this during interactive

--- a/constructor/imaging.py
+++ b/constructor/imaging.py
@@ -29,20 +29,33 @@ def new_background(size, color, bs=20, boxes=50):
     return im
 
 
+def add_text(im, xy, text, min_lines, line_height, font, color):
+    x, y = xy
+    d = ImageDraw.Draw(im)
+    lines = text.splitlines()
+    text_height = len(lines) * line_height
+    min_text_height = min_lines * line_height
+    y = int(y * (im.height - text_height) / (im.height - min_text_height))
+    for line in text.splitlines():
+        d.text((x, y), line, fill=color, font=font)
+        y += line_height
+    return d
+
+
 def mk_welcome_image(info):
     font = ImageFont.truetype(ttf_path, 20)
     im = new_background(welcome_size, info['_color'])
-    d = ImageDraw.Draw(im)
-    d.text((20, 100), info['name'], fill=white, font=font)
-    d.text((20, 130), info['version'], fill=white, font=font)
+    text = '\n'.join([info['welcome_image_text'], info['version']])
+    add_text(im, (20, 100), text, 2, 30, font, white)
     return im
 
 
 def mk_header_image(info):
     font = ImageFont.truetype(ttf_path, 20)
     im = Image.new('RGB', header_size, color=white)
-    d = ImageDraw.Draw(im)
-    d.text((20, 15), info['name'], fill=info['_color'], font=font)
+    text = info['header_image_text']
+    color = info['_color']
+    add_text(im, (20, 15), text, 1, 20, font, color)
     return im
 
 

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -88,6 +88,10 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     if verbose:
         print('conda packages download: %s' % info['_download_dir'])
 
+    for key in ('welcome_image_text', 'header_image_text'):
+        if key not in info:
+            info[key] = info['name']
+
     for key in ('license_file', 'welcome_image', 'header_image', 'icon_image',
                 'pre_install', 'post_install'):
         if key in info:

--- a/examples/grin/construct.yaml
+++ b/examples/grin/construct.yaml
@@ -51,3 +51,12 @@ license_file: eula.txt
 
 # default install prefix
 #default_prefix: /opt/example
+
+# If `welcome_image` or `header_image` are not provided, their texts
+# default to `name`, which may be overridden by the following keys
+#welcome_image_text: |-
+#                    multi-line
+#                    welcome-text
+#header_image_text:  |-
+#                    multi-line
+#                    header-text


### PR DESCRIPTION
This adds two new keys (`welcome_image_text` and `header_image_text`) which lets the user specify custom texts for the image generation. Use case: Installer name is too long for the width of `welcome_image` / `header_image`. Given the new keys, the user can provide multi-line texts to get around this problem (see `examples/grin/construct.yaml `).