### PR TITLE
Only init and create envs if conda is installed in the prefix

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -450,6 +450,12 @@ fi
 
 __INSTALL_COMMANDS__
 
+if [ -f "$PREFIX/bin/conda" ]; then
+    HAS_CONDA_IN_INSTALL=1
+else
+    HAS_CONDA_IN_INSTALL=0
+fi
+
 POSTCONDA="$PREFIX/postconda.tar.bz2"
 "$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-tarball < "$POSTCONDA" || exit 1
 rm -f "$POSTCONDA"
@@ -460,7 +466,9 @@ rm -f $PREFIX/pkgs/env.txt
 rm -rf $PREFIX/install_tmp
 export TMP="$TMP_BACKUP"
 
-mkdir -p $PREFIX/envs
+if [ "$HAS_CONDA_IN_INSTALL" = "1"]; then
+    mkdir -p $PREFIX/envs
+fi
 
 #The templating doesn't support nested if statements
 #if has_post_install
@@ -504,7 +512,7 @@ if [ "$PYTHONPATH" != "" ]; then
     printf "    in __NAME__: $PREFIX\\n"
 fi
 
-if [ "$BATCH" = "0" ]; then
+if [ "$BATCH" = "0" && "$HAS_CONDA_IN_INSTALL" = "1" ]; then
     # Interactive mode.
 #if osx
     BASH_RC="$HOME"/.bash_profile

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -466,7 +466,7 @@ rm -f $PREFIX/pkgs/env.txt
 rm -rf $PREFIX/install_tmp
 export TMP="$TMP_BACKUP"
 
-if [ "$HAS_CONDA_IN_INSTALL" = "1"]; then
+if [ "$HAS_CONDA_IN_INSTALL" = "1" ]; then
     mkdir -p $PREFIX/envs
 fi
 
@@ -512,7 +512,7 @@ if [ "$PYTHONPATH" != "" ]; then
     printf "    in __NAME__: $PREFIX\\n"
 fi
 
-if [ "$BATCH" = "0" && "$HAS_CONDA_IN_INSTALL" = "1" ]; then
+if [ "$BATCH" = "0" ] && [ "$HAS_CONDA_IN_INSTALL" = "1" ]; then
     # Interactive mode.
 #if osx
     BASH_RC="$HOME"/.bash_profile


### PR DESCRIPTION
It is useful not to have init be a question during the install procedure if you aren't really installing conda, but other software as the main software.