### PR TITLE
restrict PATH for install subprocesses to just us and Win core stuff

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -724,10 +724,12 @@ Section "Install"
     File "@NSIS_DIR@\_nsis.py"
     File "@NSIS_DIR@\_system_path.py"
 
-    ReadEnvStr $0 PATH
+    ReadEnvStr $0 SystemRoot
     # set PATH for the installer process, so that MSVC runtimes get found OK
+    #    This is also isolating PATH to be just us and Windows core stuff, which hopefully avoids
+    #    clashes with other stuff on PATH
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("PATH", \
-                  "$INSTDIR\Library\bin;$INSTDIR\Scripts;$INSTDIR;$0").r0'
+                 "$INSTDIR\Library\bin;$INSTDIR\Scripts;$INSTDIR;$0;$0\system32;$0\system32\Wbem").r0'
 
     SetOutPath "$INSTDIR\conda-meta"
     File __CONDA_HISTORY__

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ version = re.search(r"^__version__\s*=\s*(['\"])(\S*)\1", data, re.M).group(2)
 setup(
     name="constructor",
     version=version,
-    author="Ilan Schnell",
-    author_email="ilan@anaconda.com",
+    author="Anaconda, Inc.",
+    author_email="conda@anaconda.com",
     url="https://github.com/conda/constructor",
     license="BSD",
     description="create installer from conda packages",


### PR DESCRIPTION
Meant to address issues like https://github.com/ContinuumIO/anaconda-issues/issues/3488

Hopefully those will only happen with unicode stuff and py27 after this PR.