### PR TITLE
remove broken test test_link_idists

### DIFF
--- a/constructor/tests/test_install.py
+++ b/constructor/tests/test_install.py
@@ -129,9 +129,6 @@ class Misc_TestCase(unittest.TestCase):
         self.assertEqual(name_dist('conda-build-1.21.6-py35_0'),
                          'conda-build')
 
-    def test_link_idists(self):
-        self.assertRaises(NotImplementedError, link_idists)
-
 
 def run():
     suite = unittest.TestSuite()


### PR DESCRIPTION
The test case is outdated since `install.link_idists` is re-implemented now.