### PR TITLE
Check if $INSTDIR is writable before proceeding

### DIFF
--- a/constructor/nsis/Utils.nsh
+++ b/constructor/nsis/Utils.nsh
@@ -122,3 +122,54 @@ FunctionEnd
         Push $0
     ${EndIf}
 !macroend
+
+; Slightly modified version of http://nsis.sourceforge.net/IsWritable
+Function IsWritable
+  !define IsWritable `!insertmacro IsWritableCall`
+
+  !macro IsWritableCall _PATH _RESULT
+    Push `${_PATH}`
+    Call IsWritable
+    Pop ${_RESULT}
+  !macroend
+
+  Exch $R0
+  Push $R1
+
+start:
+  # Checks if $R0 is not empty.
+  StrLen $R1 $R0
+  StrCmp $R1 0 exit
+  # Checks if $R0 exists and is a directory.
+  ${GetFileAttributes} $R0 "DIRECTORY" $R1
+  StrCmp $R1 1 direxists
+  # $R0 doesn't exist, getting parent.
+  ${GetParent} $R0 $R0
+  Goto start
+
+direxists:
+  # Checks if $R0 is a directory.
+  ${GetFileAttributes} $R0 "DIRECTORY" $R1
+  StrCmp $R1 0 nook
+
+  # The directory exists. Try creating a file
+  ClearErrors
+  FileOpen $R2 $R0\.can_file_be_written.dat w
+  FileClose $R2
+  Delete $R0\.can_file_be_written.dat
+  ${If} ${Errors}
+    StrCpy $R1 1
+  ${Else}
+    StrCpy $R1 0
+  ${EndIf}
+  Goto exit
+
+nook:
+  StrCpy $R1 0
+
+exit:
+  Exch
+  Pop $R0
+  Exch $R1
+
+FunctionEnd

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -687,6 +687,19 @@ Function OnDirectoryLeave
           abort
 
       valid_path:
+
+    Push $R1
+    ${IsWritable} $INSTDIR $R1
+    IntCmp $R1 0 pathgood
+    Pop $R1
+    MessageBox mb_ok|MB_ICONEXCLAMATION \
+        "Error: Path $INSTDIR is not writable. Please check permissions or \
+         try respawning the installer with elevated privileges."
+    Abort
+
+    pathgood:
+    Pop $R1
+
 FunctionEnd
 
 Function .onVerifyInstDir


### PR DESCRIPTION
This patch introduces a function 'isWritable', which takes a directory as
an argument. If the directory exists, an attempt to create a file inside
it is made. If the directory doesn't exist, an attempt to create a file
inside it's parent directory is made. If the attempt suceeds, function
returns 0 else returns 1.