### PR TITLE
use conda init zsh if zsh is default shell

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -501,7 +501,12 @@ if [ "$BATCH" = "0" ]; then
         printf "conda init\\n"
         printf "\\n"
     else
-        $PREFIX/bin/conda init
+        if [[ $SHELL = *zsh ]]
+        then
+            $PREFIX/bin/conda init zsh
+        else
+            $PREFIX/bin/conda init
+        fi
     fi
     printf "If you'd prefer that conda's base environment not be activated on startup, \\n"
     printf "   set the auto_activate_base parameter to false: \\n"

--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -4,46 +4,11 @@
 
 # $2 is the install location, which is ~ by default, but which the user can
 # change.
-PREFIX=$(echo "$2/__NAME_LOWER__" | sed -e 's,//,/,g')
+PREFIX="$2/__NAME_LOWER__"
 
-# Logic borrowed from the official Python Mac OS X installer
-if [ -e "${HOME}/.bash_profile" ]; then
-    BASH_RC="${HOME}/.bash_profile"
-elif [ -e "${HOME}/.bash_login" ]; then
-    BASH_RC="${HOME}/.bash_login"
-elif [ -e "${HOME}/.profile" ]; then
-    BASH_RC="${HOME}/.profile"
+if [[ $SHELL = *zsh ]]
+then
+    $PREFIX/bin/conda init zsh
 else
-    BASH_RC="${HOME}/.bash_profile"
+    $PREFIX/bin/conda init
 fi
-
-BASH_RC_BAK="${BASH_RC}-__NAME_LOWER__.bak"
-
-cp -fp $BASH_RC ${BASH_RC_BAK}
-
-echo "
-Initializing __NAME__ in $BASH_RC
-
-For this change to become active, you have to open a new terminal."
-
-cat <<EOF >> "$BASH_RC"
-# added by __NAME__ __VERSION__ installer
-# >>> conda init >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="\$(CONDA_REPORT_ERRORS=false '$PREFIX/bin/conda' shell.bash hook 2> /dev/null)"
-if [ \$? -eq 0 ]; then
-    \\eval "\$__conda_setup"
-else
-    if [ -f "$PREFIX/etc/profile.d/conda.sh" ]; then
-        . "$PREFIX/etc/profile.d/conda.sh"
-        CONDA_CHANGEPS1=false conda activate base
-    else
-        \\export PATH="$PREFIX/bin:\$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda init <<<
-EOF
-
-chown "$USER" "$BASH_RC" "$BASH_RC_BAK"
-exit 0


### PR DESCRIPTION
fixes https://github.com/ContinuumIO/anaconda-issues/issues/11575

zsh is the default shell on Catalina. conda init defaults to bash if no shell is specified. Other shells may or may not set the $SHELL var (fish for instance doesn't seem to) which makes it difficult to be more generic. This should at least fix most cases we know of. 