### PR TITLE
Allow header.sh to operate regardless of content size

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -336,18 +336,42 @@ export PREFIX
 
 printf "PREFIX=%s\\n" "$PREFIX"
 
+# 3-part dd from https://unix.stackexchange.com/a/121798/34459
+# this is similar below with the tarball payload - see shar.py in constructor to see how
+#    these values are computed.
+function extract_range {
+    blk_siz=16384
+    dd1_beg=$1
+    dd3_end=$2
+    dd1_end=$(( ( $dd1_beg / $blk_siz + 1 ) * $blk_siz ))
+    dd1_cnt=$(( $dd1_end - $dd1_beg ))
+    dd2_end=$(( $dd3_end / $blk_siz ))
+    dd2_beg=$(( ( $dd1_end - 1 ) / $blk_siz + 1 ))
+    dd2_cnt=$(( $dd2_end - $dd2_beg ))
+    dd3_beg=$(( $dd2_end * $blk_siz ))
+    dd3_cnt=$(( $dd3_end - $dd3_beg ))
+    dd if="$THIS_PATH" bs=1 skip=$dd1_beg count=$dd1_cnt 2>/dev/null
+    dd if="$THIS_PATH" bs=$blk_siz skip=$dd2_beg count=$dd2_cnt 2>/dev/null
+    dd if="$THIS_PATH" bs=1 skip=$dd3_beg count=$dd3_cnt 2>/dev/null
+}
+
+last_line=$(grep -anm 1 '^@@END_HEADER@@' "$THIS_PATH" | sed 's/:.*//')
+boundary0=$(head -n $last_line "$THIS_PATH" | wc -c | sed 's/ //g')
+boundary1=$(( $boundary0 + __FIRST_PAYLOAD_SIZE__ ))
+boundary2=$(( $boundary1 + __SECOND_PAYLOAD_SIZE__ ))
+
 # verify the MD5 sum of the tarball appended to this header
-END_LINE=$(grep -a -n -m 1 '^@@END_HEADER@@' "$THIS_FILE" | sed 's/:.*//')
 #if osx
-MD5=$(tail -n +$(( $END_LINE + 1 )) "$THIS_PATH" | md5)
+MD5=$(extract_range $boundary0 $boundary2 | md5)
 #else
-MD5=$(tail -n +$(( $END_LINE + 1 )) "$THIS_PATH" | md5sum -)
+MD5=$(extract_range $boundary0 $boundary2 | md5sum -)
 #endif
 
 if ! echo "$MD5" | grep __MD5__ >/dev/null; then
     printf "WARNING: md5sum mismatch of tar archive\\n" >&2
     printf "expected: __MD5__\\n" >&2
-    printf "     got: %s\\n" "$MD5" >&2
+    printf "     got: %s\\n" "MD5" >&2
+    exit 1
 fi
 
 # extract the tarball appended to this header, this creates the *.tar.bz2 files
@@ -358,47 +382,15 @@ cd "$PREFIX"
 unset PYTHON_SYSCONFIGDATA_NAME _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
 CONDA_EXEC="$PREFIX/conda.exe"
-# 3-part dd from https://unix.stackexchange.com/a/121798/34459
-# this is similar below with the tarball payload - see shar.py in constructor to see how
-#    these values are computed.
-blk_siz=16384
-bin_siz=__FIRST_PAYLOAD_SIZE__
-dd1_beg=$(head -n $END_LINE "$THIS_PATH" | wc -c | sed 's/ //g')
-dd3_end=$(( $dd1_beg + $bin_siz ))
-dd1_end=$(( ( $dd1_beg / $blk_siz + 1 ) * $blk_siz ))
-dd1_cnt=$(( $dd1_end - $dd1_beg ))
-dd2_end=$(( $dd3_end / $blk_siz ))
-dd2_beg=$(( ( $dd1_end - 1 ) / $blk_siz + 1 ))
-dd2_cnt=$(( $dd2_end - $dd2_beg ))
-dd3_beg=$(( $dd2_end * $blk_siz ))
-dd3_cnt=$(( $dd3_end - $dd3_beg ))
-{
-    dd if="$THIS_PATH" bs=1 skip=$dd1_beg count=$dd1_cnt 2>/dev/null
-    dd if="$THIS_PATH" bs=$blk_siz skip=$dd2_beg count=$dd2_cnt 2>/dev/null
-    dd if="$THIS_PATH" bs=1 skip=$dd3_beg count=$dd3_cnt 2>/dev/null
-} > "$CONDA_EXEC"
-
+extract_range $boundary0 $boundary1 > "$CONDA_EXEC"
 chmod +x "$CONDA_EXEC"
 
 export TMP_BACKUP="$TMP"
 export TMP=$PREFIX/install_tmp
 
 printf "Unpacking payload ...\n"
-bin_siz=__SECOND_PAYLOAD_SIZE__
-dd1_beg=$dd3_end
-dd3_end=$(( $dd1_beg + $bin_siz ))
-dd1_end=$(( ( $dd1_beg / $blk_siz + 1 ) * $blk_siz ))
-dd1_cnt=$(( $dd1_end - $dd1_beg ))
-dd2_end=$(( $dd3_end / $blk_siz ))
-dd2_beg=$(( ( $dd1_end - 1 ) / $blk_siz + 1 ))
-dd2_cnt=$(( $dd2_end - $dd2_beg ))
-dd3_beg=$(( $dd2_end * $blk_siz ))
-dd3_cnt=$(( $dd3_end - $dd3_beg ))
-{
-    dd if="$THIS_PATH" bs=1 skip=$dd1_beg count=$dd1_cnt 2>/dev/null
-    dd if="$THIS_PATH" bs=$blk_siz skip=$dd2_beg count=$dd2_cnt 2>/dev/null
-    dd if="$THIS_PATH" bs=1 skip=$dd3_beg count=$dd3_cnt 2>/dev/null
-} | "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX"
+extract_range $boundary1 $boundary2 | \
+    "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX"
 
 "$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs || exit 1
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -13,7 +13,7 @@ unset LD_LIBRARY_PATH
 #endif
 
 if ! echo "$0" | grep '\.sh$' > /dev/null; then
-    printf 'Please run using "bash" or "sh", but not "." or "source"\\n' >&2
+    printf 'Please run using "bash"/"dash"/"sh"/"zsh", but not "." or "source".\n' >&2
     return 1
 fi
 
@@ -341,7 +341,7 @@ printf "PREFIX=%s\\n" "$PREFIX"
 # will not be aligned with block boundaries. The solution is to extract the
 # bulk of the payload with a larger block size, and use a block size of 1
 # only to extract the partial blocks at the beginning and the end.
-function extract_range {
+extract_range () {
     # Usage: extract_range first_byte last_byte_plus_1
     blk_siz=16384
     dd1_beg=$1

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -370,8 +370,7 @@ MD5=$(extract_range $boundary0 $boundary2 | md5sum -)
 if ! echo "$MD5" | grep __MD5__ >/dev/null; then
     printf "WARNING: md5sum mismatch of tar archive\\n" >&2
     printf "expected: __MD5__\\n" >&2
-    printf "     got: %s\\n" "MD5" >&2
-    exit 1
+    printf "     got: %s\\n" "$MD5" >&2
 fi
 
 # extract the tarball appended to this header, this creates the *.tar.bz2 files

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -48,7 +48,10 @@ def get_header(conda_exec, tarball, info):
         'DEFAULT_PREFIX': info.get('default_prefix',
                                    '$HOME/%s' % name.lower()),
         'MD5': md5_files([conda_exec, tarball]),
+        'FIRST_PAYLOAD_SIZE': str(getsize(conda_exec)),
+        'SECOND_PAYLOAD_SIZE': str(getsize(tarball)),
         'INSTALL_COMMANDS': '\n'.join(install_lines),
+        'CHANNELS': ','.join(get_final_channels(info)),
         'pycache': '__pycache__',
     }
     if has_license:
@@ -57,52 +60,6 @@ def get_header(conda_exec, tarball, info):
     data = read_header_template()
     data = preprocess(data, ppd)
     data = fill_template(data, replace)
-    n = data.count('\n')
-    data = data.replace('@LINES@', str(n + 1))
-    data = data.replace('@CHANNELS@', ','.join(get_final_channels(info)))
-
-    # Make all replacements before this - nothing beyond here is allowed to change the size of the header.
-    #    If the header size changes, the offsets for extracting things will be wrong and nothing will work.
-
-    # block size for dd in bytes
-    block_size = 16 * 1024
-    total_size = len(data) + getsize(conda_exec) + getsize(tarball)
-    # NOTE: strings here need to be the same length for sake of replacement length being same
-    whitespace = 0
-    def replace_and_add_to_whitespace(data, string, value):
-        value = str(value)
-        whitespace = len(string) - len(value)
-        data = data.replace(string, str(value) + (' ' * whitespace))
-        return data
-
-    for thing, string, extra_skip in ((conda_exec, 'CON_EXE', 0), (tarball, 'TARBALL', getsize(conda_exec))):
-        start = len(data) + extra_skip
-        # 3-part dd to handle block size alignment: https://unix.stackexchange.com/a/121798/34459
-        thing_size = getsize(thing)
-        copy1_size = block_size - (start % block_size)
-        # zero padding is to ensure size of header doesn't change depending on
-        #    size of packages included.  The actual space you have is the number
-        #    of characters in the string here - @NON_PAYLOAD_SIZE@ is 18 chars
-        data = replace_and_add_to_whitespace(data, '@%s_OFFSET_BYTES@' % string, str(start))
-        data = replace_and_add_to_whitespace(data, '@%s_SIZE_BYTES@' % string, str(thing_size))
-        data = replace_and_add_to_whitespace(data, '@%s_START_REMAINDER@' % string, str(copy1_size))
-        copy2_start = start + copy1_size
-        copy2_skip = copy2_start // block_size
-        data = replace_and_add_to_whitespace(data, '@%s_BLOCK_OFFSET@' % string, str(copy2_skip))
-        copy2_blocks = (thing_size - copy2_start + start) // block_size
-        data = replace_and_add_to_whitespace(data, '@%s_SIZE_BLOCKS@' % string, str(copy2_blocks))
-        copy3_start= (copy2_skip + copy2_blocks) * block_size
-        data = replace_and_add_to_whitespace(data, '@%s_REMAINDER_OFFSET@' % string, str(copy3_start))
-        copy3_size = thing_size - copy1_size - (copy2_blocks * block_size)
-        data = replace_and_add_to_whitespace(data, '@%s_END_REMAINDER@' % string, str(copy3_size))
-
-    data = replace_and_add_to_whitespace(data, '@BLOCK_SIZE@', str(block_size))
-    # this one is not zero-padded because it is used in a different way, and is compared
-    #    with the actual size at install time (which is not zero padded)
-    data = data.replace('@TOTAL_SIZE_BYTES@', str(n))
-
-    # assert that the total length of the file hasn't changed because of our string replacement
-    assert len(data) + getsize(conda_exec) + getsize(tarball) == total_size, "Mismatch data length.  Before string format: %s; after: %s" % (total_size, len(data) + getsize(conda_exec) + getsize(tarball))
 
     return data
 


### PR DESCRIPTION
The current version of `header.sh` requires precise knowledge of its own size in order to successfully locate and extract the embedded binaries. This modification allows it to compute those locations using POSIX shell arithmetic and some simple grep/wc logic to determine the `@@END_HEADER@@` location dynamically. The only information it needs inserted are the sizes, in bytes, of the two payloads, with no careful padding needed.

I have endeavored to make sure that only POSIX `sh` arithmetic expressions are used.

Not only does this simplify the `shar.py` logic considerably it opens up the door for us to offer constructor images that can be customized _after building them_. I have some specific applications in mind here.