### PR TITLE
add  for MacOS background image and  to permit install only in user home folder

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -213,6 +213,10 @@ interactive installation. (Windows only)
 PNG image used as the background of the MacOS package installer.  Should be ~1200x600
 pixels, and will be scaled. By default, an image is automatically generated.
 '''),
+    ('osxpkg_readme',          False, str, '''
+Path to RTF File to use as Readme for the MacOS package installer.
+By default, an Readme from Anaconda Python listing the Python pacakges will be used.
+'''),
 
     ('osxpkg_userhome_only',          False, bool, '''
 Whether to allow installing only to the user's home folder -- MacOS only.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -62,9 +62,9 @@ e.g.`https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.0.2o-h26aff7b_0.tar.bz
 '''),
 
     ('user_requested_specs',                  False, (list, str), '''
-List of package specifications to be recorded as "user-requested" for the 
+List of package specifications to be recorded as "user-requested" for the
 initial environment in conda's history file. If not given, user-requested
-specs will fall back to 'specs'. 
+specs will fall back to 'specs'.
 '''),
 
     ('exclude',                False, list, '''
@@ -154,9 +154,9 @@ Path to a post install (bash for Unix - .bat for Windows) script.
 '''),
 
     ('post_install_desc',      False, str, '''
-Short description of the "post_install" script to be displayed as label of 
+Short description of the "post_install" script to be displayed as label of
 the "Do not run post install script" checkbox in the windows installer.
-If used and not an empty string, the "Do not run post install script"  
+If used and not an empty string, the "Do not run post install script"
 checkbox will be displayed with this label.
 '''),
 
@@ -208,6 +208,15 @@ Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
 interactive installation. (Windows only)
 '''),
+
+    ('osxpkg_image',          False, str, '''
+PNG image used as the background of the MacOS package installer.  Should be ~1200x600
+pixels, and will be scaled. By default, an image is automatically generated.
+'''),
+
+    ('osxpkg_userhome_only',          False, bool, '''
+Whether to allow installing only to the user's home folder -- MacOS only.
+ '''),
 ]
 
 

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -54,8 +54,9 @@ def modify_xml(xml_path, info):
                                                   'No license'))
     root.append(license)
 
-    background = ET.Element('background',
-                            file=join(OSX_DIR, 'MacInstaller.png'),
+    bkg_image = info.get('oxspkg_image', join(OSX_DIR, 'MacInstaller.png'))
+
+    background = ET.Element('background', file=bkg_image,
                             scaling='proportional', alignment='center')
     root.append(background)
 
@@ -97,6 +98,8 @@ def modify_xml(xml_path, info):
     else:
         enable_anywhere = 'false'
         enable_localSystem = 'true'
+    if info.get('oxspkg_userhome_only'):
+        enable_anywhere = enable_localSystem = 'false'
     domains = ET.Element('domains',
                          enable_anywhere=enable_anywhere,
                          enable_currentUserHome='true',

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -54,7 +54,8 @@ def modify_xml(xml_path, info):
                                                   'No license'))
     root.append(license)
 
-    bkg_image = info.get('oxspkg_image', join(OSX_DIR, 'MacInstaller.png'))
+    bkg_image = info.get('osxpkg_image', join(OSX_DIR, 'MacInstaller.png'))
+
 
     background = ET.Element('background', file=bkg_image,
                             scaling='proportional', alignment='center')
@@ -98,7 +99,7 @@ def modify_xml(xml_path, info):
     else:
         enable_anywhere = 'false'
         enable_localSystem = 'true'
-    if info.get('oxspkg_userhome_only'):
+    if info.get('osxpkg_userhome_only'):
         enable_anywhere = enable_localSystem = 'false'
     domains = ET.Element('domains',
                          enable_anywhere=enable_anywhere,

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -15,7 +15,7 @@ from conda_package_handling.api import extract as cph_e
 OSX_DIR = join(dirname(__file__), "osx")
 CACHE_DIR = PACKAGE_ROOT = PACKAGES_DIR = None
 
-BUILDSCRIPT = '# final build script'
+SCRIPT = '# final build script'
 
 def _check_call(cmdlist):
     global SCRIPT

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -54,8 +54,7 @@ def modify_xml(xml_path, info):
                                                   'No license'))
     root.append(license)
 
-    bkg_image = info.get('osxpkg_image', join(OSX_DIR, 'MacInstaller.png'))
-
+    bkg_image = os.path.abspath(info.get('osxpkg_image', join(OSX_DIR, 'MacInstaller.png')))
 
     background = ET.Element('background', file=bkg_image,
                             scaling='proportional', alignment='center')


### PR DESCRIPTION
This partially addresses #309 by adding an option for `osxpkg_image` -- the background image for the PKG installer.  This also allows setting an option `osxpkg_userhome_only` to force the installation only to a user's home folder. 

It does not add support for custom welcome or other messages, though that would be possible.  


 