### PR TITLE
Import os in tests

### DIFF
--- a/constructor/tests/__init__.py
+++ b/constructor/tests/__init__.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
 from os.path import dirname
 import sys
 


### PR DESCRIPTION
Later in the file `os.listdir` is used as part of the macOS tests, but is not being imported. This fixes that.