### PR TITLE
Add option to use hardlinks to pkg cache

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -106,6 +106,13 @@ installer in the `pkgs` directory.  Using this option changes the default
 behavior.
 '''),
 
+    ('use_hardlinks',          False, bool, '''
+By default, conda packages are extracted into the root environment and then
+patched. Enabling this option will result into extraction of the packages into
+the `pkgs` directory and the files in the root environment will be hardlinks to
+the files kept in the `pkgs` directory and then patched accordingly.
+'''),
+
     ('pre_install',            False, str, '''
 Path to a pre install (bash - Unix only) script.
 '''),

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -339,8 +339,17 @@ install_dist()
     # and creates the conda metadata).  Note that this is all done without
     # conda.
     printf "installing: %s ...\\n" "$1"
-    PKG="$PREFIX"/pkgs/$1.tar.bz2
+    PKG_PATH="$PREFIX"/pkgs/$1
+    PKG="$PKG_PATH".tar.bz2
+    mkdir $PKG_PATH || exit 1
+#if use_hardlinks
+    bunzip2 -c "$PKG" | tar -xf - -C "$PKG_PATH" --no-same-owner || exit 1
+    "$PREFIX/pkgs/__DIST0__/bin/python" -E -s \
+        "$PREFIX"/pkgs/.install.py $INST_OPT --root-prefix="$PREFIX" --link-dist="$1" || exit 1
+#else
     bunzip2 -c "$PKG" | tar -xf - -C "$PREFIX" --no-same-owner || exit 1
+    "$PYTHON" -E -s "$PREFIX"/pkgs/.install.py $INST_OPT || exit 1
+#endif
     if [ "$1" = "__DIST0__" ]; then
         if ! "$PYTHON" -E -V; then
             printf "ERROR:\\n" >&2
@@ -349,7 +358,6 @@ install_dist()
             exit 1
         fi
     fi
-    "$PYTHON" -E -s "$PREFIX"/pkgs/.install.py $INST_OPT || exit 1
 #if not keep_pkgs
     rm "$PKG"
 #endif

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -53,6 +53,7 @@ def get_header(tarball, info):
     has_license = bool('license_file' in info)
     ppd = ns_platform(info['_platform'])
     ppd['keep_pkgs'] = bool(info.get('keep_pkgs'))
+    ppd['use_hardlinks'] = bool(info.get('use_hardlinks'))
     ppd['has_license'] = has_license
     for key in 'pre_install', 'post_install':
         ppd['has_%s' % key] = bool(key in info)


### PR DESCRIPTION
Constructor just extracts package tarballs to the
root env, does patching, etc and there is no package
cache. This patch enables the creation of package
cache and uses hardlinks to install pacakges inside
the root env.