### PR TITLE
Fix "conda init" section for shell configs

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -514,21 +514,20 @@ if [ "$BATCH" = "0" ]; then
         cat <<EOF >> "$BASH_RC"
 
 # added by __NAME__ __VERSION__ installer
-# >>> conda init >>>
+# >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="\$(CONDA_REPORT_ERRORS=false '$PREFIX/bin/conda' shell.bash hook 2> /dev/null)"
+__conda_setup="\$('$PREFIX/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
 if [ \$? -eq 0 ]; then
-    \\eval "\$__conda_setup"
+    eval "\$__conda_setup"
 else
     if [ -f "$PREFIX/etc/profile.d/conda.sh" ]; then
         . "$PREFIX/etc/profile.d/conda.sh"
-        CONDA_CHANGEPS1=false conda activate base
     else
-        \\export PATH="$PREFIX/bin:\$PATH"
+        export PATH="$PREFIX/bin:\$PATH"
     fi
 fi
 unset __conda_setup
-# <<< conda init <<<
+# <<< conda initialize <<<
 EOF
         printf "\\n"
         printf "For this change to become active, you have to open a new terminal.\\n"

--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -28,21 +28,20 @@ For this change to become active, you have to open a new terminal."
 
 cat <<EOF >> "$BASH_RC"
 # added by __NAME__ __VERSION__ installer
-# >>> conda init >>>
+# >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="\$(CONDA_REPORT_ERRORS=false '$PREFIX/bin/conda' shell.bash hook 2> /dev/null)"
+__conda_setup="\$('$PREFIX/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
 if [ \$? -eq 0 ]; then
-    \\eval "\$__conda_setup"
+    eval "\$__conda_setup"
 else
     if [ -f "$PREFIX/etc/profile.d/conda.sh" ]; then
         . "$PREFIX/etc/profile.d/conda.sh"
-        CONDA_CHANGEPS1=false conda activate base
     else
-        \\export PATH="$PREFIX/bin:\$PATH"
+        export PATH="$PREFIX/bin:\$PATH"
     fi
 fi
 unset __conda_setup
-# <<< conda init <<<
+# <<< conda initialize <<<
 EOF
 
 chown "$USER" "$BASH_RC" "$BASH_RC_BAK"


### PR DESCRIPTION
The *conda init* section that `conda init` generates in, e.g., `.bashrc` looks different than what Constructor generates. That means that `conda init` will basically add the same stuff again if you run it.

With these changes, `conda init` will no longer modify the config that Constructor generated (or add something to it).