### PR TITLE
Add multiple installer support

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -245,10 +245,11 @@ and a `.bat` file for Windows.
 
 _required:_ no<br/>
 _type:_ string<br/>
-Short description of the "post_install" script to be displayed as label of
-the "Do not run post install script" checkbox in the windows installer.
-If used and not an empty string, the "Do not run post install script"
-checkbox will be displayed with this label.
+A description of the purpose of the supplied post_install script. If this
+string is supplied and non-empty, then the Windows and macOS GUI installers
+will display it along with checkbox to enable or disable the execution of the
+script. If this string is not supplied, it is assumed that the script
+is compulsory and the option to disable it will not be offered.
 
 ## `pre_uninstall`
 
@@ -304,9 +305,9 @@ If `header_image` is not provided, use this text when generating the image
 
 _required:_ no<br/>
 _type:_ boolean<br/>
-Default choice for whether to add the installation to the PATH environment
-variable. The user is still able to change this during interactive
-installation.
+Whether to add the installation to the PATH environment variable. The default
+is true for GUI installers (msi, pkg) and False for shell installers. The user
+is able to change the default during interactive installation.
 
 ## `register_python_default`
 
@@ -315,6 +316,26 @@ _type:_ boolean<br/>
 Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
 interactive installation. (Windows only)
+
+## `installers`
+
+_required:_ no<br/>
+_type:_ dictionary<br/>
+When supplied, `installers` is a dictionary of dictionaries that allows a single
+`construct.yaml` file to describe multiple installers. In this mode, the top-level
+options provide a set of "parent" specifications which are merged which each
+child dictionary in a simple fashion to yield a complete installer specification.
+The merging approach is as follows:
+- For _string_ options, the "parent" spec provides a simple default. If a
+  child spec includes the same key, its value overrides the parent.
+- For _list_ options, the "parent" and "child" lists are _concatenated_ for the
+  final spec. This allows, for instance, the parent to specify a set of
+  base packages to include in all installers.
+- For _dictionary_ options, the "parent" and "child" dictionaries are combined,
+  with any intersecting keys resolved in favor of the child.
+
+In this mode, the name of each installer is given by the dictionary keys in the
+`installers` option, and the `name` field must not be explicitly supplied.
 
 ## `check_path_length`
 

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -11,7 +11,9 @@ from os.path import abspath, basename, expanduser, isdir, isfile, join
 import sys
 
 from .conda_interface import cc_platform
-from .construct import parse as construct_parse, verify as construct_verify
+from .construct import (parse as construct_parse,
+                        verify as construct_verify,
+                        split as construct_split)
 from .fcp import main as fcp_main
 from .install import yield_lines
 from .utils import normalize_path
@@ -75,6 +77,11 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     info['_platform'] = platform
     info['_download_dir'] = join(cache_dir, platform)
     info['_conda_exe'] = abspath(conda_exe)
+    for info in construct_split(info):
+        build_single(info, dir_path, output_dir, verbose, dry_run, conda_exe)
+
+
+def build_single(info, dir_path, output_dir, verbose, dry_run, conda_exe):
     set_installer_type(info)
 
     if info['installer_type'] == 'sh':


### PR DESCRIPTION
This PR creates a new entry in `construct.yaml` called `installers`. When supplied, it supports the creation of multiple installers in a single `constructor` call. This is useful if you have multiple installers to build that have a lot of common configuration options that you _intend_ to build at the same time.

The `installers` entry is a dictionary. The keys of this dictionary will typically provide the `name` value for each installer, while the dictionary value is a dictionary that is a (possibly partial) standard constructor specification. If this child specification supplies a `name` value, then the dictionary key is ignored.

The top-level key/value pairs in the `construct.yaml` are then used to provide global default values, and a simple one-level merge strategy is employed:

- For string values, a child value, if present, overrides the default presented in the parent spec.
- For list values, the parent values _prepend_ the values in the child spec. For instance, you can define a global set of packages in `specs`, and then augment them in each child; e.g.
  ```
  merged_value = (parent_value or []) + (child_value or [])
  ```
- For dictionary values, each key/value pair in the parent value serves as a default for the child. That is:
  ```
   merged_value = (parent_value or {}).copy()
   merged_value.update(child_value or {})
   ```

I modified the PR code in a slightly less elegant fashion that I would prefer to emphasize how little had to change there to make this work.