### PR TITLE
Optional use of conda to solve spec in order to provide channel priority

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -191,7 +191,10 @@ def main(info, verbose=True, dry_run=False, use_conda=False):
         if use_conda:
             from conda.models.channel import prioritize_channels
             from conda.exports import fetch_index
-            index = fetch_index(prioritize_channels(info['channels']))
+            channels = tuple('%s/%s/' % (url.rstrip('/'), platform)
+                for url in info['channels']
+                for platform in (info['_platform'], 'noarch'))
+            index = fetch_index(prioritize_channels(channels))
         else:
             from libconda.fetch import fetch_index
             index = fetch_index(

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -172,7 +172,10 @@ def fetch(info, use_conda):
         else:
             pkginfo = index[dist]
 
-        info['_urls'].append((urljoin(pkginfo['channel'], fn), pkginfo['md5']))
+        if not pkginfo['channel'].endswith('/'):
+            pkginfo['channel'] += '/'
+        assert pkginfo['channel'].endswith('/')
+        info['_urls'].append((pkginfo['channel'] + fn, pkginfo['md5']))
 
         if md5 and md5 != pkginfo['md5']:
             sys.exit("Error: MD5 sum for '%s' does not match in remote "

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -19,7 +19,6 @@ try:
 except ImportError:  # python 2
     from urlparse import urljoin
 
-from libconda.fetch import fetch_pkg
 
 from constructor.utils import md5_file, filename_dist
 from constructor.install import name_dist
@@ -183,7 +182,13 @@ def fetch(info, use_conda):
         if isfile(path) and md5_file(path) == pkginfo['md5']:
             continue
         print('fetching: %s' % fn)
-        fetch_pkg(pkginfo, download_dir)
+        if use_conda:
+            from conda.exports import download as fetch_pkg
+            pkg_url = pkginfo['channel'] + fn
+            fetch_pkg(pkg_url, path)
+        else:
+            from libconda.fetch import fetch_pkg
+            fetch_pkg(pkginfo, download_dir)
 
 
 def main(info, verbose=True, dry_run=False, use_conda=False):

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -149,10 +149,9 @@ def check_dists():
 
 
 def fetch(info, use_conda):
-    if use_conda:
-        from conda.exports import fetch_index
-    else:
-        from libconda.fetch import fetch_index
+    # always use the libconda fetch_index function here since no
+    # channel priority is needed
+    from libconda.fetch import fetch_index
     download_dir = info['_download_dir']
     if not isdir(download_dir):
         os.makedirs(download_dir)

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -14,12 +14,6 @@ import sys
 from collections import defaultdict
 from os.path import isdir, isfile, join
 
-try:
-    from urllib.parse import urljoin
-except ImportError:  # python 2
-    from urlparse import urljoin
-
-
 from constructor.utils import md5_file, filename_dist
 from constructor.install import name_dist
 

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -172,7 +172,7 @@ def fetch(info):
         fetch_pkg(pkginfo, download_dir)
 
 
-def main(info, verbose=True):
+def main(info, verbose=True, dry_run=False):
     if 'channels' in info:
         global index
         index = fetch_index(
@@ -198,6 +198,8 @@ def main(info, verbose=True):
     if verbose:
         show(info)
     check_dists()
+    if dry_run:
+        return
     fetch(info)
 
     info['_dists'] = list(dists)

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -202,7 +202,10 @@ def update_prefix(path, new_prefix, placeholder, mode):
 
 
 def name_dist(dist):
-    return dist.rsplit('-', 2)[0]
+    if hasattr(dist, 'name'):
+        return dist.name
+    else:
+        return dist.rsplit('-', 2)[0]
 
 
 def create_meta(prefix, dist, info_dir, extra_info):

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -37,7 +37,8 @@ def get_output_filename(info):
 
 
 def main_build(dir_path, output_dir='.', platform=cc_platform,
-               verbose=True, cache_dir=DEFAULT_CACHE_DIR, dry_run=False):
+               verbose=True, cache_dir=DEFAULT_CACHE_DIR,
+               dry_run=False, use_conda=False):
     print('platform: %s' % platform)
     cache_dir = abspath(expanduser(cache_dir))
     try:
@@ -84,7 +85,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             if any((not s) for s in info[key]):
                 sys.exit("Error: found empty element in '%s:'" % key)
 
-    fcp.main(info, verbose=verbose, dry_run=dry_run)
+    fcp.main(info, verbose=verbose, dry_run=dry_run, use_conda=use_conda)
     if dry_run:
         print("Dry run, no installer created.")
         return
@@ -143,6 +144,11 @@ def main():
                  default=False,
                  action="store_true")
 
+    p.add_option('--use-conda',
+                 help="Use conda to solve package specs rather than libconda",
+                 default=False,
+                 action="store_true")
+
     p.add_option('-v', '--verbose',
                  action="store_true")
 
@@ -183,7 +189,7 @@ def main():
 
     main_build(dir_path, output_dir=opts.output_dir, platform=opts.platform,
                verbose=opts.verbose, cache_dir=opts.cache_dir,
-               dry_run=opts.dry_run)
+               dry_run=opts.dry_run, use_conda=opts.use_conda)
 
 
 if __name__ == '__main__':

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -37,7 +37,7 @@ def get_output_filename(info):
 
 
 def main_build(dir_path, output_dir='.', platform=cc_platform,
-               verbose=True, cache_dir=DEFAULT_CACHE_DIR):
+               verbose=True, cache_dir=DEFAULT_CACHE_DIR, dry_run=False):
     print('platform: %s' % platform)
     cache_dir = abspath(expanduser(cache_dir))
     try:
@@ -84,7 +84,10 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             if any((not s) for s in info[key]):
                 sys.exit("Error: found empty element in '%s:'" % key)
 
-    fcp.main(info, verbose=verbose)
+    fcp.main(info, verbose=verbose, dry_run=dry_run)
+    if dry_run:
+        print("Dry run, no installer created.")
+        return
 
     info['_outpath'] = join(output_dir, get_output_filename(info))
     create(info)
@@ -135,6 +138,11 @@ def main():
                  help="perform some self tests and exit",
                  action="store_true")
 
+    p.add_option('--dry-run',
+                 help="solve package specs but do not create installer",
+                 default=False,
+                 action="store_true")
+
     p.add_option('-v', '--verbose',
                  action="store_true")
 
@@ -174,7 +182,8 @@ def main():
         p.error("no such directory: %s" % dir_path)
 
     main_build(dir_path, output_dir=opts.output_dir, platform=opts.platform,
-               verbose=opts.verbose, cache_dir=opts.cache_dir)
+               verbose=opts.verbose, cache_dir=opts.cache_dir,
+               dry_run=opts.dry_run)
 
 
 if __name__ == '__main__':

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -15,7 +15,7 @@ from os.path import dirname, getsize, join
 from constructor.install import name_dist
 from constructor.construct import ns_platform
 from constructor.utils import (preprocess, read_ascii_only, fill_template,
-                               md5_file)
+                               md5_file, filename_dist)
 import constructor.preconda as preconda
 
 
@@ -42,7 +42,7 @@ def add_condarc(info):
 
 def get_header(tarball, info):
     name = info['name']
-    dists = [fn[:-8] for fn in info['_dists']]
+    dists = [filename_dist(dist)[:-8] for dist in info['_dists']]
     dist0 = dists[0]
     assert name_dist(dist0) == 'python'
 
@@ -93,9 +93,11 @@ def create(info):
     t = tarfile.open(tarball, 'w')
     if 'license_file' in info:
         t.add(info['license_file'], 'LICENSE.txt')
-    for fn in preconda.files:
+    for dist in preconda.files:
+        fn = filename_dist(dist)
         t.add(join(tmp_dir, fn), 'pkgs/' + fn)
-    for fn in info['_dists']:
+    for dist in info['_dists']:
+        fn = filename_dist(dist)
         t.add(join(info['_download_dir'], fn), 'pkgs/' + fn)
     for key in 'pre_install', 'post_install':
         if key in info:

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -9,6 +9,14 @@ import sys
 import hashlib
 
 
+def filename_dist(dist):
+    """ Return the filename of a distribution. """
+    if hasattr(dist, 'to_filename'):
+        return dist.to_filename()
+    else:
+        return dist
+
+
 def fill_template(data, d):
     pat = re.compile(r'__(\w+)__')
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -16,6 +16,7 @@ from subprocess import check_call, check_output
 from constructor.construct import ns_platform
 from constructor.install import name_dist
 from constructor.utils import make_VIProductVersion, preprocess, fill_template
+from constructor.utils import filename_dist
 from constructor.imaging import write_images
 import constructor.preconda as preconda
 
@@ -39,24 +40,24 @@ def read_nsi_tmpl():
 
 
 def find_vs_runtimes(dists, py_version):
-    vs_map = {
-        '2.7': 'vs2008_runtime',
-        '3.4': 'vs2010_runtime',
-        '3.5': 'vs2015_runtime',
-        '3.6': 'vs2015_runtime',
-    }
-    vs_runtime = vs_map.get(py_version[:3])
-    return [dist for dist in dists
-            if name_dist(dist) in (vs_runtime, 'msvc_runtime')]
+    valid_runtimes = (
+        'vs2008_runtime',
+        'vs2010_runtime',
+        'vs2013_runtime',
+        'vs2015_runtime',
+        'msvc_runtime',
+    )
+    return [dist for dist in dists if name_dist(dist) in valid_runtimes]
 
 
 def pkg_commands(download_dir, dists, py_version, keep_pkgs):
     vs_dists = find_vs_runtimes(dists, py_version)
-    print("MSVC runtimes found: %s" % vs_dists)
+    print("MSVC runtimes found: %s" % ([filename_dist(d) for d in vs_dists]))
     if len(vs_dists) != 1:
         sys.exit("Error: number of MSVC runtimes found: %d" % len(vs_dists))
 
-    for n, fn in enumerate(vs_dists + dists):
+    for n, dist in enumerate(vs_dists + dists):
+        fn = filename_dist(dist)
         yield ''
         yield '# --> %s <--' % fn
         yield 'File %s' % str_esc(join(download_dir, fn))
@@ -84,7 +85,7 @@ def make_nsi(info, dir_path):
     name = info['name']
     download_dir = info['_download_dir']
     dists = info['_dists']
-    py_name, py_version, unused_build = dists[0].rsplit('-', 2)
+    py_name, py_version, unused_build = filename_dist(dists[0]).rsplit('-', 2)
     assert py_name == 'python'
     arch = int(info['_platform'].split('-')[1])
 


### PR DESCRIPTION
Add an `--use-conda` argument which uses conda rather than libconda to fetch the channel indexes and resolve the specs.  This allows for channel priority to be specified in the `constructor.yaml` file.

Add an `--dry-run` argument which stops the process prior to fetching packages.  Allows the solution to the resolved spec to be tested and examined without downloading packages or creating an installer.