### PR TITLE
Add basic jinja2 support

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -170,27 +170,16 @@ def select_lines(data, namespace):
 
 
 # adapted from conda-build
-def render_jinja(data):
-    try:
-        import jinja2
-    except ImportError as ex:
-        raise exceptions.UnableToParseMissingJinja2(original=ex)
-    env = jinja2.Environment()
-    try:
-        template = env.from_string(data)
-        rendered = template.render()
-    except jinja2.TemplateError as ex:
-        raise exceptions.UnableToParse(original=ex)
-    return rendered
-
-
-# adapted from conda-build
 def yamlize(data):
     try:
         return yaml.load(data)
     except yaml.error.YAMLError as e:
         if ('{{' not in data) and ('{%' not in data):
             raise exceptions.UnableToParse(original=e)
+        try:
+            from constructor.jinja import render_jinja
+        except ImportError as ex:
+            raise exceptions.UnableToParseMissingJinja2(original=ex)
         data = render_jinja(data)
         return yaml.load(data)
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -4,13 +4,16 @@
 # constructor is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
+from functools import partial
+from os.path import abspath, dirname
 import re
 import sys
-from os.path import abspath
 
 import yaml
 
-from constructor import exceptions
+from constructor.exceptions import (
+    UnableToParse, UnableToParseMissingJinja2, YamlParsingError,
+)
 
 
 PREABLE = '''\n
@@ -170,17 +173,18 @@ def select_lines(data, namespace):
 
 
 # adapted from conda-build
-def yamlize(data):
+def yamlize(data, directory, content_filter):
+    data = content_filter(data)
     try:
         return yaml.load(data)
     except yaml.error.YAMLError as e:
         if ('{{' not in data) and ('{%' not in data):
-            raise exceptions.UnableToParse(original=e)
+            raise UnableToParse(original=e)
         try:
             from constructor.jinja import render_jinja
         except ImportError as ex:
-            raise exceptions.UnableToParseMissingJinja2(original=ex)
-        data = render_jinja(data)
+            raise UnableToParseMissingJinja2(original=ex)
+        data = render_jinja(data, directory, content_filter)
         return yaml.load(data)
 
 
@@ -190,10 +194,11 @@ def parse(path, platform):
             data = fi.read()
     except IOError:
         sys.exit("Error: could not open '%s' for reading" % path)
-    data = select_lines(data, ns_platform(platform))
+    directory = dirname(path)
+    content_filter = partial(select_lines, namespace=ns_platform(platform))
     try:
-        res = yamlize(data)
-    except exceptions.YamlParsingError as e:
+        res = yamlize(data, directory, content_filter)
+    except YamlParsingError as e:
         sys.exit(e.error_msg())
 
     try:

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -189,7 +189,7 @@ def yamlize(data):
     try:
         return yaml.load(data)
     except yaml.error.YAMLError as e:
-        if '{{' not in data:
+        if ('{{' not in data) and ('{%' not in data):
             raise exceptions.UnableToParse(original=e)
         data = render_jinja(data)
         return yaml.load(data)

--- a/constructor/exceptions.py
+++ b/constructor/exceptions.py
@@ -1,0 +1,44 @@
+# adapted from conda-build
+
+import textwrap
+SEPARATOR = "-" * 70
+
+indent = lambda s: textwrap.fill(textwrap.dedent(s))
+
+
+class YamlParsingError(Exception):
+    pass
+
+
+class UnableToParse(YamlParsingError):
+    def __init__(self, original, *args, **kwargs):
+        super(UnableToParse, self).__init__(*args, **kwargs)
+        self.original = original
+
+    def error_msg(self):
+        return "\n".join([
+            SEPARATOR,
+            self.error_body(),
+            self.indented_exception(),
+        ])
+
+    def error_body(self):
+        return "\n".join([
+            "Unable to parse meta.yaml file\n",
+        ])
+
+    def indented_exception(self):
+        orig = str(self.original)
+        indent = lambda s: s.replace("\n", "\n--> ")
+        return "Error Message:\n--> {}\n\n".format(indent(orig))
+
+
+class UnableToParseMissingJinja2(UnableToParse):
+    def error_body(self):
+        return "\n".join([
+            super(UnableToParseMissingJinja2, self).error_body(),
+            indent("""\
+                It appears you are missing jinja2.  Please install that
+                package, then attempt to build.
+            """),
+        ])

--- a/constructor/jinja.py
+++ b/constructor/jinja.py
@@ -1,0 +1,13 @@
+from jinja2 import Environment, TemplateError
+
+from constructor.exceptions import UnableToParse
+
+# adapted from conda-build
+def render_jinja(data):
+    env = Environment()
+    try:
+        template = env.from_string(data)
+        rendered = template.render()
+    except TemplateError as ex:
+        raise UnableToParse(original=ex)
+    return rendered

--- a/constructor/jinja.py
+++ b/constructor/jinja.py
@@ -1,10 +1,31 @@
-from jinja2 import Environment, TemplateError
+from jinja2 import BaseLoader, Environment, FileSystemLoader, TemplateError
 
 from constructor.exceptions import UnableToParse
 
+
 # adapted from conda-build
-def render_jinja(data):
-    env = Environment()
+class FilteredLoader(BaseLoader):
+    """
+    A pass-through for the given loader, except that the loaded source is
+    filtered according to any metadata selectors in the source text.
+    """
+
+    def __init__(self, unfiltered_loader, content_filter):
+        self._unfiltered_loader = unfiltered_loader
+        self.list_templates = unfiltered_loader.list_templates
+        self.content_filter = content_filter
+
+    def get_source(self, environment, template):
+        loader = self._unfiltered_loader
+        contents, filename, uptodate = loader.get_source(environment, template)
+        filtered_contents = self.content_filter(contents)
+        return filtered_contents, filename, uptodate
+
+
+# adapted from conda-build
+def render_jinja(data, directory, content_filter):
+    loader = FilteredLoader(FileSystemLoader(directory), content_filter)
+    env = Environment(loader=loader)
     try:
         template = env.from_string(data)
         rendered = template.render()


### PR DESCRIPTION
This adds support for `jinja2` template parsing in `construct.yaml`. The error handling is essentially copied from `conda-build`. Unlike `conda-build` it has only basic `jinja2` support, e.g., it is not possible to access environment variables etc.

Possible use case: Build an installer with Miniconda-esque version naming:
```yaml
{% set py_major_ver = "3" %}
{% set conda_ver = "4.3.16" %}

{% version = conda_ver %}
{% name = "InstallMyConda" + py_major_ver %}

name: {{ name }}
version: {{ conda_ver }}

specs:
  - python >={{ py_major_ver }}
  - conda =={{ conda_ver }}
...
```
Note: The `jinja2` processing is done *after* applying platform selectors.
Needs documentation (e.g., example and note above). If you find this PR viable, I could add some.