### PR TITLE
Add support for a pre-uninstall script on windows.

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -234,6 +234,14 @@ argument type(s): ``str``,
 
 Path to a post install (bash for Unix - .bat for Windows) script.
 
+## `pre_uninstall`
+
+required: False
+
+argument type(s): ``str``, 
+
+Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
+
 ## `welcome_image`
 
 required: False

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -153,6 +153,10 @@ Path to a pre install (bash - Unix only) script.
 Path to a post install (bash for Unix - .bat for Windows) script.
 '''),
 
+    ('pre_uninstall',          False, str, '''
+Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
+'''),
+
     ('default_prefix',         False, str, 'XXX'),
 
     ('welcome_image',          False, str, '''

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -97,7 +97,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             info[key] = info['name']
 
     for key in ('license_file', 'welcome_image', 'header_image', 'icon_image',
-                'pre_install', 'post_install'):
+                'pre_install', 'post_install', 'pre_uninstall'):
         if key in info:
             info[key] = abspath(join(dir_path, info[key]))
 

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -186,6 +186,29 @@ def run_post_install():
         err("Error: running %s failed\n" % path)
 
 
+def run_pre_uninstall():
+    """
+    call the pre uninstall script, if the file exists
+    """
+    path = join(ROOT_PREFIX, 'pkgs', 'pre_uninstall.bat')
+    if not isfile(path):
+        return
+    env = os.environ
+    env['PREFIX'] = str(ROOT_PREFIX)
+    cmd_exe = os.path.join(os.environ['SystemRoot'], 'System32', 'cmd.exe')
+    if not os.path.isfile(cmd_exe):
+        cmd_exe = os.path.join(os.environ['windir'], 'System32', 'cmd.exe')
+    if not os.path.isfile(cmd_exe):
+        err("Error: running %s failed.  cmd.exe could not be found.  "
+            "Looked in SystemRoot and windir env vars.\n" % path)
+    args = [cmd_exe, '/d', '/c', path]
+    import subprocess
+    try:
+        subprocess.check_call(args, env=env)
+    except subprocess.CalledProcessError:
+        err("Error: running %s failed\n" % path)
+
+
 allusers = (not exists(join(ROOT_PREFIX, '.nonadmin')))
 # out('allusers is %s\n' % allusers)
 
@@ -306,6 +329,8 @@ def main():
         add_to_path(pyver, arch)
     elif cmd == 'rmpath':
         remove_from_path()
+    elif cmd == 'pre_uninstall':
+        run_pre_uninstall()
     elif cmd == 'del':
         assert len(sys.argv) == 3
         win_del(sys.argv[2].strip())

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -783,6 +783,7 @@ Section "Install"
     File __URLS_FILE__
     File __URLS_TXT_FILE__
     File __POST_INSTALL__
+    File __PRE_UNINSTALL__
     File /nonfatal /r __INDEX_CACHE__
     File /r __REPODATA_RECORD__
 
@@ -874,6 +875,7 @@ Section "Uninstall"
     #   carefully.  More info at https://docs.conda.io/projects/conda/en/latest/user-guide/troubleshooting.html#solution
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_DLL_SEARCH_MODIFICATION_ENABLE", "1").r0'
 
+    ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" pre_uninstall'
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmpath'
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" rmreg'
     ExecWait '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" del "$INSTDIR"'

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -36,7 +36,7 @@ def get_header(conda_exec, tarball, info):
     ppd['keep_pkgs'] = bool(info.get('keep_pkgs'))
     ppd['attempt_hardlinks'] = bool(info.get('attempt_hardlinks'))
     ppd['has_license'] = has_license
-    for key in 'pre_install', 'post_install':
+    for key in 'pre_install', 'post_install', 'pre_uninstall':
         ppd['has_%s' % key] = bool(key in info)
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
     install_lines = list(add_condarc(info))

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -115,6 +115,7 @@ def make_nsi(info, dir_path):
                     ('URLS_FILE', 'urls'),
                     ('URLS_TXT_FILE', 'urls.txt'),
                     ('POST_INSTALL', 'post_install.bat'),
+                    ('PRE_UNINSTALL', 'pre_uninstall.bat'),
                     ('CONDA_HISTORY', join('conda-meta', 'history')),
                     ('REPODATA_RECORD', 'repodata_record.json'),
                     ('INDEX_CACHE', 'cache')]:
@@ -201,6 +202,13 @@ def create(info, verbose=False):
     except KeyError:
         with open(post_dst, 'w') as fo:
             fo.write(":: this is an empty post install .bat script\n")
+
+    pre_dst = join(tmp_dir, 'pre_uninstall.bat')
+    try:
+        shutil.copy(info['pre_uninstall'], pre_dst)
+    except KeyError:
+        with open(pre_dst, 'w') as fo:
+            fo.write(":: this is an empty pre uninstall .bat script\n")
 
     write_images(info, tmp_dir)
     nsi = make_nsi(info, tmp_dir)


### PR DESCRIPTION
Add the option to run a "pre-uninstall" script (on windows), to allow cleaning things done in the post install script - typically desktop integration other than start menu.

See an example:
https://dev.azure.com/ericpre/hyperspy-bundle/_build/results?buildId=89&view=logs