### PR TITLE
Construct from an environment

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -18,7 +18,7 @@ end, in order to allow customization for selected platforms.
 
 required: True
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Name of the installer.  May also contain uppercase letter.  The installer
 name is independent of the names of any of the conda packages the installer
@@ -28,7 +28,7 @@ is composed of.
 
 required: True
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Version of the installer.  Just like the installer name, this version
 is independent of any conda package versions contained in the installer.
@@ -37,7 +37,7 @@ is independent of any conda package versions contained in the installer.
 
 required: False
 
-argument type(s): ``list``, 
+argument type(s): ``list``,
 
 The conda channels from which packages are retrieved, when using the `specs`
 key below, but also when using the `packages` key ,unless the full URL is
@@ -47,7 +47,7 @@ given in the `packages` list (see below).
 
 required: False
 
-argument type(s): ``list``, 
+argument type(s): ``list``,
 
 List of `(src, dest)` channels, from which, channels from `src` are also
 considered while running solver, but are replaced by corresponding values from
@@ -66,7 +66,7 @@ channels_remap:
 
 required: False
 
-argument type(s): ``list``, ``str``, 
+argument type(s): ``list``, ``str``,
 
 List of package specifications, e.g. `python 2.7*`, `pyzmq` or `numpy >=1.8`.
 This list of specifications if given to the conda resolver (as if you were
@@ -78,17 +78,17 @@ e.g.`https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.0.2o-h26aff7b_0.tar.bz
 
 required: False
 
-argument type(s): ``list``, ``str``, 
+argument type(s): ``list``, ``str``,
 
-List of package specifications to be recorded as "user-requested" for the 
+List of package specifications to be recorded as "user-requested" for the
 initial environment in conda's history file. If not given, user-requested
-specs will fall back to 'specs'. 
+specs will fall back to 'specs'.
 
 ## `exclude`
 
 required: False
 
-argument type(s): ``list``, 
+argument type(s): ``list``,
 
 List of package names to be excluded, after the '`specs` have been resolved.
 For example, you can say that `readline` should be excluded, even though it
@@ -98,7 +98,7 @@ is contained as a result of resolving the specs for `python 2.7`.
 
 required: False
 
-argument type(s): ``list``, 
+argument type(s): ``list``,
 
 Packages for menu items will be installed (if the conda package contains the
 necessary metadata in "Menu/<package name>.json").  Menu items are currently
@@ -108,7 +108,7 @@ only supported on Windows.  By default, all menu items will be installed.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 By default, constructor will error out when adding packages with duplicate
 files in them. Enable this option to warn instead and continue.
@@ -117,18 +117,39 @@ files in them. Enable this option to warn instead and continue.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 By default the conda packages included in the created installer are installed
 in alphabetical order, Python is always installed first for technical
 reasons.  Using this option, the packages are installed in their dependency
 order (unless the explicit list in `packages` is used).
 
+## `environment`
+
+required: False
+
+argument type(s): ``str``,
+
+Name of the environment to construct from. If this option is present and
+non-empty, specs will be ignored.
+
+## `environment_file`
+
+required: False
+
+argument type(s): ``str``,
+
+Path to an environment file to construct from. If this option is present,
+a temporary environment will be created, constructor will build an installer
+from that, and then the temporary environment will be removed. This ensures
+that constructor and conda use the same mechanism to discover and install
+the packages. If this option is present and non-empty, specs will be ignored.
+
 ## `conda_default_channels`
 
 required: False
 
-argument type(s): ``list``, 
+argument type(s): ``list``,
 
 You can list conda channels here which will be the default conda channels
 of the created installer (if it includes conda).
@@ -137,7 +158,7 @@ of the created installer (if it includes conda).
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 The filename of the installer being created.  A reasonable default filename
 will determined by the `name`, `version`, platform and installer type.
@@ -146,7 +167,7 @@ will determined by the `name`, `version`, platform and installer type.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
@@ -155,7 +176,7 @@ and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Path to the license file being displayed by the installer during the install
 process.
@@ -164,7 +185,7 @@ process.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 By default, no conda packages are preserved after running the created
 installer in the `pkgs` directory.  Using this option changes the default
@@ -174,7 +195,7 @@ behavior.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified
 using this option, it will be used to sign the installer. Note that you will need
@@ -185,7 +206,7 @@ in one of your accessible keychains.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 By default, conda packages are extracted into the root environment and then
 patched. Enabling this option will result into extraction of the packages into
@@ -196,7 +217,7 @@ the files kept in the `pkgs` directory and then patched accordingly.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 By default, no .condarc file is written. If set, a .condarc file is written to
 the base environment if there are any channels or conda_default_channels is set.
@@ -205,7 +226,7 @@ the base environment if there are any channels or conda_default_channels is set.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Name of the company/entity who is responsible for the installer.
 
@@ -213,7 +234,7 @@ Name of the company/entity who is responsible for the installer.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Application name in the Windows "Programs and Features" control panel.
 Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
@@ -222,7 +243,7 @@ Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Path to a pre install (bash - Unix only) script.
 
@@ -230,7 +251,7 @@ Path to a pre install (bash - Unix only) script.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Path to a post install (bash for Unix - .bat for Windows) script.
 
@@ -238,18 +259,18 @@ Path to a post install (bash for Unix - .bat for Windows) script.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
-Short description of the "post_install" script to be displayed as label of 
+Short description of the "post_install" script to be displayed as label of
 the "Do not run post install script" checkbox in the windows installer.
-If used and not an empty string, the "Do not run post install script" 
+If used and not an empty string, the "Do not run post install script"
 checkbox will be displayed with this label.
 
 ## `pre_uninstall`
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
 
@@ -257,7 +278,7 @@ Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Path to an image (in any common image format `.png`, `.jpg`, `.tif`, etc.)
 which is used as the welcome image for the Windows installer.
@@ -268,7 +289,7 @@ By default, an image is automatically generated.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Like `welcome_image` for Windows, re-sized to 150 x 57 pixels.
 
@@ -276,7 +297,7 @@ Like `welcome_image` for Windows, re-sized to 150 x 57 pixels.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 Like `welcome_image` for Windows, re-sized to 256 x 256 pixels.
 
@@ -284,7 +305,7 @@ Like `welcome_image` for Windows, re-sized to 256 x 256 pixels.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 The color of the default images (when not providing explicit image files)
 used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
@@ -294,7 +315,7 @@ The default is `blue`.
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 If `welcome_image` is not provided, use this text when generating the image
 (Windows only). Defaults to `name`.
@@ -303,7 +324,7 @@ If `welcome_image` is not provided, use this text when generating the image
 
 required: False
 
-argument type(s): ``str``, 
+argument type(s): ``str``,
 
 If `header_image` is not provided, use this text when generating the image
 (Windows only). Defaults to `name`.
@@ -312,7 +333,7 @@ If `header_image` is not provided, use this text when generating the image
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 Default choice for whether to add the installation to the PATH environment
 variable. The user is still able to change this during interactive
@@ -322,7 +343,7 @@ installation.
 
 required: False
 
-argument type(s): ``bool``, 
+argument type(s): ``bool``,
 
 Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -62,9 +62,9 @@ e.g.`https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.0.2o-h26aff7b_0.tar.bz
 '''),
 
     ('user_requested_specs',                  False, (list, str), '''
-List of package specifications to be recorded as "user-requested" for the 
+List of package specifications to be recorded as "user-requested" for the
 initial environment in conda's history file. If not given, user-requested
-specs will fall back to 'specs'. 
+specs will fall back to 'specs'.
 '''),
 
     ('exclude',                False, list, '''
@@ -89,6 +89,19 @@ By default the conda packages included in the created installer are installed
 in alphabetical order, Python is always installed first for technical
 reasons.  Using this option, the packages are installed in their dependency
 order (unless the explicit list in `packages` is used).
+'''),
+
+    ('environment', False, str, '''
+Name of the environment to construct from. If this option is present and
+non-empty, specs will be ignored.
+'''),
+
+    ('environment_file', False, str, '''
+Path to an environment file to construct from. If this option is present,
+a temporary environment will be created, constructor will build an installer
+from that, and then the temporary environment will be removed. This ensures
+that constructor and conda use the same mechanism to discover and install
+the packages. If this option is present and non-empty, specs will be ignored.
 '''),
 
     ('conda_default_channels', False, list, '''
@@ -154,9 +167,9 @@ Path to a post install (bash for Unix - .bat for Windows) script.
 '''),
 
     ('post_install_desc',      False, str, '''
-Short description of the "post_install" script to be displayed as label of 
+Short description of the "post_install" script to be displayed as label of
 the "Do not run post install script" checkbox in the windows installer.
-If used and not an empty string, the "Do not run post install script"  
+If used and not an empty string, the "Do not run post install script"
 checkbox will be displayed with this label.
 '''),
 

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -189,7 +189,7 @@ def _precs_from_environment(environment):
                              "--explicit", "--json", "--md5"],
                             universal_newlines=True)
     ordering = []
-    for line in explicit.splitlines()
+    for line in explicit.splitlines():
         if not line or line.startswith("#") or line.startswith("@"):
             continue
         url, _, md5 = line.rpartition("#")
@@ -279,7 +279,7 @@ def main(info, verbose=True, dry_run=False):
     platform = info["_platform"]
     channel_urls = all_channel_urls(info.get("channels", ()))
     channels_remap = info.get('channels_remap', ())
-    specs = info["specs"]
+    specs = info.get("specs", ())
     exclude = info.get("exclude", ())
     menu_packages = info.get("menu_packages", ())
     install_in_dependency_order = info.get("install_in_dependency_order", True)

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -116,7 +116,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             if any((not s) for s in info[key]):
                 sys.exit("Error: found empty element in '%s:'" % key)
 
-    fcp_main(info, verbose=verbose, dry_run=dry_run)
+    fcp_main(info, verbose=verbose, dry_run=dry_run, conda_exe=conda_exe)
     if dry_run:
         print("Dry run, no installer created.")
         return

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -98,7 +98,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             info[key] = info['name']
 
     for key in ('license_file', 'welcome_image', 'header_image', 'icon_image',
-                'pre_install', 'post_install', 'pre_uninstall'):
+                'pre_install', 'post_install', 'pre_uninstall', 'environment_file'):
         if key in info:
             info[key] = abspath(join(dir_path, info[key]))
 

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -78,7 +78,8 @@ def system_info():
            'platform_full': platform.version()}
     if sys.platform == 'darwin':
         out['extra'] = platform.mac_ver()
-    elif sys.platform.startswith('linux'):
+    elif sys.platform.startswith('linux') and hasattr(platform, 'dist'):
+        # dist() was deprtecated in Python 3.5 and removed in 3.8
         out['extra'] = platform.dist()
     elif sys.platform.startswith('win'):
         out['extra'] = platform.win32_ver()
@@ -118,7 +119,7 @@ def write_files(info, dst_dir):
 
 
 def write_conda_meta(info, dst_dir, final_urls_md5s):
-    user_requested_specs = info.get('user_requested_specs', info['specs'])
+    user_requested_specs = info.get('user_requested_specs', info.get('specs', ()))
     cmd = path_split(sys.argv[0])[-1]
     if len(sys.argv) > 1:
         cmd = "%s %s" % (cmd, " ".join(sys.argv[1:]))


### PR DESCRIPTION
This PR adds the ability to construct from an environment (name or prefix) or an environment file. This has a couple of main advantages: 

1. It separates the concerns of environment creation and installer creation, enabling the reuse of an `environment.yml` file that already exists for a project
2. It uses the same solve that conda itself produces when creating an environment. This is a useful consistency to have. It is also a mechanism to avoid a bug on certain platforms (Windows) where conda can create the environment just fine, but constructor's `Solver` call fails in weird and unexpected ways, even for trivial specs.

As always, I welcome any feedback!