### PR TITLE
support for `post_install` in OSX Packages 

### DIFF
--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -254,6 +254,17 @@ def create(info, verbose=False):
     # can be disabled.
     pkgbuild_script('pathupdate', info, 'update_path.sh')
 
+    post_packages = ['postextract', 'pathupdate']
+
+    # Next, the users post_install script, if specified
+    if info.get('post_install', None) is not None:
+        scripts_dir = join(CACHE_DIR, "scripts")
+        fresh_dir(scripts_dir)
+        move_script(info['post_install'], join(scripts_dir, 'postinstall'), info)
+        fresh_dir(PACKAGE_ROOT)
+        pkgbuild('user_postinstall', scripts_dir)
+        post_packages.append('user_postinstall')
+
     # Next, the script to be run before everything, which checks if Anaconda
     # is already installed.
     pkgbuild_script('apreinstall', info, 'preinstall.sh', 'preinstall')
@@ -261,7 +272,7 @@ def create(info, verbose=False):
     # Now build the final package
     names = ['apreinstall', 'preconda']
     names.extend(name_dist(dist) for dist in info['_dists'])
-    names.extend(['postextract', 'pathupdate'])
+    names.extend(post_packages)
 
     xml_path = join(PACKAGES_DIR, 'distribution.xml')
     args = ["productbuild", "--synthesize"]

--- a/examples/osxpkg/construct.yaml
+++ b/examples/osxpkg/construct.yaml
@@ -1,0 +1,19 @@
+name: osxpkgtest
+version: 1
+
+channels:
+    - http://repo.anaconda.com/pkgs/main/
+
+attempt_hardlinks: True
+
+specs:
+    - python
+    - conda
+    - openssl
+    - asn1crypto
+    - readline
+    - setuptools
+    - numpy
+
+post_install: post_install.sh   [unix]
+installer_type: pkg  [osx]

--- a/examples/osxpkg/post_install.sh
+++ b/examples/osxpkg/post_install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# $2 is the install location, ($HOME by default)
+if [ xxx$PREFIX == 'xxx' ]; then
+    PREFIX=$(echo "$2/__NAME_LOWER__" | sed -e 's,//,/,g')
+fi
+
+echo '## Hello from Post_install script ' > $HOME/postinstall.txt
+printenv >> $HOME/postinstall.txt


### PR DESCRIPTION
This is an attempt to address #241.  Here, a final "package" is built with `pkgbuild` to run a user-supplied `post_install` script, if provided.

This approach works for me (a simple example is added) and seems 'simple enough', but I do not know if this is the preferred approach.

There is at least one outstanding issue:   In the post install script with Unix shell or Windows, the environment variable `PREFIX` is set correctly.   But `PREFIX` is not set here, and one would have to the sort of magic done at the top of `update_path.sh`, namely 

```
# $2 is the install location, which is ~ by default, but which the user can
# change.
PREFIX=$(echo "$2/__NAME_LOWER__" | sed -e 's,//,/,g')
```

I'm not sure if  a replacement as is done for `__NAME_LOWER___` from inside the `move_script()` function could be done directly for `$PREFIX`.   The  `__NAME_LOWER___` trick would be an acceptable workaround, but it would be sort of unfortunate to need that for Mac OSX packages, and not any other  `post_install` scripts.

