### PR TITLE
tests: fix osxpkg import

### DIFF
--- a/constructor/tests/__init__.py
+++ b/constructor/tests/__init__.py
@@ -36,7 +36,7 @@ def main():
         shar.read_header_template()
 
     if sys.platform == 'darwin':
-        from .osxpkg import OSX_DIR
+        from ..osxpkg import OSX_DIR
         assert len(os.listdir(OSX_DIR)) == 6
 
     test_parser.test_1()


### PR DESCRIPTION
Fixes a typo in the relative import for macOS tests.