### PR TITLE
mkdir -p ~/.conda for .sh installer to avoid warning

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -403,6 +403,12 @@ MSGS="$PREFIX/.messages.txt"
 touch "$MSGS"
 export FORCE
 
+# original issue report:
+# https://github.com/ContinuumIO/anaconda-issues/issues/11148
+# First try to fix it (this apparently didn't work; QA reported the issue again)
+# https://github.com/conda/conda/pull/9073
+mkdir -p ~/.conda > /dev/null 2>&1
+
 CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=@CHANNELS@ \


### PR DESCRIPTION
Originally reported in https://github.com/ContinuumIO/anaconda-issues/issues/11148

Tried to fix in https://github.com/conda/conda/pull/9073 but QA is reporting the same issue.  This PR should hopefully fix it for good.

Note that permission errors past this point are a genuine issue and should be reported.  The error is still valid in general, just not when this directory is mysteriously not being created for no real reason.