### PR TITLE
setup.py enhancements

### DIFF
--- a/bin/constructor
+++ b/bin/constructor
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-if __name__ == '__main__':
-    import sys
-    from constructor.main import main
-
-    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,75 @@
 import re
 import sys
 from os.path import abspath, dirname, join
+from contextlib import contextmanager
 
-from setuptools import setup
+from setuptools import setup, Distribution
+from distutils.util import get_platform
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:
+    bdist_wheel = None
 
 
 SETUP_PY_DIR = dirname(abspath(__file__))
+
+
+def get_package_data(platform):
+    platform_package_data = {
+        "win32": ["nsis/*", "ttf/*"],
+        "unix": ["header.sh"],
+    }
+    if platform is None:
+        package_data = sum(platform_package_data.values(), [])
+    else:
+        platform = platform if platform in platform_package_data else "unix"
+        package_data = platform_package_data[platform]
+    return {"constructor": package_data}
+
+
+class PlatformSpecificDistribution(Distribution):
+    def run_commands(self):
+        for cmd in self.commands:
+            with self.patch_dist_data(cmd):
+                self.run_command(cmd)
+
+    @contextmanager
+    def patch_dist_data(dist, cmd):
+        old_have_run = dist.have_run
+        old_command_obj = dist.command_obj
+        old_package_data = dist.package_data
+        old_has_ext_modules = dist.has_ext_modules
+        try:
+            # rerun everthing for top cmds since patched dist data may differ
+            dist.have_run = {}
+            dist.command_obj = {}
+            if cmd in {"build", "install", "bdist", "bdist_egg", "bdist_wheel"}:
+                # use platform dependent package data
+                dist.package_data = get_package_data(sys.platform)
+            if cmd in {"bdist_egg"}:
+                # force platform specific build for bdist_egg
+                dist.has_ext_modules = lambda: True
+            yield
+        finally:
+            dist.have_run = old_have_run
+            dist.command_obj = old_command_obj
+            dist.package_data = old_package_data
+            dist.has_ext_modules = old_has_ext_modules
+
+
+cmdclass = {}
+
+if bdist_wheel:
+    class BDistWheel(bdist_wheel):
+        def finalize_options(self):
+            # make wheels platform but not Python specific
+            self.plat_name = self.plat_name or get_platform()
+            self.universal = True
+            super(BDistWheel, self).finalize_options()
+
+
+    cmdclass["bdist_wheel"] = BDistWheel
+
 
 # read version from constructor/__init__.py
 data = open(join(SETUP_PY_DIR, "constructor", "__init__.py")).read()
@@ -34,20 +98,7 @@ setup(
         "libconda",
         "pyyaml",
     ],
+    package_data=get_package_data(None),
+    cmdclass=cmdclass,
+    distclass=PlatformSpecificDistribution,
 )
-
-
-if "install" in sys.argv:
-    import shutil
-
-    if sys.platform == "win32":
-        sp_dir = join(sys.prefix, "Lib", "site-packages")
-        for dn in "nsis", "ttf":
-            shutil.copytree(abspath(join("constructor", dn)),
-                            join(sp_dir, "constructor", dn))
-
-    else:
-        sp_dir = join(sys.prefix,
-                      "lib/python%d.%d/site-packages" % sys.version_info[:2])
-        shutil.copy(abspath("constructor/header.sh"),
-                    join(sp_dir, "constructor"))

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
 import re
 import sys
 from os.path import abspath, dirname, join
+
 from setuptools import setup
 
 
@@ -17,15 +18,15 @@ data = open(join(SETUP_PY_DIR, "constructor", "__init__.py")).read()
 version = re.search(r"^__version__\s*=\s*(['\"])(\S*)\1", data, re.M).group(2)
 
 setup(
-    name = "constructor",
-    version = version,
-    author = "Ilan Schnell",
-    author_email = "ilan@continuum.io",
-    url = "https://github.com/conda/constructor",
-    license = "BSD",
-    description = "create installer from conda packages",
-    long_description = open(join(SETUP_PY_DIR, 'README.md')).read(),
-    packages = ['constructor', 'constructor.tests'],
+    name="constructor",
+    version=version,
+    author="Ilan Schnell",
+    author_email="ilan@continuum.io",
+    url="https://github.com/conda/constructor",
+    license="BSD",
+    description="create installer from conda packages",
+    long_description=open(join(SETUP_PY_DIR, "README.md")).read(),
+    packages=["constructor", "constructor.tests"],
     entry_points={
         "console_scripts": ["constructor = constructor.main:main"],
     },
@@ -36,17 +37,17 @@ setup(
 )
 
 
-if 'install' in sys.argv:
+if "install" in sys.argv:
     import shutil
 
-    if sys.platform == 'win32':
-        sp_dir = join(sys.prefix, 'Lib', 'site-packages')
-        for dn in 'nsis', 'ttf':
-            shutil.copytree(abspath(join('constructor', dn)),
-                            join(sp_dir, 'constructor', dn))
+    if sys.platform == "win32":
+        sp_dir = join(sys.prefix, "Lib", "site-packages")
+        for dn in "nsis", "ttf":
+            shutil.copytree(abspath(join("constructor", dn)),
+                            join(sp_dir, "constructor", dn))
 
     else:
-        sp_dir = join(sys.prefix, 'lib/python%d.%d/site-packages' %
-                                               sys.version_info[:2])
-        shutil.copy(abspath('constructor/header.sh'),
-                    join(sp_dir, 'constructor'))
+        sp_dir = join(sys.prefix,
+                      "lib/python%d.%d/site-packages" % sys.version_info[:2])
+        shutil.copy(abspath("constructor/header.sh"),
+                    join(sp_dir, "constructor"))

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,8 @@ setup(
     install_requires=[
         "libconda",
         "pyyaml",
+        "pillow >=3.1 ; platform_system=='Windows'",
+        # non-python dependency: "nsis >=3.01 ; platform_system=='Windows'",
     ],
     package_data=get_package_data(None),
     cmdclass=cmdclass,

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ setup(
     entry_points={
         "console_scripts": ["constructor = constructor.main:main"],
     },
+    install_requires=[
+        "libconda",
+        "pyyaml",
+    ],
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,15 @@
 
 import re
 import sys
-from os.path import abspath, join
+from os.path import abspath, dirname, join
 from distutils.core import setup
 
 
+SETUP_PY_DIR = dirname(abspath(__file__))
+
 # read version from constructor/__init__.py
-pat = re.compile(r'__version__\s*=\s*(\S+)', re.M)
-data = open(join('constructor', '__init__.py')).read()
-version = eval(pat.search(data).group(1))
+data = open(join(SETUP_PY_DIR, "constructor", "__init__.py")).read()
+version = re.search(r"^__version__\s*=\s*(['\"])(\S*)\1", data, re.M).group(2)
 
 setup(
     name = "constructor",
@@ -23,7 +24,7 @@ setup(
     url = "https://github.com/conda/constructor",
     license = "BSD",
     description = "create installer from conda packages",
-    long_description = open('README.md').read(),
+    long_description = open(join(SETUP_PY_DIR, 'README.md')).read(),
     packages = ['constructor', 'constructor.tests'],
     scripts = ['bin/constructor'],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 import re
 import sys
 from os.path import abspath, dirname, join
-from distutils.core import setup
+from setuptools import setup
 
 
 SETUP_PY_DIR = dirname(abspath(__file__))
@@ -26,7 +26,9 @@ setup(
     description = "create installer from conda packages",
     long_description = open(join(SETUP_PY_DIR, 'README.md')).read(),
     packages = ['constructor', 'constructor.tests'],
-    scripts = ['bin/constructor'],
+    entry_points={
+        "console_scripts": ["constructor = constructor.main:main"],
+    },
 )
 
 


### PR DESCRIPTION
This updates `setup.py` to use `entry_points`, `install_requires`, `package_data` from `setuptools`.
It allows the creation of egg- and wheel-distributions that include the platform specific files (`['header.sh']` or `['nsis/*', 'ttf/*']`, resp.) and removes the hard-coded post-processing copying.