### PR TITLE
Fix missing navigator menus

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -6,6 +6,8 @@ from os.path import join
 import sys
 import json
 
+NAV_APPS = ['glueviz', 'jupyterlab', 'notebook', 'orange3', 'qtconsole', 'rstudio', 'spyder', 'vscode']
+
 try:
     from conda import __version__ as CONDA_INTERFACE_VERSION
     conda_interface_type = 'conda'
@@ -74,12 +76,12 @@ if conda_interface_type == 'conda':
                                                                                        'packages.conda',
                                                                                        'removed',))}
         repodata_filename = _cache_fn_url(used_repodata['_url'].rstrip("/"))
-        used_repodata['packages'] = {}
         used_repodata['packages.conda'] = {}
         used_repodata['removed'] = []
         # arbitrary old, expired date, so that conda will want to immediately update it
         # when not being run in offline mode
         used_repodata['_mod'] = "Mon, 07 Jan 2019 15:22:15 GMT"
+        used_repodata['packages'] = {k: v for k, v in full_repodata['packages'].items() if v['name'] in NAV_APPS}
         for package in used_packages:
             for key in ('packages', 'packages.conda'):
                 if package in full_repodata.get(key, {}):

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -42,7 +42,7 @@ def write_index_cache(info, dst_dir, used_packages):
 
     remap_urls = []
     for subdir in _platforms:
-        for url in info.get('channels_remap'):
+        for url in info.get('channels_remap', []):
             remap_urls.append({'src': ('%s/%s/' % (url['src'].rstrip('/'), subdir)),
                                'dest':  ('%s/%s/' % (url['dest'].rstrip('/'), subdir))})
     for remap in remap_urls:


### PR DESCRIPTION
This adds the packages that navigator usually displays to our trimmed repodata cache for the installers.
