### PR TITLE
Allow keep_pkgs to be a command-line option

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -173,9 +173,11 @@ process.
 
 _required:_ no<br/>
 _type:_ boolean<br/>
-By default, no conda packages are preserved after running the created
-installer in the `pkgs` directory.  Using this option changes the default
-behavior.
+If `False` (default), the package cache in the `pkgs` subdirectory is removed
+when the installation process is complete. If `True`, this subdirectory and
+its contents are preserved. If `keep_pkgs` is `False`, Unix `.sh` and Windows `.msi`
+installers offer a command-line option (`-k` and `/KeepPkgCache`, respectively)
+to preserve the package cache.
 
 ## `signing_identity_name`
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -134,9 +134,11 @@ process.
 '''),
 
     ('keep_pkgs',              False, bool, '''
-By default, no conda packages are preserved after running the created
-installer in the `pkgs` directory.  Using this option changes the default
-behavior.
+If `False` (default), the package cache in the `pkgs` subdirectory is removed
+when the installation process is complete. If `True`, this subdirectory and
+its contents are preserved. If `keep_pkgs` is `False`, Unix `.sh` and Windows `.msi`
+installers offer a command-line option (`-k` and `/KeepPkgCache`, respectively)
+to preserve the package cache.
 '''),
 
     ('signing_identity_name',  False, str, '''

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -188,10 +188,11 @@ and a `.bat` file for Windows.
 '''),
 
     ('post_install_desc',      False, str, '''
-Short description of the "post_install" script to be displayed as label of
-the "Do not run post install script" checkbox in the windows installer.
-If used and not an empty string, the "Do not run post install script"
-checkbox will be displayed with this label.
+A description of the purpose of the supplied post_install script. If this
+string is supplied and non-empty, then the Windows and macOS GUI installers
+will display it along with checkbox to enable or disable the execution of the
+script. If this string is not supplied, it is assumed that the script
+is compulsory and the option to disable it will not be offered.
 '''),
 
     ('pre_uninstall',          False, str, '''
@@ -233,9 +234,9 @@ If `header_image` is not provided, use this text when generating the image
 '''),
 
     ('initialize_by_default',    False, bool, '''
-Default choice for whether to add the installation to the PATH environment
-variable. The user is still able to change this during interactive
-installation.
+Whether to add the installation to the PATH environment variable. The default
+is true for GUI installers (msi, pkg) and False for shell installers. The user
+is able to change the default during interactive installation.
 '''),
 
     ('register_python_default',  False, bool, '''

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -225,7 +225,7 @@ FunctionEnd
     ClearErrors
     ${GetOptions} $ARGV "/KeepPkgCache=" $ARGV_KeepPkgCache
     ${If} ${Errors}
-        StrCpy $ARGV_KeepPkgCache "0"
+        StrCpy $ARGV_KeepPkgCache "@KEEP_PKGS@"
     ${EndIf}
 
     ClearErrors
@@ -867,10 +867,10 @@ Section "Install"
 
     # Cleanup
     SetOutPath "$INSTDIR"
-    ${If} $ARGV_KeepPkgCache == "1"
-        Delete "$INSTDIR\pkgs\env.txt"
-    ${Else}
-        RMDir /r "$INSTDIR\pkgs"
+    Delete "$INSTDIR\pkgs\env.txt"
+    ${If} $ARGV_KeepPkgCache == "0"
+        DetailPrint "Clearing the package cache..."
+        nsExec::ExecToLog '"$INSTDIR\_conda.exe" clean --all --force-pkgs-dirs --yes'
     ${EndIf}
 
     @WRITE_CONDARC@

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -48,6 +48,7 @@ var /global ARGV
 var /global ARGV_Help
 var /global ARGV_InstallationType
 var /global ARGV_AddToPath
+var /global ARGV_KeepPkgCache
 var /global ARGV_RegisterPython
 var /global ARGV_NoRegistry
 var /global ARGV_NoScripts
@@ -176,6 +177,7 @@ FunctionEnd
              Options:$\n$\n\
                 /InstallationType=AllUsers [default: JustMe]$\n$\n\
                 /AddToPath=[0|1] [default: 0]$\n$\n\
+                /KeepPkgCache=[0|1] [default: @KEEP_PKGS@]$\n$\n\
                 /RegisterPython=[0|1] [default: AllUsers: 1, JustMe: 0]$\n$\n\
                 /NoRegistry=[0|1] [default: AllUsers: 0, JustMe: 0]$\n$\n\
                 /NoScripts=[0|1] [default: 0]$\n$\n\
@@ -218,6 +220,12 @@ FunctionEnd
         ${ElseIf} $ARGV_AddToPath = "0"
             StrCpy $Ana_AddToPath_State ${BST_UNCHECKED}
         ${EndIf}
+    ${EndIf}
+
+    ClearErrors
+    ${GetOptions} $ARGV "/KeepPkgCache=" $ARGV_KeepPkgCache
+    ${If} ${Errors}
+        StrCpy $ARGV_KeepPkgCache "0"
     ${EndIf}
 
     ClearErrors
@@ -858,7 +866,12 @@ Section "Install"
     @PKG_COMMANDS@
 
     # Cleanup
-    Delete "$INSTDIR\pkgs\env.txt"
+    SetOutPath "$INSTDIR"
+    ${If} $ARGV_KeepPkgCache == "1"
+        Delete "$INSTDIR\pkgs\env.txt"
+    ${Else}
+        RMDir /r "$INSTDIR\pkgs"
+    ${EndIf}
 
     @WRITE_CONDARC@
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -28,6 +28,7 @@ Unicode "true"
 !define PY_VER __PY_VER__
 !define PYVERSION_JUSTDIGITS __PYVERSION_JUSTDIGITS__
 !define PYVERSION __PYVERSION__
+!define PYVERSION_MAJOR __PYVERSION_MAJOR__
 !define DEFAULT_PREFIX __DEFAULT_PREFIX__
 !define POST_INSTALL_DESC __POST_INSTALL_DESC__
 !define PRODUCT_NAME "${NAME} ${VERSION} (${ARCH})"
@@ -177,7 +178,12 @@ FunctionEnd
              Options:$\n$\n\
                 /InstallationType=AllUsers [default: JustMe]$\n$\n\
                 /AddToPath=[0|1] [default: 0]$\n$\n\
-                /KeepPkgCache=[0|1] [default: @KEEP_PKGS@]$\n$\n\
+#if keep_pkgs is True
+                /KeepPkgCache=[0|1] [default: 1]$\n$\n\
+#endif
+#if keep_pkgs is False
+                /KeepPkgCache=[0|1] [default: 0]$\n$\n\
+#endif
                 /RegisterPython=[0|1] [default: AllUsers: 1, JustMe: 0]$\n$\n\
                 /NoRegistry=[0|1] [default: AllUsers: 0, JustMe: 0]$\n$\n\
                 /NoScripts=[0|1] [default: 0]$\n$\n\
@@ -238,9 +244,9 @@ FunctionEnd
     ${GetOptions} $ARGV "/NoScripts=" $ARGV_NoScripts
     ${IfNot} ${Errors}
         ${If} $ARGV_NoScripts = "1"
-            StrCpy $Ana_NoScripts_State ${BST_CHECKED}
+            StrCpy $Ana_PostInstall_State ${BST_UNCHECKED}
         ${ElseIf} $ARGV_NoScripts = "0"
-            StrCpy $Ana_NoScripts_State ${BST_UNCHECKED}
+            StrCpy $Ana_PostInstall_State ${BST_CHECKED}
         ${EndIf}
     ${EndIf}
 
@@ -551,6 +557,18 @@ Function .onInit
 #if check_path_length is False
     StrCpy $CheckPathLength "0"
 #endif
+#if keep_pkgs is True
+    StrCpy $Ana_ClearPkgCache_State ${BST_UNCHECKED}
+#endif
+#if keep_pkgs is False
+    StrCpy $Ana_ClearPkgCache_State ${BST_CHECKED}
+#endif
+#if post_install_exists is True
+    StrCpy $Ana_PostInstall_State ${BST_CHECKED}
+#endif
+#if post_install_exists is False
+    StrCpy $Ana_PostInstall_State ${BST_UNCHECKED}
+#endif
 
     Call OnInit_Release
 
@@ -786,26 +804,6 @@ Function .onVerifyInstDir
     PathGood:
 FunctionEnd
 
-Function AbortRetryExecWait
-    Pop $1
-    Pop $2
-    ${Do}
-        ExecWait $2 $0
-        ${If} $0 != "0"
-            MessageBox MB_ABORTRETRYIGNORE|MB_ICONEXCLAMATION|MB_DEFBUTTON3 \
-                    $1 /SD IDIGNORE IDABORT abort IDRETRY retry
-            ; IDIGNORE: Continue anyway
-            StrCpy $0 "0"
-            goto retry
-          abort:
-            ; Abort installation
-            Abort
-          retry:
-            ; Retry the ExecWait command
-        ${EndIf}
-    ${LoopWhile} $0 != "0"
-FunctionEnd
-
 Function AbortRetryNSExecWait
     Pop $1
     Pop $2
@@ -822,7 +820,7 @@ Function AbortRetryNSExecWait
             ; Abort installation
             Abort
           retry:
-            ; Retry the ExecWait command
+            ; Retry the nsExec command
         ${EndIf}
     ${LoopWhile} $0 != "0"
 FunctionEnd
@@ -868,10 +866,6 @@ Section "Install"
     # Cleanup
     SetOutPath "$INSTDIR"
     Delete "$INSTDIR\pkgs\env.txt"
-    ${If} $ARGV_KeepPkgCache == "0"
-        DetailPrint "Clearing the package cache..."
-        nsExec::ExecToLog '"$INSTDIR\_conda.exe" clean --all --force-pkgs-dirs --yes'
-    ${EndIf}
 
     @WRITE_CONDARC@
 
@@ -889,21 +883,28 @@ Section "Install"
 
     push '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" mkdirs'
     push 'Failed to initialize Anaconda directories'
-    call AbortRetryExecWait
+    call AbortRetryNSExecWait
 
-    ${If} $Ana_NoScripts_State = ${BST_UNCHECKED}
+    ${If} $Ana_PostInstall_State = ${BST_CHECKED}
         DetailPrint "Running post install..."
         push '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" post_install'
         push 'Failed to run post install script'
-        call AbortRetryExecWait
+        call AbortRetryNSExecWait
+    ${EndIf}
+
+    ${If} $Ana_ClearPkgCache_State = ${BST_CHECKED}
+        DetailPrint "Clearing package cache..."
+        push '"$INSTDIR\_conda.exe" clean --all --force-pkgs-dirs --yes'
+        push 'Failed to clear package cache'
+        call AbortRetryNSExecWait
     ${EndIf}
 
     ${If} $Ana_AddToPath_State = ${BST_CHECKED}
+        DetailPrint "Adding to PATH..."
         push '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" addpath ${PYVERSION} ${NAME} ${VERSION} ${ARCH}'
         push 'Failed to add @NAME@ to the system PATH'
-        call AbortRetryExecWait
+        call AbortRetryNSExecWait
     ${EndIf}
-
 
     # Create registry entries saying this is the system Python
     # (for this version)

--- a/constructor/osx/clean_cache.sh
+++ b/constructor/osx/clean_cache.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright (c) 2012-2020 Anaconda, Inc.
+# All rights reserved.
+
+# $2 is the install location, which is ~ by default
+# but which the user can change.
+PREFIX="$2/__NAME_LOWER__"
+rm -rf "$PREFIX/pkgs"

--- a/constructor/osx/post_extract.sh
+++ b/constructor/osx/post_extract.sh
@@ -29,6 +29,7 @@ cp "$PREFIX/conda-meta/history.bak" "$PREFIX/conda-meta/history"
 # Cleanup!
 rm -f "$CONDA_EXEC"
 rm -f "$PREFIX/pkgs/env.txt"
+__KEEP_PKGS__
 
 __WRITE_CONDARC__
 

--- a/constructor/osx/post_extract.sh
+++ b/constructor/osx/post_extract.sh
@@ -4,32 +4,44 @@
 
 unset DYLD_LIBRARY_PATH
 
-# TODO: We could use syslog instead of echo to log things to the console so
-# that they can actually be seen by someone looking for them.
-
-# $2 is the install location, which is ~ by default, but which the user can
-# change.
 PREFIX="$2/__NAME_LOWER__"
 PREFIX=$(cd "$PREFIX"; pwd)
 export PREFIX
-
 echo "PREFIX=$PREFIX"
 
 CONDA_EXEC="$PREFIX/conda.exe"
 chmod +x "$CONDA_EXEC"
 
-cp "$PREFIX/conda-meta/history" "$PREFIX/conda-meta/history.bak"
+# Create a blank history file so conda thinks this is an existing env
+mkdir -p $PREFIX/conda-meta
+touch $PREFIX/conda-meta/history
+
+# Extract the conda packages but avoiding the overwriting of the
+# custom metadata we have already put in place
+"$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs
+if (( $? )); then
+    echo "ERROR: could not extract the conda packages"
+    exit 1
+fi
+
+# Perform the conda install
 CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=__CHANNELS__ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
 "$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" || exit 1
-cp "$PREFIX/conda-meta/history.bak" "$PREFIX/conda-meta/history"
+if (( $? )); then
+    echo "ERROR: could not complete the conda install"
+    exit 1
+fi
+
+# Move the prepackaged history file into place
+mv "$PREFIX/pkgs/conda-meta/history" "$PREFIX/conda-meta/history"
 
 # Cleanup!
 rm -f "$CONDA_EXEC"
-rm -f "$PREFIX/pkgs/env.txt"
-__KEEP_PKGS__
+rm -f "$PREFIX/env.txt"
+find "$PREFIX/pkgs" -type d -empty -exec rmdir {} \; 2>/dev/null || :
 
 __WRITE_CONDARC__
 

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -116,6 +116,8 @@ def move_script(src, dst, info):
     data = data.replace('__VERSION__', info['version'])
     data = data.replace('__CHANNELS__', ','.join(get_final_channels(info)))
     data = data.replace('__WRITE_CONDARC__', '\n'.join(add_condarc(info)))
+    keep_pkgs = '' if info.get('keep_pkgs', False) else 'rm -rf "$PREFIX/pkgs"'
+    data = data.replace('__KEEP_PKGS__', keep_pkgs)
 
     with open(dst, 'w') as fo:
         fo.write(data)
@@ -216,6 +218,7 @@ def create(info, verbose=False):
 
     pkgbuild('preconda')
 
+    keep_pkgs = info.get('keep_pkgs', False)
     for dist in info['_dists']:
         if isinstance(dist, str if version_info[0] >= 3 else basestring):
            fn = dist
@@ -230,6 +233,8 @@ def create(info, verbose=False):
             ndist = dist.name
         fresh_dir(PACKAGE_ROOT)
         cph_e(join(CACHE_DIR, fn), join(pkgs_dir, dname))
+        if keep_pkgs:
+            shutil.copy(join(CACHE_DIR, fn), join(pkgs_dir, fn))
         pkgbuild(ndist)
 
     fresh_dir(PACKAGE_ROOT)

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -32,7 +32,7 @@ def get_header(conda_exec, tarball, info):
 
     has_license = bool('license_file' in info)
     ppd = ns_platform(info['_platform'])
-    ppd['keep_pkgs'] = bool(info.get('keep_pkgs'))
+    ppd['keep_pkgs'] = bool(info.get('keep_pkgs', False))
     ppd['attempt_hardlinks'] = bool(info.get('attempt_hardlinks'))
     ppd['has_license'] = has_license
     for key in 'pre_install', 'post_install', 'pre_uninstall':

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -95,6 +95,7 @@ def make_nsi(info, dir_path):
         'ARCH': '%d-bit' % arch,
         'PY_VER': py_version[:3],
         'PYVERSION': py_version,
+        'PYVERSION_MAJOR': py_version.split('.')[0],
         'PYVERSION_JUSTDIGITS': ''.join(py_version.split('.')),
         'OUTFILE': info['_outpath'],
         'LICENSEFILE': abspath(info.get('license_file',
@@ -126,6 +127,8 @@ def make_nsi(info, dir_path):
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
     ppd['register_python_default'] = info.get('register_python_default', None)
     ppd['check_path_length'] = info.get('check_path_length', None)
+    ppd['keep_pkgs'] = info.get('keep_pkgs') or False
+    ppd['post_install_exists'] = bool(info.get('post_install'))
     data = preprocess(data, ppd)
     data = fill_template(data, replace)
 
@@ -142,7 +145,6 @@ def make_nsi(info, dir_path):
         ('@NAME@', name),
         ('@NSIS_DIR@', NSIS_DIR),
         ('@BITS@', str(arch)),
-        ('@KEEP_PKGS@', '1' if info.get('keep_pkgs', False) else '0'),
         ('@PKG_COMMANDS@', '\n    '.join(cmds)),
         ('@WRITE_CONDARC@', '\n    '.join(add_condarc(info))),
         ('@MENU_PKGS@', ' '.join(info.get('menu_packages', []))),


### PR DESCRIPTION
I've added a `-k` option to the shell script header that instructs the installer not to remove the package cache contents after the installation. I'm using this to implement an automated workflow to build multiple environment formats from a single constructor specification, and due to `channels_remap` renaming it is important to use the cache provided by the installer itself, not the package cache used to build the installer in the first place.