### PR TITLE
Add support for pip packages 

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -57,6 +57,12 @@ e.g.`https://repo.continuum.io/pkgs/free/osx-64/openssl-1.0.1k-1.tar.bz2`.
 Optionally, the MD5 hash sum of the package, may be added after an immediate
 `#` character, e.g. `readline-6.2-2.tar.bz2#0801e644bd0c1cd7f0923b56c52eb7f7`.
 
+`pip`:
+----------------
+A list of pip packages to be included.  Each line is in the format of
+that in requirements.txt.  These will be downloaded by pip, included
+and installed as part of the install process.  Note, the `pip` package should
+be added in the `specs` section or this won't work.
 
 `menu_packages`:
 ----------------

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -85,6 +85,12 @@ You can list conda channels here which will be the default conda channels
 of the created installer (if it includes conda).
 '''),
 
+    ('pip',                    False, (list, str), '''
+A list of pip packages to be included.  Each line is in the format of
+that in requirements.txt.  These will be downloaded by pip, included
+and installed as part of the install process.
+'''),
+
     ('installer_filename',     False, str, '''
 The filename of the installer being created.  A reasonable default filename
 will determined by the `name`, `version`, platform and installer type.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -88,7 +88,8 @@ of the created installer (if it includes conda).
     ('pip',                    False, (list, str), '''
 A list of pip packages to be included.  Each line is in the format of
 that in requirements.txt.  These will be downloaded by pip, included
-and installed as part of the install process.
+and installed as part of the install process.  Note, the `pip` package should
+be added in the `specs` section or this won't work.
 '''),
 
     ('installer_filename',     False, str, '''

--- a/constructor/fpip.py
+++ b/constructor/fpip.py
@@ -1,0 +1,45 @@
+# (c) 2016 Continuum Analytics, Inc. / http://continuum.io
+# All Rights Reserved
+#
+# constructor is distributed under the terms of the BSD 3-clause license.
+# Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
+"""
+fpip (fetch pip packages) module
+"""
+
+import os
+import pip
+from os.path import isdir, join
+
+requirements_name = 'requirements.txt'
+
+
+def fetch(info, verbose=True):
+    download_dir = info['_pip_download_dir']
+    if not isdir(download_dir):
+        os.makedirs(download_dir)
+
+    specs = info['pip']
+    if verbose:
+        print("pip specs: %r" % specs)
+
+    # Generate the requirements file
+    requirements_path = join(download_dir, requirements_name)
+    with open(requirements_path) as requirements:
+        requirements.write('\n'.join(specs))
+        requirements.close()
+    # execute pip from within python
+    pip_cmd = ['download',
+               '--disable-pip-version-check',
+               '-d', download_dir,
+               '-r', requirements_path]
+
+    if verbose:
+        print("Running pip module with arguments: ", pip_cmd)
+    pip.main(pip_cmd)
+
+
+def main(info, verbose=True):
+    if 'pip' in info:
+        fetch(info, verbose)
+

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -292,7 +292,8 @@ if [ -f $PIP ]; then
     REQUIREMENTS=$PREFIX/pip/requirements.txt
     if [ -f $REQUIREMENTS ]; then
         echo "installing pip packages..."
-        $PIP install --disable-pip-version-check --no-index --find-links $PREFIX/pip -r $REQUIREMENTS
+        $PYTHON  -E -s $PIP install --disable-pip-version-check \
+            --no-index --find-links $PREFIX/pip -r $REQUIREMENTS
     fi
 fi
 #if not keep_pkgs

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -287,6 +287,18 @@ rm -f $MSGS
 rm -rf $PREFIX/pkgs
 #endif
 
+PIP="$PREFIX/bin/pip"
+if [ -f $PIP ]; then
+    REQUIREMENTS=$PREFIX/pip/requirements.txt
+    if [ -f $REQUIREMENTS ]; then
+        echo "installing pip packages..."
+        $PIP install --disable-pip-version-check --no-index --find-links $PREFIX/pip -r $REQUIREMENTS
+    fi
+fi
+#if not keep_pkgs
+rm -rf $PREFIX/pip
+#endif
+
 echo "installation finished."
 
 if [[ $BATCH == 0 ]] # interactive mode

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -14,6 +14,7 @@ from libconda.config import subdir as cc_platform
 
 from constructor.install import yield_lines
 import constructor.fcp as fcp
+import constructor.fpip as fpip
 import constructor.construct as construct
 
 
@@ -85,6 +86,9 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
                 sys.exit("Error: found empty element in '%s:'" % key)
 
     fcp.main(info, verbose=verbose)
+
+    info['_pip_download_dir'] = join(cache_dir, 'pip')
+    fpip.main(info, verbose=verbose)
 
     info['_outpath'] = join(output_dir, get_output_filename(info))
     create(info)

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -473,6 +473,10 @@ Section "Install"
     File __POST_INSTALL__
 
     @PKG_COMMANDS@
+    
+    SetOutPath "$INSTDIR"
+    File /nonfatal "pip\*.*"
+        
 
     ${If} $InstMode = ${JUST_ME}
         SetOutPath "$INSTDIR"
@@ -496,6 +500,12 @@ Section "Install"
         call AbortRetryExecWait
     ${EndIf}
 
+    ${If} ${FileExists} "$INSTDIR\pip\requirements.txt" ${AndIf} \
+        ${FileExists} "$INSTDIR\Scripts\pip.exe"
+        ExecWait '"$INSTDIR\Scripts\pip.exe install --disable-pip-version-check \
+                   --no-index --find-links $INSTDIR\pip\
+                   -r $INSTDIR\pip\requirements.txt"'
+    ${EndIf}
 
     # Create registry entries saying this is the system Python
     # (for this version)

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -474,8 +474,8 @@ Section "Install"
 
     @PKG_COMMANDS@
     
-    SetOutPath "$INSTDIR"
-    File /nonfatal "pip\*.*"
+    SetOutPath "$INSTDIR\pip"
+    File /nonfatal /r "@PIP_DOWNLOAD_DIR@\*.*"
         
 
     ${If} $InstMode = ${JUST_ME}
@@ -500,11 +500,13 @@ Section "Install"
         call AbortRetryExecWait
     ${EndIf}
 
-    ${If} ${FileExists} "$INSTDIR\pip\requirements.txt" ${AndIf} \
-        ${FileExists} "$INSTDIR\Scripts\pip.exe"
-        ExecWait '"$INSTDIR\Scripts\pip.exe install --disable-pip-version-check \
-                   --no-index --find-links $INSTDIR\pip\
-                   -r $INSTDIR\pip\requirements.txt"'
+    ${If} ${FileExists} "$INSTDIR\pip\requirements.txt"
+    ${AndIf} ${FileExists} "$INSTDIR\Scripts\pip-script.py"
+        DetailPrint "Installing pip requirements..."
+        ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Scripts\pip-script.py" \
+                   install --disable-pip-version-check --no-index \
+                   --find-links "$INSTDIR\pip" \
+                   -r "$INSTDIR\pip\requirements.txt"'
     ${EndIf}
 
     # Create registry entries saying this is the system Python

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -6,7 +6,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-import glob
 import os
 import shutil
 import tarfile
@@ -101,8 +100,8 @@ def create(info):
     for key in 'pre_install', 'post_install':
         if key in info:
             t.add(info[key], 'pkgs/%s.sh' % key)
-    for fn in glob.glob(join(info['_pip_download_dir'], "*.*")):
-        t.add(fn, 'pip/' + basename(fn))
+    for fn in os.listdir(info['_pip_download_dir']):
+        t.add(join(info['_pip_download_dir'], fn), 'pip/' + fn)
 
     t.close()
 

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -6,11 +6,12 @@
 
 from __future__ import print_function, division, absolute_import
 
+import glob
 import os
 import shutil
 import tarfile
 import tempfile
-from os.path import dirname, getsize, join
+from os.path import dirname, getsize, join, basename
 
 from constructor.install import name_dist
 from constructor.construct import ns_platform
@@ -100,6 +101,9 @@ def create(info):
     for key in 'pre_install', 'post_install':
         if key in info:
             t.add(info[key], 'pkgs/%s.sh' % key)
+    for fn in glob.glob(join(info['_pip_download_dir'], "*.*")):
+        t.add(fn, 'pip/' + basename(fn))
+
     t.close()
 
     header = get_header(tarball, info)

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -21,7 +21,7 @@ import constructor.preconda as preconda
 
 
 THIS_DIR = dirname(__file__)
-NSIS_DIR = join(THIS_DIR, 'nsis')
+NSIS_DIR = abspath(join(THIS_DIR, 'nsis'))
 MAKENSIS_EXE = join(sys.prefix, 'NSIS', 'makensis.exe')
 
 
@@ -98,7 +98,7 @@ def make_nsi(info, dir_path):
         'PY_VER': py_version[:3],
         'PYVERSION': py_version,
         'PYVERSION_JUSTDIGITS': ''.join(py_version.split('.')),
-        'OUTFILE': info['_outpath'],
+        'OUTFILE': abspath(info['_outpath']),
         'LICENSEFILE': abspath(info.get('license_file',
                                join(NSIS_DIR, 'placeholder_license.txt'))),
         'DEFAULT_PREFIX': info.get(

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -130,6 +130,7 @@ def make_nsi(info, dir_path):
         ('@BITS@', str(arch)),
         ('@PKG_COMMANDS@', '\n    '.join(cmds)),
         ('@MENU_PKGS@', ' '.join(info.get('menu_packages', []))),
+        ('@PIP_DOWNLOAD_DIR@', info['_pip_download_dir']),
         ]:
         data = data.replace(key, value)
 


### PR DESCRIPTION
This adds support for pip packages for constructor.  It roughly works the following way:

- Similar to pip support in conda itself, each line of the `pip` section in `construct.yml` is compiled into a `requirements.txt`, and placed into a `pip/` cache directory
- `pip download -r requirements.txt` is executed (with some extra parameters) which downloads all relevant packages according to the spec.  This is also placed in the `pip/` cache directory
- The `pip/` cache directory is copied into $PREFIX/pip (Linux) and NSIS does roughly the same thing for Windows (analogous to the conda `pkg` directory).
- After installation of conda, and pip cache directory is copied over, `pip install --no-index --find-links $PREFIX/pip -r $PREFIX/pip/requirements.txt`.  This installs offline the previously downloaded packages.