### PR TITLE
use 3-part dd for all extractions

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -357,47 +357,24 @@ cd "$PREFIX"
 # disable sysconfigdata overrides, since we want whatever was frozen to be used
 unset PYTHON_SYSCONFIGDATA_NAME _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
-# this is much faster with larger block size, but requires a dd from around 2012
-#   specifically the skip_bytes and count_bytes iflags
-dd iflag=skip_bytes > /dev/null 2>&1
-OLD_DD="$?"
-
 CONDA_EXEC="$PREFIX/conda.exe"
-if [ "$OLD_DD" = "1" ]; then
-    # 3-part dd from https://unix.stackexchange.com/a/121798/34459
-    # {
-    #     dd if="$in_file" bs=1 skip="$start" count="$copy1_size"
-    #     dd if="$in_file" bs="$block_size" skip="$copy2_skip" count="$copy2_blocks"
-    #     dd if="$in_file" bs=1 skip="$copy3_start" count="$copy3_size"
-    # }
-    # this is similar below with the tarball payload - see shar.py in constructor to see how
-    #    these values are computed.
-    {
-        dd if="$THIS_PATH" bs=1 skip=@CON_EXE_OFFSET_BYTES@ count=@CON_EXE_START_REMAINDER@ 2>/dev/null
-        dd if="$THIS_PATH" bs=@BLOCK_SIZE@ skip=@CON_EXE_BLOCK_OFFSET@ count=@CON_EXE_SIZE_BLOCKS@ 2>/dev/null
-        dd if="$THIS_PATH" bs=1 skip=@CON_EXE_REMAINDER_OFFSET@ count=@CON_EXE_END_REMAINDER@ 2>/dev/null
-    } > "$CONDA_EXEC";
-else
-    dd if="$THIS_PATH" of="$CONDA_EXEC" skip=@CON_EXE_OFFSET_BYTES@ count=@CON_EXE_SIZE_BYTES@ \
-       iflag=skip_bytes,count_bytes 2>/dev/null;
-fi
+# 3-part dd from https://unix.stackexchange.com/a/121798/34459
+# this is similar below with the tarball payload - see shar.py in constructor to see how
+#    these values are computed.
+{
+    dd if="$THIS_PATH" bs=1 skip=@CON_EXE_OFFSET_BYTES@ count=@CON_EXE_START_REMAINDER@ 2>/dev/null
+    dd if="$THIS_PATH" bs=@BLOCK_SIZE@ skip=@CON_EXE_BLOCK_OFFSET@ count=@CON_EXE_SIZE_BLOCKS@ 2>/dev/null
+    dd if="$THIS_PATH" bs=1 skip=@CON_EXE_REMAINDER_OFFSET@ count=@CON_EXE_END_REMAINDER@ 2>/dev/null
+} > "$CONDA_EXEC"
 
 chmod +x "$CONDA_EXEC"
 
 printf "Unpacking payload ...\n"
-# this is much faster with larger block size, but requires a dd from around 2012
-#   specifically the skip_bytes and count_bytes iflags
-if [ "$OLD_DD" = "1" ]; then
-    {
-        dd if="$THIS_PATH" bs=1 skip=@TARBALL_OFFSET_BYTES@ count=@TARBALL_START_REMAINDER@ 2>/dev/null
-        dd if="$THIS_PATH" bs=@BLOCK_SIZE@ skip=@TARBALL_BLOCK_OFFSET@ count=@TARBALL_SIZE_BLOCKS@ 2>/dev/null
-        dd if="$THIS_PATH" bs=1 skip=@TARBALL_REMAINDER_OFFSET@ count=@TARBALL_END_REMAINDER@ 2>/dev/null
-    } | "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX";
-else
-    dd if="$THIS_PATH" skip=@TARBALL_OFFSET_BYTES@ count=@TARBALL_SIZE_BYTES@ \
-       iflag=skip_bytes,count_bytes 2>/dev/null | \
-        "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX";
-fi
+{
+    dd if="$THIS_PATH" bs=1 skip=@TARBALL_OFFSET_BYTES@ count=@TARBALL_START_REMAINDER@ 2>/dev/null
+    dd if="$THIS_PATH" bs=@BLOCK_SIZE@ skip=@TARBALL_BLOCK_OFFSET@ count=@TARBALL_SIZE_BLOCKS@ 2>/dev/null
+    dd if="$THIS_PATH" bs=1 skip=@TARBALL_REMAINDER_OFFSET@ count=@TARBALL_END_REMAINDER@ 2>/dev/null
+} | "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX"
 
 "$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs || exit 1
 


### PR DESCRIPTION
having bifurcated logic here is not helpful.  The older 3-part dd is fast enough and much more compatible.