### PR TITLE
Add logic to reset AutoRun reg keys on Uninstallation

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -835,6 +835,7 @@ Section "Uninstall"
     # Remove menu items, path entries
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmmenus'
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmpath'
+    ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmreg'
 
     DeleteRegKey SHCTX "${UNINSTREG}"
     # If Anaconda was registered as the official Python for this version,


### PR DESCRIPTION
This will be required starting conda 4.6.x

xref: https://github.com/conda/conda/issues/7594
xref: https://github.com/conda/conda/issues/7881