### PR TITLE
Support full condarc customization

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -199,8 +199,18 @@ the files kept in the `pkgs` directory and then patched accordingly.
 
 _required:_ no<br/>
 _type:_ boolean<br/>
-By default, no .condarc file is written. If set, a .condarc file is written to
+By default, no `.condarc` file is written. If set, a `.condarc` file is written to
 the base environment if there are any channels or conda_default_channels is set.
+
+## `condarc`
+
+_required:_ no<br/>
+_types:_ dictionary, string<br/>
+If set, a `.condarc` file is written to the base environment containing the contents
+of this value. The value can either be a string (likely a multi-line string) or
+a dictionary, which will be converted to a YAML string for writing. _Note:_ if this
+option is used, then all other options related to the construction of a `.condarc`
+file&mdash;`write_condarc`, `conda_default_channels`, etc.&mdash;are ignored.
 
 ## `company`
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -8,11 +8,7 @@ from functools import partial
 from os.path import abspath, dirname
 import re
 import sys
-
-try:
-    import yaml
-except:
-    import ruamel_yaml as yaml
+from .utils import yaml
 
 from constructor.exceptions import (
     UnableToParse, UnableToParseMissingJinja2, YamlParsingError,
@@ -158,8 +154,16 @@ the files kept in the `pkgs` directory and then patched accordingly.
 '''),
 
     ('write_condarc',          False, bool, '''
-By default, no .condarc file is written. If set, a .condarc file is written to
+By default, no `.condarc` file is written. If set, a `.condarc` file is written to
 the base environment if there are any channels or conda_default_channels is set.
+'''),
+
+    ('condarc',          False, (dict, str), '''
+If set, a `.condarc` file is written to the base environment containing the contents
+of this value. The value can either be a string (likely a multi-line string) or
+a dictionary, which will be converted to a YAML string for writing. _Note:_ if this
+option is used, then all other options related to the construction of a `.condarc`
+file&mdash;`write_condarc`, `conda_default_channels`, etc.&mdash;are ignored.
 '''),
 
     ('company',                False, str, '''


### PR DESCRIPTION
This PR creates a new option `condarc` that allows an arbitrary `condarc` to be included within `construct.yaml` itself. This replaces the use of options like `conda_default_channels` and `write_condarc`.

The `condarc` value can be a string or a dictionary. If the latter, it is converted to YAML.  For instance:
```
name: Miniconda
version: 2020.07.31
channels:
  - defaults
specs:
  - conda
  - python=3.7
condarc:
  channel_alias: https://repo.example.com
  default_channels:
    - main
    - r
```
