### PR TITLE
Add ability to provide defaults for custom options

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -132,3 +132,17 @@ The color of the default images (when not providing explicit image files)
 used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
 The default is `blue`.
 
+
+`add_to_path_default`:
+----------------
+Default choice for whether to add the installation to the PATH environment
+variable. The user is still able to change this during interactive
+installation.
+
+
+`register_python_default`:
+----------------
+Default choice for whether to register the installed Python instance as the
+system's default Python. The user is still able to change this during
+interactive installation. (Windows only)
+

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -131,6 +131,18 @@ The color of the default images (when not providing explicit image files)
 used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
 The default is `blue`.
 '''),
+
+    ('add_to_path_default',    False, bool, '''
+Default choice for whether to add the installation to the PATH environment
+variable. The user is still able to change this during interactive
+installation.
+'''),
+
+    ('register_python_default',  False, bool, '''
+Default choice for whether to register the installed Python instance as the
+system's default Python. The user is still able to change this during
+interactive installation. (Windows only)
+'''),
 ]
 
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -292,6 +292,12 @@ then
     BASH_RC=$HOME/.bashrc
     DEFAULT=no
 #endif
+#if add_to_path_default is True
+    DEFAULT=yes
+#endif
+#if add_to_path_default is False
+    DEFAULT=no
+#endif
 
     echo -n "Do you wish the installer to prepend the __NAME__ install location
 to PATH in your $BASH_RC ? [yes|no]

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -394,6 +394,20 @@ Function .onInit
 
     # Initialize the default settings for the anaconda custom options
     Call mui_AnaCustomOptions_InitDefaults
+    # Override custom options with explicitly given values from contruct.yaml.
+    # If add_to_path_default (register_python_default) is None, do nothing.
+#if add_to_path_default is True
+    StrCpy $Ana_AddToPath_State ${BST_CHECKED}
+#endif
+#if add_to_path_default is False
+    StrCpy $Ana_AddToPath_State ${BST_UNCHECKED}
+#endif
+#if register_python_default is True
+    StrCpy $Ana_RegisterSystemPython_State ${BST_CHECKED}
+#endif
+#if register_python_default is False
+    StrCpy $Ana_RegisterSystemPython_State ${BST_UNCHECKED}
+#endif
 
     Pop $R2
     Pop $R1

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -52,6 +52,7 @@ def get_header(tarball, info):
     ppd['has_license'] = has_license
     for key in 'pre_install', 'post_install':
         ppd['has_%s' % key] = bool(key in info)
+    ppd['add_to_path_default'] = info.get('add_to_path_default', None)
 
     install_lines = ['install_dist %s' % d for d in dists]
     install_lines.extend(add_condarc(info))

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -118,7 +118,10 @@ def make_nsi(info, dir_path):
         replace[key] = str_esc(replace[key])
 
     data = read_nsi_tmpl()
-    data = preprocess(data, ns_platform(info['_platform']))
+    ppd = ns_platform(info['_platform'])
+    ppd['add_to_path_default'] = info.get('add_to_path_default', None)
+    ppd['register_python_default'] = info.get('register_python_default', None)
+    data = preprocess(data, ppd)
     data = fill_template(data, replace)
 
     cmds = pkg_commands(download_dir, dists, py_version,


### PR DESCRIPTION
This adds to new keys (`add_to_path_default`, `register_python_default`) with which the installer's custom options can be given explicit default values in `construct.yaml`. Useful if one wants to create an installer which, by default, does not interfere with the system (i.e. both values set to `False`).