### PR TITLE
Move more into the nsis template for easier reading

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -861,7 +861,24 @@ Section "Install"
     File /nonfatal /r __INDEX_CACHE__
     File /r __REPODATA_RECORD__
 
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_CHANNELS", __CHANNELS__).r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PKGS_DIRS", "$INSTDIR\pkgs")".r0'
+
     @PKG_COMMANDS@
+
+    SetDetailsPrint TextOnly
+    DetailPrint "Settting up the package cache ..."
+    nsExec::ExecToLog '"$INSTDIR\_conda.exe" constructor --prefix "$INSTDIR" --extract-conda-pkgs'
+    Pop $0
+    SetDetailsPrint both
+
+    SetDetailsPrint TextOnly
+    DetailPrint "Setting up the base environment ..."
+    nsExec::ExecToLog '"$INSTDIR\_conda.exe" install --offline -yp "$INSTDIR" --file "$INSTDIR\pkgs\env.txt"'
+    Pop $0
+    SetDetailsPrint both
 
     # Cleanup
     SetOutPath "$INSTDIR"
@@ -980,5 +997,4 @@ Section "Uninstall"
     ${If} $0 == "$INSTDIR"
         DeleteRegKey SHCTX "Software\Python\PythonCore\${PY_VER}"
     ${EndIf}
-
 SectionEnd


### PR DESCRIPTION
Did some cleanup of winexe.py and the main NSIS template for better understanding, reading, an improvement.

In particular:
- Moved NSIS code out of `yield` statements in `winexe.py` that really doesn't need to be there. It helped to be able to define a new `__CHANNELS__` replacement variable
- Cleaned up the replacement key/value code a bit: rearranged them so they are in the same order as they appear in nsis.tmpl for easier tracking