### PR TITLE
channel_remap fixes: unavailable destination, .conda file format

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -232,8 +232,8 @@ def main(info, verbose=True, dry_run=False):
     install_in_dependency_order = info.get("install_in_dependency_order", True)
     ignore_duplicate_files = info.get("ignore_duplicate_files", False)
 
-    if not channel_urls:
-        sys.exit("Error: 'channels' is required")
+    if not channel_urls and not channels_remap:
+        sys.exit("Error: at least one entry in 'channels' or 'channels_remap' is required")
 
     with env_vars({
         "CONDA_PKGS_DIRS": download_dir,

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -43,8 +43,15 @@ def write_index_cache(info, dst_dir, used_packages):
     remap_urls = []
     for subdir in _platforms:
         for url in info.get('channels_remap', []):
-            remap_urls.append({'src': ('%s/%s/' % (url['src'].rstrip('/'), subdir)),
-                               'dest':  ('%s/%s/' % (url['dest'].rstrip('/'), subdir))})
+            src = '%s/%s/' % (url['src'].rstrip('/'), subdir)
+            dest = '%s/%s/' % (url['dest'].rstrip('/'), subdir)
+            remap_urls.append({'src': src, 'dest': dest})
+            if dest not in repodatas:
+                repodatas[dest] =  {
+                    '_url': dest,
+                    'info': {'subdir': subdir},
+                    'packages': {}
+                }
     for remap in remap_urls:
         for _ in repodatas[remap['src']]['packages']:
             if (remap['src'] + _) in package_urls:

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -48,15 +48,15 @@ def write_index_cache(info, dst_dir, used_packages):
         if dst is not None:
             src = '%s/%s/' % (src, subdir)
             dst = '%s/%s/' % (dst, subdir)
-        if dst not in repodatas:
-            repodatas[dst] =  {
-                '_url': dst,
-                'info': {'subdir': subdir},
-                'packages': {}
-            }
-        if fn.endswith('.conda'):
-            fn = fn.rsplit('.', 1)[0] + '.tar.bz2'
-        repodatas[dst]['packages'][fn] = repodatas[src]['packages'][fn]
+            if dst not in repodatas:
+                repodatas[dst] =  {
+                    '_url': dst,
+                    'info': {'subdir': subdir},
+                    'packages': {}
+                }
+            if fn.endswith('.conda'):
+                fn = fn.rsplit('.', 1)[0] + '.tar.bz2'
+            repodatas[dst]['packages'][fn] = repodatas[src]['packages'][fn]
     for src in remaps:
         for subdir in _platforms:
             repodatas.pop('%s/%s/' % (src, subdir), None)

--- a/constructor/tests/test_utils.py
+++ b/constructor/tests/test_utils.py
@@ -1,5 +1,7 @@
 from ..utils import make_VIProductVersion, fill_template, preprocess, normalize_path
 
+from os import sep
+
 
 def test_make_VIProductVersion():
     f = make_VIProductVersion
@@ -65,11 +67,11 @@ E
 
 
 def test_normalize_path():
-    path = "//test//test/test"
-    assert normalize_path(path) == "/test/test/test"
+    path = "//test//test/test".replace('/', sep)
+    assert normalize_path(path) == "/test/test/test".replace('/', sep)
 
-    path = "test///test/test"
-    assert normalize_path(path) == "test/test/test"
+    path = "test///test/test".replace('/', sep)
+    assert normalize_path(path) == "test/test/test".replace('/', sep)
 
 
 def main():

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -8,6 +8,8 @@ import re
 import sys
 import hashlib
 from os.path import normpath
+from os import sep
+
 
 def filename_dist(dist):
     """ Return the filename of a distribution. """
@@ -141,6 +143,6 @@ def get_final_channels(info):
 
 def normalize_path(path):
     new_path = normpath(path)
-    return new_path.replace("//", "/")
+    return new_path.replace(sep + sep, sep)
 
 


### PR DESCRIPTION
There seems to have been a regression in behavior with regards to `channel_remap`. Specifically, if any of the destination channels are not in the `channels` list, you get KeyErrors, like so:
```
Traceback (most recent call last):
  File "C:\Users\builder\Miniconda3\Scripts\constructor-script.py", line 11, in <module>
    load_entry_point('constructor', 'console_scripts', 'constructor')()
  File "c:\users\builder\desktop\constructor\constructor\main.py", line 244, in main
    dry_run=args.dry_run, conda_exe=args.conda_exe)
  File "c:\users\builder\desktop\constructor\constructor\main.py", line 134, in main_build
    create(info, verbose=verbose)
  File "c:\users\builder\desktop\constructor\constructor\winexe.py", line 192, in create
    preconda_write_files(info, tmp_dir)
  File "c:\users\builder\desktop\constructor\constructor\preconda.py", line 102, in write_files
    write_index_cache(info, dst_dir, info['_dists'])
  File "c:\users\builder\desktop\constructor\constructor\preconda.py", line 58, in write_index_cache
    write_repodata(cache_dir, url, repodata, used_packages)
  File "c:\users\builder\desktop\constructor\constructor\conda_interface.py", line 78, in write_repodata
    repodata_filename = _cache_fn_url(used_repodata['_url'].rstrip("/"))
KeyError: '_url'
```
It is not feasible to expect the destination channels to also be listed in the `channels` list, because those channels might not be accessible from the location where we are building the constructor. Consider the case where an installer is being built outside of a company firewall with the intention of being used inside that firewall, connected to an internal repository. On the other hand, it _is_ reasonable to expect the source channels to be in the channel list.