### PR TITLE
Check installation path length

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -349,6 +349,16 @@ Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
 interactive installation. (Windows only)
 
+## `check_path_length`
+
+required: False
+
+argument type(s): ``bool``,
+
+Check the length of the path where the distribution is installed to ensure nodejs
+can be installed.  Raise a message to request shorter path (less than 46 character)
+or enable long path on windows > 10 (require admin right).  Default is True. (Windows only)
+
 
 ## List of available selectors:
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -18,7 +18,7 @@ end, in order to allow customization for selected platforms.
 
 required: True
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Name of the installer.  May also contain uppercase letter.  The installer
 name is independent of the names of any of the conda packages the installer
@@ -28,7 +28,7 @@ is composed of.
 
 required: True
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Version of the installer.  Just like the installer name, this version
 is independent of any conda package versions contained in the installer.
@@ -37,7 +37,7 @@ is independent of any conda package versions contained in the installer.
 
 required: False
 
-argument type(s): ``list``,
+argument type(s): ``list``, 
 
 The conda channels from which packages are retrieved, when using the `specs`
 key below, but also when using the `packages` key ,unless the full URL is
@@ -47,7 +47,7 @@ given in the `packages` list (see below).
 
 required: False
 
-argument type(s): ``list``,
+argument type(s): ``list``, 
 
 List of `(src, dest)` channels, from which, channels from `src` are also
 considered while running solver, but are replaced by corresponding values from
@@ -66,7 +66,7 @@ channels_remap:
 
 required: False
 
-argument type(s): ``list``, ``str``,
+argument type(s): ``list``, ``str``, 
 
 List of package specifications, e.g. `python 2.7*`, `pyzmq` or `numpy >=1.8`.
 This list of specifications if given to the conda resolver (as if you were
@@ -78,7 +78,7 @@ e.g.`https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.0.2o-h26aff7b_0.tar.bz
 
 required: False
 
-argument type(s): ``list``, ``str``,
+argument type(s): ``list``, ``str``, 
 
 List of package specifications to be recorded as "user-requested" for the
 initial environment in conda's history file. If not given, user-requested
@@ -88,7 +88,7 @@ specs will fall back to 'specs'.
 
 required: False
 
-argument type(s): ``list``,
+argument type(s): ``list``, 
 
 List of package names to be excluded, after the '`specs` have been resolved.
 For example, you can say that `readline` should be excluded, even though it
@@ -98,7 +98,7 @@ is contained as a result of resolving the specs for `python 2.7`.
 
 required: False
 
-argument type(s): ``list``,
+argument type(s): ``list``, 
 
 Packages for menu items will be installed (if the conda package contains the
 necessary metadata in "Menu/<package name>.json").  Menu items are currently
@@ -108,7 +108,7 @@ only supported on Windows.  By default, all menu items will be installed.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 By default, constructor will error out when adding packages with duplicate
 files in them. Enable this option to warn instead and continue.
@@ -117,7 +117,7 @@ files in them. Enable this option to warn instead and continue.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 By default the conda packages included in the created installer are installed
 in alphabetical order, Python is always installed first for technical
@@ -128,7 +128,7 @@ order (unless the explicit list in `packages` is used).
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Name of the environment to construct from. If this option is present and
 non-empty, specs will be ignored.
@@ -137,7 +137,7 @@ non-empty, specs will be ignored.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to an environment file to construct from. If this option is present,
 a temporary environment will be created, constructor will build an installer
@@ -149,7 +149,7 @@ the packages. If this option is present and non-empty, specs will be ignored.
 
 required: False
 
-argument type(s): ``list``,
+argument type(s): ``list``, 
 
 You can list conda channels here which will be the default conda channels
 of the created installer (if it includes conda).
@@ -158,7 +158,7 @@ of the created installer (if it includes conda).
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 The filename of the installer being created.  A reasonable default filename
 will determined by the `name`, `version`, platform and installer type.
@@ -167,7 +167,7 @@ will determined by the `name`, `version`, platform and installer type.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
@@ -176,7 +176,7 @@ and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to the license file being displayed by the installer during the install
 process.
@@ -185,7 +185,7 @@ process.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 By default, no conda packages are preserved after running the created
 installer in the `pkgs` directory.  Using this option changes the default
@@ -195,7 +195,7 @@ behavior.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified
 using this option, it will be used to sign the installer. Note that you will need
@@ -206,7 +206,7 @@ in one of your accessible keychains.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 By default, conda packages are extracted into the root environment and then
 patched. Enabling this option will result into extraction of the packages into
@@ -217,7 +217,7 @@ the files kept in the `pkgs` directory and then patched accordingly.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 By default, no .condarc file is written. If set, a .condarc file is written to
 the base environment if there are any channels or conda_default_channels is set.
@@ -226,7 +226,7 @@ the base environment if there are any channels or conda_default_channels is set.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Name of the company/entity who is responsible for the installer.
 
@@ -234,7 +234,7 @@ Name of the company/entity who is responsible for the installer.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Application name in the Windows "Programs and Features" control panel.
 Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
@@ -243,7 +243,7 @@ Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to a pre install (bash - Unix only) script.
 
@@ -251,7 +251,7 @@ Path to a pre install (bash - Unix only) script.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to a post install (bash for Unix - .bat for Windows) script.
 
@@ -259,7 +259,7 @@ Path to a post install (bash for Unix - .bat for Windows) script.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Short description of the "post_install" script to be displayed as label of
 the "Do not run post install script" checkbox in the windows installer.
@@ -270,7 +270,7 @@ checkbox will be displayed with this label.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
 
@@ -278,7 +278,7 @@ Path to a pre uninstall (.bat for Windows) script. Only supported on Windows.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Path to an image (in any common image format `.png`, `.jpg`, `.tif`, etc.)
 which is used as the welcome image for the Windows installer.
@@ -289,7 +289,7 @@ By default, an image is automatically generated.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Like `welcome_image` for Windows, re-sized to 150 x 57 pixels.
 
@@ -297,7 +297,7 @@ Like `welcome_image` for Windows, re-sized to 150 x 57 pixels.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 Like `welcome_image` for Windows, re-sized to 256 x 256 pixels.
 
@@ -305,7 +305,7 @@ Like `welcome_image` for Windows, re-sized to 256 x 256 pixels.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 The color of the default images (when not providing explicit image files)
 used on Windows.  Possible values are `red`, `green`, `blue`, `yellow`.
@@ -315,7 +315,7 @@ The default is `blue`.
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 If `welcome_image` is not provided, use this text when generating the image
 (Windows only). Defaults to `name`.
@@ -324,7 +324,7 @@ If `welcome_image` is not provided, use this text when generating the image
 
 required: False
 
-argument type(s): ``str``,
+argument type(s): ``str``, 
 
 If `header_image` is not provided, use this text when generating the image
 (Windows only). Defaults to `name`.
@@ -333,7 +333,7 @@ If `header_image` is not provided, use this text when generating the image
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 Default choice for whether to add the installation to the PATH environment
 variable. The user is still able to change this during interactive
@@ -343,7 +343,7 @@ installation.
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
@@ -353,11 +353,11 @@ interactive installation. (Windows only)
 
 required: False
 
-argument type(s): ``bool``,
+argument type(s): ``bool``, 
 
 Check the length of the path where the distribution is installed to ensure nodejs
 can be installed.  Raise a message to request shorter path (less than 46 character)
-or enable long path on windows > 10 (require admin right).  Default is True. (Windows only)
+or enable long path on windows > 10 (require admin right). Default is True. (Windows only)
 
 
 ## List of available selectors:
@@ -369,6 +369,7 @@ or enable long path on windows > 10 (require admin right).  Default is True. (Wi
 - ``linux64``
 - ``osx``
 - ``ppc64le``
+- ``s390x``
 - ``unix``
 - ``win``
 - ``win32``

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -119,6 +119,12 @@ The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 '''),
 
+    ('check_long_path',     True, str, '''
+Check the length of the path where the distribution is installed, raise a
+message to request shorter path (less than 38 character) or enable long path
+on windows > 10 (require admin right).  By default, True. Windows only.
+'''),
+
     ('license_file',           False, str, '''
 Path to the license file being displayed by the installer during the install
 process.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -225,7 +225,7 @@ interactive installation. (Windows only)
     ('check_path_length',     False, bool, '''
 Check the length of the path where the distribution is installed to ensure nodejs
 can be installed.  Raise a message to request shorter path (less than 46 character)
-or enable long path on windows > 10 (require admin right).  By default, True. (Windows only)
+or enable long path on windows > 10 (require admin right). Default is True. (Windows only)
 '''),
 ]
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -119,7 +119,7 @@ The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 '''),
 
-    ('check_long_path',     True, str, '''
+    ('check_long_path',     False, bool, '''
 Check the length of the path where the distribution is installed, raise a
 message to request shorter path (less than 38 character) or enable long path
 on windows > 10 (require admin right).  By default, True. Windows only.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -119,7 +119,7 @@ The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 '''),
 
-    ('check_long_path',     False, bool, '''
+    ('check_path_length',     False, bool, '''
 Check the length of the path where the distribution is installed, raise a
 message to request shorter path (less than 38 character) or enable long path
 on windows > 10 (require admin right).  By default, True. Windows only.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -119,12 +119,6 @@ The type of the installer being created.  Possible values are "sh", "pkg",
 and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
 '''),
 
-    ('check_path_length',     False, bool, '''
-Check the length of the path where the distribution is installed, raise a
-message to request shorter path (less than 38 character) or enable long path
-on windows > 10 (require admin right).  By default, True. Windows only.
-'''),
-
     ('license_file',           False, str, '''
 Path to the license file being displayed by the installer during the install
 process.
@@ -227,8 +221,13 @@ Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
 interactive installation. (Windows only)
 '''),
-]
 
+    ('check_path_length',     False, bool, '''
+Check the length of the path where the distribution is installed to ensure nodejs
+can be installed.  Raise a message to request shorter path (less than 46 character)
+or enable long path on windows > 10 (require admin right).  By default, True. (Windows only)
+'''),
+]
 
 def ns_platform(platform):
     p = platform

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -54,6 +54,9 @@ var /global ARGV_NoScripts
 var /global ARGV_CheckPathLength
 
 var /global IsDomainUser
+var /global CheckPathLength
+var /global LongPathsEnabled
+var /global InstDirLen
 
 var /global InstModePage_RadioButton_JustMe
 var /global InstModePage_RadioButton_AllUsers
@@ -235,8 +238,12 @@ FunctionEnd
 
     ClearErrors
     ${GetOptions} $ARGV "/CheckPathLength=" $ARGV_CheckPathLength
-    ${If} ${Errors}
-        StrCpy $ARGV_CheckPathLength "1"
+    ${IfNot} ${Errors}
+        ${If} $ARGV_CheckPathLength = "0"
+            StrCpy $CheckPathLength "0"
+        ${ElseIf} $ARGV_CheckPathLength = "1"
+            StrCpy $CheckPathLength "1"
+        ${EndIf}
     ${EndIf}
 
 !macroend
@@ -509,6 +516,11 @@ Function .onInit
         ${EndIf}
     ${EndIf}
 
+    ; Set default value
+    ${If} $CheckPathLength == ""
+        StrCpy $CheckPathLength "1"
+    ${EndIf}
+
     # Initialize the default settings for the anaconda custom options
     Call mui_AnaCustomOptions_InitDefaults
     # Override custom options with explicitly given values from contruct.yaml.
@@ -524,6 +536,12 @@ Function .onInit
 #endif
 #if register_python_default is False
     StrCpy $Ana_RegisterSystemPython_State ${BST_UNCHECKED}
+#endif
+#if check_path_length is True
+    StrCpy $CheckPathLength "1"
+#endif
+#if check_path_length is False
+    StrCpy $CheckPathLength "0"
 #endif
 
     Call OnInit_Release
@@ -649,9 +667,12 @@ Function OnDirectoryLeave
         Abort
     ${EndIf}
 
-    StrLen $InstDirLen "${APP_INSTDIR}"
-    ${If} $InstDirLen > 38
-    ${AndIf} $ARGV_CheckPathLength = "1"
+    ReadRegStr $LongPathsEnabled HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled"
+    StrLen $InstDirLen "$InstDir"
+
+    ${If} $CheckPathLength == "1"
+    ${AndIf} $LongPathsEnabled == "0"
+    ${AndIf} $InstDirLen > 38
         ; With windows 10, we can enable support for long path, for earlier
         ; version, suggest user to use shorter installation path
         ${If} ${AtLeastWin10}

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -51,6 +51,7 @@ var /global ARGV_AddToPath
 var /global ARGV_RegisterPython
 var /global ARGV_NoRegistry
 var /global ARGV_NoScripts
+var /global ARGV_CheckLongPath
 
 var /global IsDomainUser
 
@@ -175,6 +176,7 @@ FunctionEnd
                 /RegisterPython=[0|1] [default: AllUsers: 1, JustMe: 0]$\n$\n\
                 /NoRegistry=[0|1] [default: AllUsers: 0, JustMe: 0]$\n$\n\
                 /NoScripts=[0|1] [default: 0]$\n$\n\
+                /CheckLongPath=[0|1] [default: 1]$\n$\n\
             Examples:$\n\
                 Install for all users, but don't add to PATH env var:$\n\
                     $EXEFILE /InstallationType=AllUsers$\n$\n\
@@ -229,6 +231,12 @@ FunctionEnd
         ${ElseIf} $ARGV_NoScripts = "0"
             StrCpy $Ana_NoScripts_State ${BST_UNCHECKED}
         ${EndIf}
+    ${EndIf}
+
+    ClearErrors
+    ${GetOptions} $ARGV "/CheckLongPath=" $ARGV_CheckLongPath
+    ${If} ${Errors}
+        StrCpy $ARGV_CheckLongPath "1"
     ${EndIf}
 
 !macroend
@@ -640,6 +648,32 @@ Function OnDirectoryLeave
              please choose a different location."
         Abort
     ${EndIf}
+
+    StrLen $InstDirLen "${APP_INSTDIR}"
+    ${If} $InstDirLen > 38
+    ${AndIf} $ARGV_CheckLongPath = "1"
+        ; With windows 10, we can enable support for long path, for earlier
+        ; version, suggest user to use shorter installation path
+        ${If} ${AtLeastWin10}
+        ${AndIfNot} $ARGV_NoRegistry = "1"
+            ; If we have admin right, we enable long path on windows
+            ${If} ${UAC_IsAdmin}
+                WriteRegDWORD HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled" 1
+            ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
+            ${Else}
+                MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 38 characters or \
+                                              the installation requires administrator rights to enable long \
+                                              path on Windows."
+                Abort
+            ${EndIf}
+        ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
+        ${Else}
+            MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 38 characters. \
+                                          Please choose another location."
+            Abort
+        ${EndIf}
+    ${EndIf}
+
     # Call the CheckForSpaces function.
     Push $INSTDIR # Input string (install path).
     Call CheckForSpaces

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -672,7 +672,7 @@ Function OnDirectoryLeave
 
     ${If} $CheckPathLength == "1"
     ${AndIf} $LongPathsEnabled == "0"
-    ${AndIf} $InstDirLen > 38
+    ${AndIf} $InstDirLen > 46
         ; With windows 10, we can enable support for long path, for earlier
         ; version, suggest user to use shorter installation path
         ${If} ${AtLeastWin10}

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -51,7 +51,7 @@ var /global ARGV_AddToPath
 var /global ARGV_RegisterPython
 var /global ARGV_NoRegistry
 var /global ARGV_NoScripts
-var /global ARGV_CheckLongPath
+var /global ARGV_CheckPathLength
 
 var /global IsDomainUser
 
@@ -176,7 +176,7 @@ FunctionEnd
                 /RegisterPython=[0|1] [default: AllUsers: 1, JustMe: 0]$\n$\n\
                 /NoRegistry=[0|1] [default: AllUsers: 0, JustMe: 0]$\n$\n\
                 /NoScripts=[0|1] [default: 0]$\n$\n\
-                /CheckLongPath=[0|1] [default: 1]$\n$\n\
+                /CheckPathLength=[0|1] [default: 1]$\n$\n\
             Examples:$\n\
                 Install for all users, but don't add to PATH env var:$\n\
                     $EXEFILE /InstallationType=AllUsers$\n$\n\
@@ -234,9 +234,9 @@ FunctionEnd
     ${EndIf}
 
     ClearErrors
-    ${GetOptions} $ARGV "/CheckLongPath=" $ARGV_CheckLongPath
+    ${GetOptions} $ARGV "/CheckPathLength=" $ARGV_CheckPathLength
     ${If} ${Errors}
-        StrCpy $ARGV_CheckLongPath "1"
+        StrCpy $ARGV_CheckPathLength "1"
     ${EndIf}
 
 !macroend
@@ -651,7 +651,7 @@ Function OnDirectoryLeave
 
     StrLen $InstDirLen "${APP_INSTDIR}"
     ${If} $InstDirLen > 38
-    ${AndIf} $ARGV_CheckLongPath = "1"
+    ${AndIf} $ARGV_CheckPathLength = "1"
         ; With windows 10, we can enable support for long path, for earlier
         ; version, suggest user to use shorter installation path
         ${If} ${AtLeastWin10}

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -682,14 +682,14 @@ Function OnDirectoryLeave
                 WriteRegDWORD HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled" 1
             ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
             ${Else}
-                MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 38 characters or \
+                MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 46 characters or \
                                               the installation requires administrator rights to enable long \
                                               path on Windows."
                 Abort
             ${EndIf}
         ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
         ${Else}
-            MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 38 characters. \
+            MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 46 characters. \
                                           Please choose another location."
             Abort
         ${EndIf}

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -129,6 +129,7 @@ def make_nsi(info, dir_path):
     ppd = ns_platform(info['_platform'])
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
     ppd['register_python_default'] = info.get('register_python_default', None)
+    ppd['check_path_length'] = info.get('check_path_length', None)
     data = preprocess(data, ppd)
     data = fill_template(data, replace)
 


### PR DESCRIPTION
The installation of nodejs and its highly nested directory structure requires installation directory path shorter than ~46 characters in order to avoid the default 260 characters path limits on windows. This PR add an option to check the path length and make sure it is not longer than an estimated limit (based on nodejs 10.13 from the defaults channel).
If the installation path is too long, it would raise an message to request the user to choose a shorter path or enable support for long path on windows 10 (requires admin right).