### PR TITLE
new 'uninstall_name' config param

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -216,7 +216,7 @@ required: False
 argument type(s): ``str``, 
 
 Application name in the Windows "Programs and Features" control panel.
-Defaults to `Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})`.
+Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 
 ## `pre_install`
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -209,6 +209,15 @@ argument type(s): ``str``,
 
 Name of the company/entity who is responsible for the installer.
 
+## `uninstall_name`
+
+required: False
+
+argument type(s): ``str``, 
+
+Application name in the Windows "Programs and Features" control panel.
+Defaults to `Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})`.
+
 ## `pre_install`
 
 required: False

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -142,7 +142,7 @@ Name of the company/entity who is responsible for the installer.
 
     ('uninstall_name',         False, str, '''
 Application name in the Windows "Programs and Features" control panel.
-Defaults to `Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})`.
+Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 '''),
 
     ('pre_install',            False, str, '''

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -140,6 +140,11 @@ the base environment if there are any channels or conda_default_channels is set.
 Name of the company/entity who is responsible for the installer.
 '''),
 
+    ('uninstall_name',         False, str, '''
+Application name in the Windows "Programs and Features" control panel.
+Defaults to `Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})`.
+'''),
+
     ('pre_install',            False, str, '''
 Path to a pre install (bash - Unix only) script.
 '''),

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -30,7 +30,7 @@ Unicode "true"
 !define PYVERSION __PYVERSION__
 !define DEFAULT_PREFIX __DEFAULT_PREFIX__
 !define PRODUCT_NAME "${NAME} ${VERSION} (${ARCH})"
-!define UNINSTALL_NAME "Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})"
+!define UNINSTALL_NAME "@UNINSTALL_NAME@"
 !define UNINSTREG "SOFTWARE\Microsoft\Windows\CurrentVersion\
                    \Uninstall\${UNINSTALL_NAME}"
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -173,7 +173,7 @@ def make_nsi(info, dir_path):
         ('@MENU_PKGS@', ' '.join(info.get('menu_packages', []))),
         ('@SIZE@', str(approx_pkgs_size_kb)),
         ('@UNINSTALL_NAME@', info.get('uninstall_name',
-            'Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})'
+            '${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})'
         )),
         ]:
         data = data.replace(key, value)

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -172,6 +172,9 @@ def make_nsi(info, dir_path):
         ('@WRITE_CONDARC@', '\n    '.join(add_condarc(info))),
         ('@MENU_PKGS@', ' '.join(info.get('menu_packages', []))),
         ('@SIZE@', str(approx_pkgs_size_kb)),
+        ('@UNINSTALL_NAME@', info.get('uninstall_name',
+            'Python ${PYVERSION} (${NAME} ${VERSION} ${ARCH})'
+        )),
         ]:
         data = data.replace(key, value)
 


### PR DESCRIPTION
Example which puts the application name first (instead of "Python X.Y", see #88):
```yaml
uninstall_name: "${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})"
```