### PR TITLE
Don't assume that attempt_hardlinks is defined

### DIFF
--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -90,7 +90,7 @@ def modify_xml(xml_path, info):
 
     # TODO :: Check that varying these based on 'attempt_hardlinks' is the
     #         right thing to do.
-    if info['attempt_hardlinks']:
+    if bool(info.get('attempt_hardlinks')):
         enable_anywhere = 'true'
         enable_localSystem = 'false'
     else:
@@ -186,7 +186,7 @@ def create(info, verbose=False):
             dname = dist.dist_name
             ndist = dist.name
         fresh_dir(PACKAGE_ROOT)
-        if info['attempt_hardlinks']:
+        if bool(info.get('attempt_hardlinks')):
             t = tarfile.open(join(CACHE_DIR, fn), 'r:bz2')
             os.makedirs(join(pkgs_dir, dname))
             t.extractall(join(pkgs_dir, dname))


### PR DESCRIPTION
Without this, building a MacOS X pkg results in:

```
Traceback (most recent call last):
  File "/Users/travis/miniconda/bin/constructor", line 11, in <module>
    load_entry_point('constructor==2.0.1', 'console_scripts', 'constructor')()
  File "/Users/travis/miniconda/lib/python3.6/site-packages/constructor/main.py", line 221, in main
    dry_run=opts.dry_run)
  File "/Users/travis/miniconda/lib/python3.6/site-packages/constructor/main.py", line 128, in main_build
    create(info, verbose=verbose)
  File "/Users/travis/miniconda/lib/python3.6/site-packages/constructor/osxpkg.py", line 189, in create
    if info['attempt_hardlinks']:
KeyError: 'attempt_hardlinks'
```

(if not defined in ``construct.yml``)