### PR TITLE
Change ownership back to $USER after updating dot profile

### DIFF
--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -17,7 +17,9 @@ else
     BASH_RC="${HOME}/.bash_profile"
 fi
 
-cp -fp $BASH_RC ${BASH_RC}-__NAME_LOWER__.bak
+BASH_RC_BAK="${BASH_RC}-__NAME_LOWER__.bak"
+
+cp -fp $BASH_RC ${BASH_RC_BAK}
 
 echo "
 Prepending PATH=$PREFIX/bin to PATH in $BASH_RC
@@ -28,4 +30,5 @@ echo "
 # added by __NAME__ __VERSION__ installer
 export PATH=\"$PREFIX/bin:\$PATH\"" >>$BASH_RC
 
+chown "$USER" "$BASH_RC" "$BASH_RC_BAK"
 exit 0


### PR DESCRIPTION
If the user chooses to install to a custom location, he is prompted for
a password and the modification to the dot profile file for PATH
modification happens as root user. Since $USER is still set to the
original user who spawned the installer, we can use it to reset the
ownership of the dot profile and it's backup back to $USER.