### PR TITLE
WIP: support remapping file:// urls to local

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -235,6 +235,10 @@ def main(info, verbose=True, dry_run=False):
     if not channel_urls:
         sys.exit("Error: 'channels' is required")
 
+    for url in channel_urls:
+        if url.startswith('file://') and not any(remap[0] == url for remap in channels_remap):
+            channels_remap = list(channels_remap) + [{'src': url, 'dest': 'local'}]
+
     with env_vars({
         "CONDA_PKGS_DIRS": download_dir,
     }, conda_replace_context_default):

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -395,7 +395,7 @@ CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=@CHANNELS@ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
-"$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" || exit 1
+"$CONDA_EXEC" install --repodata-fn repodata.json -c $PREFIX/conda-bld --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" || exit 1
 
 #if not keep_pkgs
     rm -fr $PREFIX/pkgs/*.tar.bz2

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -134,9 +134,10 @@ def get_final_channels(info):
     mapped_channels = []
     for channel in info.get('channels', []):
         url = get_final_url(info, channel)
+        # we handle these by pretending that they come from the local channel
+        #   ($PREFIX/conda-bld by default)
         if url.startswith("file://"):
-            print("WARNING: local channel {} does not have a remap. "
-                  "It will not be included in the installer".format(url))
+            mapped_channels.append('local')
             continue
         mapped_channels.append(url)
     return mapped_channels


### PR DESCRIPTION
fixes #269 

This only works for .sh so far.  It makes a $PREFIX/conda-bld folder and puts any local files into that folder.  It copies the repodata entries from the local index to make a valid channel in that conda-bld folder.