### PR TITLE
Add conda_channel_alias

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -141,6 +141,13 @@ in this list will be included as the value of the `default_channels:`
 option in the environment's `.condarc` file. This will have an impact
 only if `conda` is included in the environmnent.
 
+## `conda_channel_alias`
+
+_required:_ no<br/>
+_type:_ string<br/>
+The channel alias that would be assumed for the created installer
+(only useful if it includes conda).
+
 ## `installer_filename`
 
 _required:_ no<br/>

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -117,6 +117,10 @@ in this list will be included as the value of the `default_channels:`
 option in the environment's `.condarc` file. This will have an impact
 only if `conda` is included in the environmnent.
 '''),
+    ('conda_channel_alias', False, str, '''
+The channel alias that would be assumed for the created installer
+(only useful if it includes conda).
+'''),
 
     ('installer_filename',     False, str, '''
 The filename of the installer being created. If not supplied, a reasonable

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -84,12 +84,13 @@ def preprocess(data, namespace):
 def add_condarc(info):
     if info.get('write_condarc'):
         default_channels = info.get('conda_default_channels')
+        channel_alias = info.get('conda_channel_alias')
         channels = info.get('channels')
         if sys.platform == 'win32':
-            if default_channels or channels:
+            if default_channels or channels or channel_alias:
                 yield '# ----- add condarc'
                 yield 'Var /Global CONDARC'
-                yield 'FileOpen $CONDARC "$INSTDIR\.condarc" w'
+                yield 'FileOpen $CONDARC "$INSTDIR\\.condarc" w'
                 if default_channels:
                     yield 'FileWrite $CONDARC "default_channels:$\\r$\\n"'
                     for url in default_channels:
@@ -98,9 +99,11 @@ def add_condarc(info):
                     yield 'FileWrite $CONDARC "channels:$\\r$\\n"'
                     for url in channels:
                         yield 'FileWrite $CONDARC "  - %s$\\r$\\n"' % url
+                if channel_alias:
+                    yield 'FileWrite $CONDARC "channel_alias: %s$\\r$\\n"' % channel_alias
                 yield 'FileClose $CONDARC'
         else:
-            if default_channels or channels:
+            if default_channels or channels or channel_alias:
                 yield '# ----- add condarc'
                 yield 'cat <<EOF >$PREFIX/.condarc'
                 if default_channels:
@@ -111,6 +114,8 @@ def add_condarc(info):
                     yield 'channels:'
                     for url in channels:
                         yield '  - %s' % url
+                if channel_alias:
+                    yield 'channel_alias: %s' % channel_alias
                 yield 'EOF'
     else:
         yield ''


### PR DESCRIPTION
With this PR, if `write_condarc` is true, then a `channel_alias:` entry will be created in `$PREFIX/.condarc` and its value will be set to `conda_channel_alias`. Combined with `conda_default_channels`, this allows the constructor to produce an installer preconfigured to point to a specific repository and/or a specific set of channels for `defaults`.