### PR TITLE
Firm up cross-platform messaging

### DIFF
--- a/constructor/main.py
+++ b/constructor/main.py
@@ -40,9 +40,9 @@ def get_installer_type(info):
                  (itype, osname, os_allowed))
     else:
         result = itype,
-    if 'pkg' in result and cc_platform != 'osx':
+    if 'pkg' in result and not cc_platform.startswith('osx-'):
         sys.exit("Error: cannot construct an macOS 'pkg' installer on '%s'" % cc_platform)
-    if 'exe' in result and cc_platform != 'win':
+    if 'exe' in result and not cc_platform.startswith('win-'):
         sys.exit("Error: cannot construct a Windows 'exe' installer on '%s'" % cc_platform)
     return result
 
@@ -225,11 +225,14 @@ def main():
     conda_exe_default_path = join(sys.prefix, "standalone_conda", "conda.exe")
     conda_exe_default_path = normalize_path(abspath(conda_exe_default_path))
     conda_exe = normalize_path(abspath(args.conda_exe)) if args.conda_exe else conda_exe_default_path
-    if args.platform and args.platform != cc_platform and conda_exe == conda_exe_default_path:
-        sys.exit("Error: In order to build a '%s' constructor on '%s', the default "
-                 "conda executable cannot be used. Instead, the --conda-exe option "
-                 "must be supplied with the path to a '%s'-compatible standalone "
-                 "conda executable." % (args.platform, cc_platform, args.platform))
+    if args.platform and args.platform != cc_platform:
+        if args.platform.startswith('win-'):
+            sys.exit("Error: cannot construct a '%s' installer on '%s'" % (args.platform, cc_platform))
+        if conda_exe == conda_exe_default_path:
+            sys.exit("Error: In order to build a '%s' constructor on '%s', the default "
+                     "conda executable cannot be used. Instead, the --conda-exe option "
+                     "must be supplied with the path to a '%s'-compatible standalone "
+                     "conda executable." % (args.platform, cc_platform, args.platform))
     if not os.path.isfile(conda_exe):
         if conda_exe == conda_exe_default_path:
             sys.exit("Error: A standalone conda executable for this platform could not "

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -28,9 +28,9 @@ def get_installer_type(info):
 
     itype = info.get('installer_type')
     if not itype:
-        return os_allowed[osname][:1]
+        result = os_allowed[osname][:1]
     elif itype == 'all':
-        return os_allowed[osname]
+        result = os_allowed[osname]
     elif itype not in all_allowed:
         all_allowed = ', '.join(sorted(all_allowed))
         sys.exit("Error: invalid installer type '%s'; allowed: %s" % (itype, all_allowed))
@@ -39,7 +39,12 @@ def get_installer_type(info):
         sys.exit("Error: invalid installer type '%s' for %s; allowed: %s" %
                  (itype, osname, os_allowed))
     else:
-        return itype,
+        result = itype,
+    if 'pkg' in result and cc_platform != 'osx':
+        sys.exit("Error: cannot construct an macOS 'pkg' installer on '%s'" % cc_platform)
+    if 'exe' in result and cc_platform != 'win':
+        sys.exit("Error: cannot construct a Windows 'exe' installer on '%s'" % cc_platform)
+    return result
 
 
 def get_output_filename(info):


### PR DESCRIPTION
The `--platform` option has needed some love:
- It's possible to build a `.sh` installer on any platform as long as the proper platform-specific conda.exe is used.
- It's not possible to build a `.pkg` or `.exe` installer on non-native platforms.

Fixes #366