### PR TITLE
Fix bug where size_in_bytes is not an attribute to PathData objects

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -117,7 +117,10 @@ def check_duplicates_files(pc_recs, platform, ignore_duplicate_files=False):
         paths_data = read_paths_json(extracted_package_dir).paths
         for path_data in paths_data:
             short_path = path_data.path
-            size = path_data.size_in_bytes or getsize(join(extracted_package_dir, short_path))
+            try:
+                size = path_data.size_in_bytes
+            except AttributeError:
+                size = getsize(join(extracted_package_dir, short_path))
             total_extracted_pkgs_size += size
 
             map_members_scase[short_path].add(fn)


### PR DESCRIPTION
Fix #226 