### PR TITLE
Allow custom prefix for non-domain Windows accounts

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -450,10 +450,10 @@ Function .onInit
     ${EndIf} # USERDNSDOMAIN != ""
 
     ${If} $IsDomainUser = 0
-        StrCpy $INSTDIR_JUSTME "$Profile\${NAME}"
-    ${ElseIf} $IsDomainUser = 1
         ExpandEnvStrings $0 ${DEFAULT_PREFIX}
         StrCpy $INSTDIR_JUSTME $0
+    ${ElseIf} $IsDomainUser = 1
+        StrCpy $INSTDIR_JUSTME "$Profile\${NAME}"
     ${Else}
         # Should never happen; indicates a logic error above.
         MessageBox MB_OK "Internal error: IsUserDomain not set properly!"


### PR DESCRIPTION
Fixes #271:

> I wanted to set default_prefix on Windows, and it was having no effect in my tests; this proved to be why. If we remove the check for IsDomainUser, keeping the ElseIf branch, the behavior is as I expected.

From the [comments](https://github.com/conda/constructor/blob/329020236da0828b4574c2c25133b8b17aea7246/constructor/nsis/main.nsi.tmpl#L386-L392), the intent seems to be to disallow the setting of a custom prefix _for domain users_. But the way the if/then is constructed it's disallowing the setting of a custom prefix for _non_-domain users.