### PR TITLE
reorder paths

### DIFF
--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -156,10 +156,10 @@ out('allusers is %s\n' % allusers)
 
 # This must be the same as conda's binpath_from_arg() in conda/cli/activate.py
 PATH_SUFFIXES = ('',
-                 os.path.join('Library', 'mingw-w64', 'bin'),
-                 os.path.join('Library', 'usr', 'bin'),
                  os.path.join('Library', 'bin'),
-                 'Scripts')
+                 'Scripts'
+                 os.path.join('Library', 'mingw-w64', 'bin'),
+                 os.path.join('Library', 'usr', 'bin'), )
 
 
 def remove_from_path(root_prefix=None):


### PR DESCRIPTION
Having Library/usr/bin and Library/mingw-w64/bin ahead of Library/bin bit me pretty hard today with curl.  There was a git4win curl version shadowing ours, and that git4win one was busted.