### PR TITLE
Support noarch:python packages

### DIFF
--- a/constructor/install.py
+++ b/constructor/install.py
@@ -426,17 +426,19 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
 #-*- coding: utf-8 -*-
 
 import sys
-from ${module} import ${func}
+import ${module}
 
 if __name__ == "__main__":
-    sys.exit(${func}())
+    sys.exit(${obj}())
 ''')
         python_interp = join(prefix, "bin", "python")
         for s in link_json["noarch"]["entry_points"]:
             name, entry = map(lambda x: x.strip(), s.split("="))
-            module, func = entry.split(":")
+            entry_segs = entry.split(":")
+            module = entry_segs[0]
+            obj = ".".join(entry_segs)
             content = tpl.substitute(python=python_interp, module=module,
-                                     func=func)
+                                     obj=obj)
             out_f = join(prefix, "bin", name)
             with open(out_f, "w") as f:
                 f.write(content)

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -441,6 +441,7 @@ if __name__ == "__main__":
             with open(out_f, "w") as f:
                 f.write(content)
             os.chmod(out_f, 509) # 509 is the octal rep of 0755/0o755
+            files.append(join("bin", name))
         break
 
     if not run_script(prefix, dist, 'post-link'):

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -27,6 +27,7 @@ import sys
 import json
 import shutil
 import stat
+import string
 from os.path import abspath, dirname, exists, isdir, isfile, islink, join
 from optparse import OptionParser
 
@@ -315,6 +316,12 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
     been extra_info in either
       - <PKGS_DIR>/dist
       - <ROOT_PREFIX>/ (when the linktype is None)
+
+    Preliminary support of noarch:python is introduced. files in
+    <prefix>/site-packages will be moved into
+    <prefix>/lib/pythonX.Y/site-packages and entry_points will be created in
+    <prefix>/bin. This makes most noarch:python packages work but the pyc files
+    are not compiled.
     '''
     if linktype:
         source_dir = join(PKGS_DIR, dist)
@@ -326,11 +333,18 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
     files = list(yield_lines(join(info_dir, 'files')))
     # TODO: Use paths.json, if available or fall back to this method
     has_prefix_files = read_has_prefix(join(info_dir, 'has_prefix'))
+    python_xy = "python%d.%d" % sys.version_info[:2]
 
     if linktype:
-        for f in files:
+        for i, f in enumerate(files):
             src = join(source_dir, f)
-            dst = join(prefix, f)
+            # link site-packages into python-specific path for noarch:python
+            # packages and fix file paths.
+            if f.startswith("site-packages" + os.path.sep):
+                dst = join(prefix, "lib", python_xy, f)
+                files[i] = join("lib", python_xy, f)
+            else:
+                dst = join(prefix, f)
             dst_dir = dirname(dst)
             if not isdir(dst_dir):
                 os.makedirs(dst_dir)
@@ -346,6 +360,26 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
                 _link(src, dst, lt)
             except OSError:
                 pass
+    else:
+        # move site-packages into python-specific path for noarch:python
+        # packages and fix file paths.
+        for i, f in enumerate(files):
+            if not f.startswith("site-packages" + os.path.sep):
+                continue
+            src = join(prefix, f)
+            if not os.path.exists(src):
+                continue
+            dst = join(prefix, "lib", python_xy, f)
+            try:
+                dst_dir = dirname(dst)
+                if not os.path.exists(dst_dir):
+                    os.makedirs(dst_dir)
+                shutil.copyfile(src, dst)
+                os.remove(src)
+            except OSError:
+                pass
+            files[i] = join("lib", python_xy, f)
+        rm_rf(join(prefix, "site-packages"))
 
     for f in sorted(has_prefix_files):
         placeholder, mode = has_prefix_files[f]
@@ -354,6 +388,38 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
         except PaddingError:
             sys.exit("ERROR: placeholder '%s' too short in: %s\n" %
                      (placeholder, dist))
+
+    # Create entry points for a noarch:python package
+    link_fn = join(info_dir, "link.json")
+    while exists(link_fn):
+        with open(link_fn) as f:
+            link_json = json.load(f)
+        if "noarch" not in link_json:
+            break
+        if link_json["noarch"]["type"] != "python":
+            break
+        if "entry_points" not in link_json["noarch"]:
+            break
+        tpl = string.Template('''#!${python}
+#-*- coding: utf-8 -*-
+
+import sys
+from ${module} import ${func}
+
+if __name__ == "__main__":
+    sys.exit(${func}())
+''')
+        python_interp = join(prefix, "bin", python_xy)
+        for s in link_json["noarch"]["entry_points"]:
+            name, entry = map(lambda x: x.strip(), s.split("="))
+            module, func = entry.split(":")
+            content = tpl.substitute(python=python_interp, module=module,
+                                     func=func)
+            out_f = join(prefix, "bin", name)
+            with open(out_f, "w") as f:
+                f.write(content)
+            os.chmod(out_f, 509) # 509 is the octal rep of 0755/0o755
+        break
 
     if not run_script(prefix, dist, 'post-link'):
         sys.exit("Error: post-link failed for: %s" % dist)

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -446,12 +446,13 @@ if __name__ == "__main__":
             content = tpl.substitute(python=python_interp, module=module,
                                      obj=obj)
             if on_win:
-                name = name + ".py"
-            out_f = join(prefix, "bin", name)
+                out_f = join(prefix, "Scripts", name + ".py")
+            else:
+                out_f = join(prefix, "bin", name)
             with open(out_f, "w") as f:
                 f.write(content)
             os.chmod(out_f, 509) # 509 is the octal rep of 0755/0o755
-            files.append(join("bin", name))
+            files.append(os.path.relpath(out_f, prefix))
         break
 
     if not run_script(prefix, dist, 'post-link'):

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -342,7 +342,10 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
             # packages and fix file paths.
             noarch_python = False
             if f.startswith("site-packages" + os.path.sep):
-                dst = join(prefix, "lib", python_xy, f)
+                if on_win:
+                    dst = join(prefix, "Lib", f)
+                else:
+                    dst = join(prefix, "lib", python_xy, f)
                 noarch_python = True
             elif f.startswith("python-scripts" + os.path.sep):
                 dst = join(prefix, "bin", os.path.basename(f))
@@ -381,7 +384,10 @@ def link(prefix, dist, linktype=LINK_HARD, info_dir=None):
             if not os.path.exists(src):
                 continue
             if f.startswith("site-packages" + os.path.sep):
-                dst = join(prefix, "lib", python_xy, f)
+                if on_win:
+                    dst = join(prefix, "Lib", f)
+                else:
+                    dst = join(prefix, "lib", python_xy, f)
             elif f.startswith("python-scripts" + os.path.sep):
                 dst = join(prefix, "bin", os.path.basename(f))
             else:

--- a/constructor/install.py
+++ b/constructor/install.py
@@ -445,6 +445,8 @@ if __name__ == "__main__":
             obj = ".".join(entry_segs)
             content = tpl.substitute(python=python_interp, module=module,
                                      obj=obj)
+            if on_win:
+                name = name + ".py"
             out_f = join(prefix, "bin", name)
             with open(out_f, "w") as f:
                 f.write(content)


### PR DESCRIPTION
noarch:python packages are now widely used in channels such as plotly, pyviz and conda-forge. Yet constructor does not support them correctly. This PR addresses this issue.

The idea of this PR is to follow the noarch:python specification in https://www.anaconda.com/condas-new-noarch-packages/ and imitate conda install. `install.py` is modified to do the following things:
1. move `site-packages/*` into `lib/pythonX.Y/site-packages`
2. move `python-scripts/*` into `bin`
3. update prefix in the above files
4. create wrappers for entry points found in `info/link.json`
5. fix paths in conda meta.

Python files are not compiled at the moment but can be added. I test this PR with https://github.com/ProgramFan/anaconda-plus/ and it works as expected.