### PR TITLE
Add feature to check file duplicates across dists

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -76,6 +76,11 @@ necessary metadata in "Menu/<package name>.json").  Menu items are currently
 only supported on Windows.  By default, all menu items will be installed.
 '''),
 
+    ('ignore_duplicate_files',  False, bool, '''
+By default, constructor will error out when adding packages with duplicate
+files in them. Enable this option to warn instead and continue.
+'''),
+
     ('install_in_dependency_order', False, bool, '''
 By default the conda packages included in the created installer are installed
 in alphabetical order, Python is always installed first for technical


### PR DESCRIPTION
If there is more than one package with the same file, constructor doesn't care
and happily adds it. Resulting into an error on installing, for e.g:
```
  Exception: dst exists: '/Users/nwani/miniconda3/share/terminfo/e/eterm'
```

This patch adds the functionality to check for duplicate files across packages
and can be turned off by setting the option: `ignore_duplicate_files` to `True`

Example run:
```
  Error: File 'share/man/man3/history.3' found in multiple packages:
  readline-7.0-h6da6fa9_1.tar.bz2, libedit-3.1-h3b20077_0.tar.bz2
```

It also checks for duplicate files with case sensitivity turned off, as one
should not assume that the target filesystem would always be case sensitive.

Example run:
```
  Warning: Files 'share/terminfo/P/P9-W', 'share/terminfo/p/p9-w' found in the
  package(s): ncurses-6.0-h6f92afc_0.tar.bz2
```