### PR TITLE
trim repodata cache to include only pkgs included with installer

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -81,7 +81,7 @@ if conda_interface_type == 'conda':
         used_repodata['_mod'] = "Mon, 07 Jan 2019 15:22:15 GMT"
         for package in used_packages:
             for key in ('packages', 'packages.conda'):
-                if package in full_repodata[key]:
+                if package in full_repodata.get(key, {}):
                     used_repodata[key][package] = full_repodata[key][package]
         with open(join(cache_dir, repodata_filename), 'w') as fh:
             json.dump(used_repodata, fh, indent=2)

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -76,10 +76,13 @@ if conda_interface_type == 'conda':
         used_repodata['packages'] = {}
         used_repodata['packages.conda'] = {}
         used_repodata['removed'] = []
+        # arbitrary old, expired date, so that conda will want to immediately update it
+        # when not being run in offline mode
+        used_repodata['_mod'] = "Mon, 07 Jan 2019 15:22:15 GMT"
         for package in used_packages:
             for key in ('packages', 'packages.conda'):
                 if package in full_repodata[key]:
                     used_repodata[key][package] = full_repodata[key][package]
         with open(join(cache_dir, repodata_filename), 'w') as fh:
-            json.dump(used_repodata, fh)
+            json.dump(used_repodata, fh, indent=2)
 

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -24,7 +24,7 @@ except:
 
 files = '.constructor-build.info', 'urls', 'urls.txt', 'env.txt'
 
-def write_index_cache(info, dst_dir):
+def write_index_cache(info, dst_dir, used_packages):
     cache_dir = join(dst_dir, 'cache')
 
     if not isdir(cache_dir):
@@ -37,7 +37,7 @@ def write_index_cache(info, dst_dir):
                         for url in _urls for subdir in _platforms)
 
     for url in subdir_urls:
-        write_repodata(cache_dir, url)
+        write_repodata(cache_dir, url, used_packages)
 
     for cache_file in os.listdir(cache_dir):
         if not cache_file.endswith(".json"):
@@ -82,7 +82,7 @@ def write_files(info, dst_dir):
         for url, _ in final_urls_md5s:
             fo.write('%s\n' % url)
 
-    write_index_cache(info, dst_dir)
+    write_index_cache(info, dst_dir, info['_dists'])
 
     write_conda_meta(info, dst_dir, final_urls_md5s)
 


### PR DESCRIPTION
Addresses an issue reported by QA where conda would try to use packages from repodata.json that were not available when using --offline flag.  This limits the initial install with --offline to only exactly what is available, but future requests will obtain new repodata for the rest of the packages.

This may need a tiny bit more work to force the repodata to be refreshed when it is first used without the --offline flag.