### PR TITLE
Offer warnings for obsolete options

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -106,10 +106,10 @@ files in them. Enable this option to warn instead and continue.
 ## `install_in_dependency_order`
 
 _required:_ no<br/>
-_type:_ boolean<br/>
-By default, the conda packages included in the created installer are installed
-in alphabetical order, with the exception of Python itself, which is installed
-first. Using this option, packages are installed in dependency order.
+_types:_ boolean, string<br/>
+_Obsolete_. The current version of constructor relies on the standalone
+conda executable for its installation behavior. This option is now
+ignored with a warning.
 
 ## `environment`
 
@@ -197,11 +197,10 @@ in one of your accessible keychains.
 ## `attempt_hardlinks`
 
 _required:_ no<br/>
-_type:_ boolean<br/>
-By default, conda packages are extracted into the root environment and then
-patched. Enabling this option will result into extraction of the packages into
-the `pkgs` directory and the files in the root environment will be hardlinks to
-the files kept in the `pkgs` directory and then patched accordingly.
+_types:_ boolean, string<br/>
+_Obsolete_. The current version of constructor relies on the standalone
+conda executable for its installation behavior. This option is now
+ignored with a warning.
 
 ## `write_condarc`
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -8,7 +8,6 @@ from functools import partial
 from os.path import dirname
 import re
 import sys
-import warnings
 from .utils import yaml
 
 from constructor.exceptions import (UnableToParse, UnableToParseMissingJinja2,

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -85,8 +85,9 @@ files in them. Enable this option to warn instead and continue.
 '''),
 
     ('install_in_dependency_order', False, (bool, str), '''
-_Obsolete_. The current version of constructor rely entirely on conda's default
-installation behavior. This option is now ignored with a warning.
+_Obsolete_. The current version of constructor relies on the standalone
+conda executable for its installation behavior. This option is now
+ignored with a warning.
 '''),
 
     ('environment', False, str, '''
@@ -154,8 +155,9 @@ in one of your accessible keychains.
 '''),
 
     ('attempt_hardlinks',          False, (bool, str), '''
-_Obsolete_. The current version of constructor relies entirely on conda for its
-installation behavior. This option is now ignored with a warning.
+_Obsolete_. The current version of constructor relies on the standalone
+conda executable for its installation behavior. This option is now
+ignored with a warning.
 '''),
 
     ('write_condarc',          False, bool, '''

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -222,9 +222,8 @@ def _precs_from_environment(environment, download_dir, user_conda):
 
 
 def _main(name, version, download_dir, platform, channel_urls=(), channels_remap=(), specs=(),
-          exclude=(), menu_packages=(), install_in_dependency_order=True,
-          ignore_duplicate_files=False, environment=None, environment_file=None,
-          verbose=True, dry_run=False, conda_exe="conda.exe"):
+          exclude=(), menu_packages=(),  ignore_duplicate_files=False, environment=None, 
+          environment_file=None, verbose=True, dry_run=False, conda_exe="conda.exe"):
     # Add python to specs, since all installers need a python interpreter. In the future we'll
     # probably want to add conda too.
     specs = list(concatv(specs, ("python",)))
@@ -263,9 +262,6 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
             specs_to_add=specs,
         )
         precs = list(solver.solve_final_state())
-
-    if not install_in_dependency_order:
-        precs = sorted(precs, key="name")
 
     # move python first
     python_prec = next(prec for prec in precs if prec.name == "python")
@@ -314,7 +310,6 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
     specs = info.get("specs", ())
     exclude = info.get("exclude", ())
     menu_packages = info.get("menu_packages", ())
-    install_in_dependency_order = info.get("install_in_dependency_order", True)
     ignore_duplicate_files = info.get("ignore_duplicate_files", False)
     environment = info.get("environment", None)
     environment_file = info.get("environment_file", None)
@@ -327,9 +322,8 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
     }, conda_replace_context_default):
         _urls, dists, approx_tarballs_size, approx_pkgs_size = _main(
             name, version, download_dir, platform, channel_urls, channels_remap, specs,
-            exclude, menu_packages, install_in_dependency_order,
-            ignore_duplicate_files, environment, environment_file, verbose,
-            dry_run, conda_exe,
+            exclude, menu_packages, ignore_duplicate_files, environment, environment_file,
+            verbose, dry_run, conda_exe,
         )
 
     info["_urls"] = _urls

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -222,7 +222,7 @@ def _precs_from_environment(environment, download_dir, user_conda):
 
 
 def _main(name, version, download_dir, platform, channel_urls=(), channels_remap=(), specs=(),
-          exclude=(), menu_packages=(),  ignore_duplicate_files=False, environment=None, 
+          exclude=(), menu_packages=(),  ignore_duplicate_files=False, environment=None,
           environment_file=None, verbose=True, dry_run=False, conda_exe="conda.exe"):
     # Add python to specs, since all installers need a python interpreter. In the future we'll
     # probably want to add conda too.

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -33,7 +33,6 @@ def get_header(conda_exec, tarball, info):
     has_license = bool('license_file' in info)
     ppd = ns_platform(info['_platform'])
     ppd['keep_pkgs'] = bool(info.get('keep_pkgs', False))
-    ppd['attempt_hardlinks'] = bool(info.get('attempt_hardlinks'))
     ppd['has_license'] = has_license
     for key in 'pre_install', 'post_install', 'pre_uninstall':
         ppd['has_%s' % key] = bool(key in info)

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -38,7 +38,7 @@ def read_nsi_tmpl():
         return fi.read()
 
 
-def pkg_commands(download_dir, dists, py_version, attempt_hardlinks, channels):
+def pkg_commands(download_dir, dists, py_version, channels):
     for n, dist in enumerate(dists):
         fn = filename_dist(dist)
         yield ''
@@ -133,7 +133,6 @@ def make_nsi(info, dir_path):
     data = fill_template(data, replace)
 
     cmds = pkg_commands(download_dir, dists, py_version,
-                        bool(info.get('attempt_hardlinks')),
                         get_final_channels(info))
 
     # division by 10^3 instead of 2^10 is deliberate here. gives us more room


### PR DESCRIPTION
Fixes #275 

Offers warnings if `install_in_dependency_order` or `attempt_hardlinks` is used.