### PR TITLE
FileNotFoundError

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -142,6 +142,8 @@ def check_duplicates_files(pc_recs, platform, ignore_duplicate_files=False):
                         getsize(join(extracted_package_dir, short_path)))
             except AttributeError:
                 size = getsize(join(extracted_package_dir, short_path))
+            except FileNotFoundError:
+                continue
             total_extracted_pkgs_size += size
 
             map_members_scase[short_path].add(fn)


### PR DESCRIPTION
Some packages contain links that are not present in the archive. I work around the problem by ignoring inaccessible files. Maybe I need to do some more checking.