### PR TITLE
pass through verbose option to makensis

### DIFF
--- a/constructor/main.py
+++ b/constructor/main.py
@@ -87,7 +87,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     fcp.main(info, verbose=verbose)
 
     info['_outpath'] = join(output_dir, get_output_filename(info))
-    create(info)
+    create(info, verbose=verbose)
     if 0:
         with open(join(output_dir, 'pkg-list.txt'), 'w') as fo:
             fo.write('# installer: %s\n' % basename(info['_outpath']))

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -166,7 +166,7 @@ Error: no file %s
         sys.exit("Error: no file untgz.dll")
 
 
-def create(info):
+def create(info, verbose=False):
     verify_nsis_install()
     tmp_dir = tempfile.mkdtemp()
     preconda.write_files(info, tmp_dir)
@@ -182,7 +182,11 @@ def create(info):
 
     write_images(info, tmp_dir)
     nsi = make_nsi(info, tmp_dir)
-    args = [MAKENSIS_EXE, '/V2', nsi]
+    if verbose:
+        verbosity = '/V4'
+    else:
+        verbosity = '/V2'
+    args = [MAKENSIS_EXE, verbosity, nsi]
     print('Calling: %s' % args)
     check_call(args)
     shutil.rmtree(tmp_dir)

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -11,7 +11,7 @@ import sys
 import shutil
 import tempfile
 from os.path import abspath, dirname, isfile, join
-from subprocess import check_call, check_output
+from subprocess import Popen, PIPE, check_call, check_output
 
 from constructor.construct import ns_platform
 from constructor.install import name_dist
@@ -188,7 +188,17 @@ def create(info, verbose=False):
         verbosity = '/V2'
     args = [MAKENSIS_EXE, verbosity, nsi]
     print('Calling: %s' % args)
-    check_call(args)
+    if verbose:
+        sub = Popen(args, stdout=PIPE, stderr=PIPE)
+        stdout, stderr = sub.communicate()
+        for msg, info in zip((stdout, stderr), ('stdout', 'stderr')):
+            # on Python3 we're getting bytes
+            if hasattr(msg, 'decode'):
+                msg = msg.decode()
+            print('makensis {}:'.format(info))
+            print(msg)
+    else:
+        check_call(args)
     shutil.rmtree(tmp_dir)
 
 


### PR DESCRIPTION
We're currently debugging a problem with nsis (building installers in appveyor) and our problem is that the verbosity CL-option is not passed through to `makensis` which is always running on low verbosity.. I think verbosity should definitly also be set for `makensis`.