### PR TITLE
Fixed nsis fails when INDEX_CACHE is empty

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -683,7 +683,7 @@ Section "Install"
     File __URLS_FILE__
     File __URLS_TXT_FILE__
     File __POST_INSTALL__
-    File /r __INDEX_CACHE__
+    File /nonfatal /r __INDEX_CACHE__
 
     @PKG_COMMANDS@
 


### PR DESCRIPTION
Add a /nonfatal to the __INDEX_CACHE__ File def in nsis template
I think this happens when you specify custom local channels

Error:

    Created C:\**\main.nsi file
    Calling: ['C:\\ProgramData\\Anaconda3\\NSIS\\makensis.exe', '/V2', 
    'C:\\**\\Temp\\tmpb76dl6rn\\main.nsi']
    File: "C:\**Temp\tmpb76dl6rn\cache" -> no files found
    Usage: File [/nonfatal] [/a] ([/r] [/x filespec [...]] filespec [...] |  /oname=outfile one_file_only)
    Error in script "C:\**\Temp\tmpb76dl6rn\main.nsi" on line 672 -- aborting creation process
