### PR TITLE
Not delete $INSTDIR while Python is still running

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -876,7 +876,6 @@ Section "Uninstall"
 
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmpath'
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmreg'
-    ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" del "$INSTDIR"'
 
     RMDir /r /REBOOTOK "$INSTDIR"
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -858,6 +858,13 @@ Section "Install"
     WriteUninstaller "$INSTDIR\Uninstall-${NAME}.exe"
 SectionEnd
 
+!macro ExecWaitLibNsisCmd cmd
+    IfSilent +3
+        ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" ${cmd}'
+        Goto +2
+    ExecWait '"$INSTDIR\python.exe" -E -s "$INSTDIR\Lib\_nsis.py" ${cmd}'
+!macroend
+
 Section "Uninstall"
     # Remove menu items, path entries
 
@@ -874,8 +881,10 @@ Section "Uninstall"
     #   carefully.  More info at https://docs.conda.io/projects/conda/en/latest/user-guide/troubleshooting.html#solution
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_DLL_SEARCH_MODIFICATION_ENABLE", "1").r0'
 
-    ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmpath'
-    ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmreg'
+    !insertmacro ExecWaitLibNsisCmd "pre_uninstall"
+    !insertmacro ExecWaitLibNsisCmd "rmpath"
+    !insertmacro ExecWaitLibNsisCmd "rmreg"
+    !insertmacro ExecWaitLibNsisCmd 'del "$INSTDIR"'
 
     RMDir /r /REBOOTOK "$INSTDIR"
 


### PR DESCRIPTION
On Windows, it may occur that a process is locking access
to loaded DLLs or its EXE file. If the uninstaller tries to
call Python for deleting the Anaconda installation directory,
Python will prevent itself from deleting its own executable.

Therefore, NSIS should perform the deletion, not Python itself.
(which is done anyways in the next line)
