### PR TITLE
Fallback to cat if more is not available

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -222,7 +222,11 @@ then
     printf "Please, press ENTER to continue\\n"
     printf ">>> "
     read -r dummy
-    more <<EOF
+    pager="cat"
+    if command -v "more" > /dev/null 2>&1; then
+      pager="more"
+    fi
+    "$pager" <<EOF
 __LICENSE__
 EOF
     printf "\\n"


### PR DESCRIPTION
Some Linux distributions don't have the utility 'more' available in
their minimal installations. This causes the license to not show up.

This patch fixes https://github.com/ContinuumIO/anaconda/issues/1066
by falling back to `cat` if `more` isn't available.

`command` is chosen over `hash/type/which` for POSIX compatibility.
https://stackoverflow.com/q/592620/1005215