### PR TITLE
Fix conda incompatibilities

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-import sys
 
+import json
 from os.path import join
+import sys
 
 try:
     from conda import __version__ as CONDA_INTERFACE_VERSION
@@ -16,13 +17,16 @@ except ImportError:
                            "with sys.prefix: %s" % sys.prefix)
 
 if conda_interface_type == 'conda':
+    CONDA_MAJOR_MINOR = tuple(int(x) for x in CONDA_INTERFACE_VERSION.split('.')[:2])
+
     from conda.base.context import context
     cc_platform = context.subdir
 
-    from conda.exports import fetch_index as _fetch_index
+    from conda.exports import fetch_index as _fetch_index, cache_fn_url as _cache_fn_url
     from conda.exports import Resolve, NoPackagesFound
-
-    from conda.exports import download
+    from conda.exports import default_prefix
+    from conda.exports import linked_data
+    from conda.exports import download as _download
 
     from conda.models.channel import prioritize_channels
 
@@ -32,14 +36,41 @@ if conda_interface_type == 'conda':
     def fetch_pkg(pkginfo, download_dir):
         pkg_url = pkginfo['url']
         assert pkg_url
-        download(pkg_url, join(download_dir, pkginfo['fn']))
+        _download(pkg_url, join(download_dir, pkginfo['fn']))
+
+    def write_repodata(cache_dir, url):
+        if CONDA_MAJOR_MINOR >= (4, 4):
+            from conda.core.repodata import fetch_repodata_remote_request
+            raw_repodata_str = fetch_repodata_remote_request(url, None, None)
+            repodata_filename = _cache_fn_url(url)
+            with open(join(cache_dir, repodata_filename), 'w') as fh:
+                fh.write(raw_repodata_str)
+        elif CONDA_MAJOR_MINOR >= (4, 3):
+            from conda.core.repodata import fetch_repodata_remote_request
+            repodata_obj = fetch_repodata_remote_request(None, url, None, None)
+            raw_repodata_str = json.dumps(repodata_obj)
+            repodata_filename = _cache_fn_url(url)
+            with open(join(cache_dir, repodata_filename), 'w') as fh:
+                fh.write(raw_repodata_str)
+        else:
+            raise NotImplementedError("unsupported version of conda: %s" % CONDA_INTERFACE_VERSION)
+
+
 
 else:
-    from libconda.config import subdir as cc_platform
+    from libconda.config import subdir as cc_platform, default_prefix
     from libconda.fetch import fetch_index, fetch_pkg
     from libconda.resolve import Resolve, NoPackagesFound
+
+    linked_data = {}
+
+    def write_repodata(cache_dir, url):
+        # not implemented, pending resolution of #139
+        return
 
 
 cc_platform = cc_platform
 fetch_index, fetch_pkg = fetch_index, fetch_pkg
 Resolve, NoPackagesFound = Resolve, NoPackagesFound
+default_prefix = default_prefix
+linked_data = linked_data


### PR DESCRIPTION
This PR is a bit of a follow-on to #134.  It does two things.

1. renames the file `system.info` to `.constructor-build.info`, per https://github.com/conda/constructor/pull/134/files#r150033200
2. cleans up usage of conda and conda internals in `preconda.py`