### PR TITLE
PR: Add initial CI for appveyor and travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # omit anything in a tests folder
+    */tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 .cache/
 _cenv/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+# https://travis-ci.org/conda/constructor
+
+language: python
+sudo: false
+
+branches:
+  only:
+    - master
+
+matrix:
+  include:
+    # Linux
+    - os: linux
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6 CONDA_CANARY=false
+    - os: linux
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=2.7 CONDA_CANARY=false
+    - os: linux
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6 CONDA_CANARY=true
+    # OSX
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6 CONDA_CANARY=false
+  allow_failures:
+    - os: linux
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6 CONDA_CANARY=true
+
+cache:
+  directories:
+    - $HOME/condacache/pkgs
+    - $HOME/.cache/pip
+
+install:
+  # Install latest miniconda
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      MINICONDA_OS=Linux ;
+    else
+      MINICONDA_OS=MacOSX ;
+    fi ;
+    MINICONDA_PYVERSION=${TRAVIS_PYTHON_VERSION:0:1} ;
+    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYVERSION-latest-$MINICONDA_OS-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p "$HOME"/miniconda
+  - source "$HOME"/miniconda/bin/activate root
+  - conda config --set always_yes yes 
+  - conda update -n root conda -q --no-pin
+  - conda config --add pkgs_dirs ~/condacache/pkgs
+  # Install run dependencies
+  - conda install -n root pillow>=3.1 ruamel_yaml
+  # Install test dependencies
+  - conda install codecov pytest pytest-cov -c conda-forge
+  # Install this package
+  - python setup.py develop
+  # Install conda canary before running tests, ensure conda is updated
+  - if [ "${CONDA_CANARY}" = "true" ]; then
+      conda update -n root conda -c conda-canary --no-pin;
+    else
+      conda update -n root conda --no-pin;
+    fi
+  - source "$HOME"/miniconda/bin/activate root
+  - conda info
+  - conda list
+
+script:
+  - pytest --cov=constructor constructor
+  - python scripts/run_examples.py
+
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-(conda) constructor
-===================
+# (conda) constructor
+
+
+## Build status
+
+[![Build Status](https://travis-ci.org/conda/constructor.svg?branch=master)](https://travis-ci.org/conda/constructor)
+[![Build status](https://ci.appveyor.com/api/projects/status/cxf565h1rh3v0kaq?svg=true)](https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/constructor)
+[![codecov](https://codecov.io/gh/conda/constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/conda/constructor)
+
+## Description:
 
 constructor is a tool which allows constructing an installer for
 a collection of conda packages.  Basically, it creates an Anaconda-like
@@ -7,8 +15,7 @@ installer consisting of conda packages.   This tool was previously
 proprietary and known as `cas-installer`.
 
 
-Installation:
--------------
+## Installation:
 
 As of version 1.3.0, `constructor` may be installed into any conda
 environment using:
@@ -20,8 +27,7 @@ Once installed, the constructor command will be available:
     $ constructor -h
 
 
-Usage:
-------
+## Usage:
 
 The `constructor` command takes an installer specification directory as its
 argument.  This directory needs to contain a file `construct.yaml`,
@@ -35,8 +41,7 @@ An example is located
 in <a href="./examples/maxiconda">examples/maxiconda</a>.
 
 
-Notes:
-------
+## Notes:
 
   * Constructor does not work with `noarch`-Python packages.
     All conda packages must be available for the platform you are

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,65 @@
+# https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/constructor
+
+branches:
+  only:
+    - master
+
+environment:
+  global:
+    PYTHON: "C:\\conda"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+    PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
+                      # of 32 bit and 64 bit builds are needed, move this
+                      # to the matrix section.
+
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      CONDA_CANARY: "false"
+    - PYTHON_VERSION: "2.7"
+      CONDA_CANARY: "false"
+    - PYTHON_VERSION: "2.7"
+      CONDA_CANARY: "true"
+
+matrix:
+  allow_failures:
+    - PYTHON_VERSION: "2.7"
+      CONDA_CANARY: "true"
+
+platform:
+  -x64
+
+cache:
+  - "C:\\condacache\\pkgs"
+
+install:
+  # Astropy ci-helpers. See https://github.com/astropy/ci-helpers
+  - "git clone git://github.com/astropy/ci-helpers.git"
+  - if "%PYTHON_VERSION%" == "3.5" set "BASE_PYTHON_VERSION=35"
+  - if "%PYTHON_VERSION%" == "3.6" set "BASE_PYTHON_VERSION=36"
+  - if "%PYTHON_ARCH%" == "64" set "ARCH_LABEL=-x64"
+  # These are already installed on appveyor
+  - set "CONDA_ROOT=C:\Miniconda%BASE_PYTHON_VERSION%%ARCH_LABEL%"
+  - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
+  - "conda config --set always_yes yes"
+  - "conda update -n root conda -q --no-pin"
+  - "%CONDA_ROOT%\\Scripts\\activate root"
+  - "conda config --add pkgs_dirs C:\\condacache\\pkgs"
+  # Install run dependencies
+  - "conda install -n root nsis pillow>=3.1 ruamel_yaml"
+  # Install test dependencies
+  - "conda install -n root pytest pytest-cov"
+  # Install this package
+  - "python setup.py develop"
+  # Install conda canary before running tests, ensure conda is updated
+  - if "%CONDA_CANARY%" == "true" conda update -n root conda -c conda-canary --no-pin
+  - if "%CONDA_CANARY%" == "false" conda update -n root conda --no-pin
+  - "%CONDA_ROOT%\\Scripts\\activate root"
+  - "conda info"
+  - "conda list"
+
+# Not a .NET project, we build in the install step instead
+build: false
+
+test_script:
+  - "%CMD_IN_ENV% pytest --cov=constructor constructor"
+  - "%CMD_IN_ENV% python scripts\\run_examples.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  precision: 2
+  round: nearest
+  range: 15...100
+  status:
+    patch: off
+    project: off
+
+comment: off

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Run examples bundled with this repo."""
+
+# Standard library imports
+import os
+import subprocess
+import sys
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+REPO_DIR = os.path.dirname(HERE)
+EXAMPLES_DIR = os.path.join(REPO_DIR, 'examples')
+PY3 = sys.version_info[0] == 3
+WHITELIST = ['grin', 'jetsonconda', 'maxiconda', 'newchan']
+
+
+def run_examples():
+    """Run examples bundled with the repository."""
+    example_paths = []
+    errored = 0
+    whitelist = [os.path.join(EXAMPLES_DIR, p) for p in WHITELIST]
+    for fname in os.listdir(EXAMPLES_DIR):
+        fpath = os.path.join(EXAMPLES_DIR, fname)
+        if os.path.isdir(fpath) and fpath not in whitelist:
+            example_paths.append(fpath)
+
+    for i, example_path in enumerate(sorted(example_paths)):
+        cmd = ['constructor', example_path]
+        p = subprocess.Popen(cmd, stderr=subprocess.PIPE)
+        print('\n\n# Testing example {}:\n--------------------'.format(i + 1))
+        print(example_path)
+        print('\n')
+        stdout, stderr = p.communicate()
+        if PY3:
+            stderr = stderr.decode().strip()
+
+        if stderr:
+            errored += 1
+            print(stderr)
+
+    if errored:
+        print('\n\nSome examples failed!\n\n')
+        sys.exit(1)
+    else:
+        print('\n\nAll examples ran successfully!\n\n')
+
+
+if __name__ == '__main__':
+    run_examples()


### PR DESCRIPTION
@kalefranz this is just some initial work to get the CI running with whatever tests are found. I also ran the examples in the example folder but at the moment 2/4 fail.

Also conda in canary is failing but I added those tests to allowed failures. I could add the travis also on this PR, but [I do not have rights to do so](https://travis-ci.org/conda/constructor)

Comments / thoughts?


----

This is where we are:

```
---------- coverage: platform darwin, python 2.7.13-final-0 ----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
constructor/__init__.py              1      0   100%
constructor/__main__.py              5      5     0%
constructor/conda_interface.py      31     13    58%
constructor/construct.py            94     94     0%
constructor/exceptions.py           20     20     0%
constructor/fcp.py                 197    157    20%
constructor/imaging.py              68      6    91%
constructor/install.py             362    284    22%
constructor/jinja.py                21     21     0%
constructor/main.py                119    119     0%
constructor/osxpkg.py              142    142     0%
constructor/preconda.py             85     85     0%
constructor/shar.py                 82     82     0%
constructor/utils.py                77     47    39%
constructor/winexe.py              143    143     0%
----------------------------------------------------
TOTAL                             1447   1218    16%
```

I could add coveralls.io to this as well,  but I think @kalefranz is more fond of codecov.io ?

---

**Update:**
- [x] Travis added for 2.7 and 3.6 for linux and mac (only 3.6) and linux with conda-canary for 3.6
- [x] Appveyor added for 2.7 and 3.6 for win and conda-canary for 2.7
- [x] Updated README to include badges for builds and coverage
