### PR TITLE
Revert "use build instead of build number"

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -53,11 +53,11 @@ def _find_out_of_date_precs(precs, channel_urls, platform):
     for prec in precs:
         all_versions = SubdirData.query_all(prec.name, channels=channel_urls, subdirs=[platform])
         if all_versions:
-            most_recent = max(all_versions, key=lambda package_version: (VersionOrder(package_version.version), package_version.build))
+            most_recent = max(all_versions, key=lambda package_version: (VersionOrder(package_version.version), package_version.build_number))
             prec_version = VersionOrder(prec.version)
             latest_version = VersionOrder(most_recent.version)
             if prec_version < latest_version or (prec_version == latest_version
-              and prec.build < most_recent.build):
+              and prec.build_number < most_recent.build_number):
                 out_of_date_package_records[prec.name] = most_recent
     return out_of_date_package_records
 


### PR DESCRIPTION
This reverts commit 4a5d188869943b842a997e7b77cd17c33c185130.