### PR TITLE
WIP: Isolate from .condarc for more stable results

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -462,17 +462,21 @@ MSGS="$PREFIX/.messages.txt"
 touch "$MSGS"
 export FORCE
 
-# original issue report:
-# https://github.com/ContinuumIO/anaconda-issues/issues/11148
-# First try to fix it (this apparently didn't work; QA reported the issue again)
-# https://github.com/conda/conda/pull/9073
-mkdir -p ~/.conda > /dev/null 2>&1
+# See https://github.com/conda/constructor/issues/302
+FAKE_HOME="$PREFIX/pkgs/.fake"
+mkdir -p "$FAKE_HOME/.conda" $HOME/.conda 2>/dev/null
+cp -p $HOME/.conda/environments.txt $FAKE_HOME/.conda/environments.txt 2>/dev/null
 
+HOME="$FAKE_HOME" \
+CONDA_PREFIX="$FAKE_HOME" \
 CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=__CHANNELS__ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
 "$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" || exit 1
+
+cp -p $FAKE_HOME/.conda/environments.txt $HOME/.conda/environments.txt 2>/dev/null
+rm -rf $FAKE_HOME
 
 if [ "$KEEP_PKGS" = "0" ]; then
     rm -fr $PREFIX/pkgs/*.tar.bz2

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -59,6 +59,7 @@ var /global IsDomainUser
 var /global CheckPathLength
 var /global LongPathsEnabled
 var /global InstDirLen
+var /global FakeHome
 
 var /global InstModePage_RadioButton_JustMe
 var /global InstModePage_RadioButton_AllUsers
@@ -862,10 +863,11 @@ Section "Install"
     File /r __REPODATA_RECORD__
 
     # See https://github.com/conda/constructor/issues/302
-    CreateDirectory "$INSTDIR\pkgs\.fake\.conda"
-    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PREFIX", "$INSTDIR\pkgs\.fake").r0'
-    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$INSTDIR\pkgs\.fake").r0'
-    CopyFiles /silent /filesonly "$PROFILE\.conda\environments.txt" "$INSTDIR\pkgs\.fake\.conda"
+    StrCpy $FakeHome "$INSTDIR\pkgs\.fake"
+    CreateDirectory "$FakeHome\.conda"
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PREFIX", "$FakeHome").r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$FakeHome").r0'
+    CopyFiles /silent /filesonly "$PROFILE\.conda\environments.txt" "$FakeHome\.conda"
 
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'
@@ -888,12 +890,12 @@ Section "Install"
 
     # See https://github.com/conda/constructor/issues/302
     CreateDirectory "$PROFILE\.conda"
-    CopyFiles /silent /filesonly "$INSTDIR\pkgs\.fake\.conda\environments.txt" "$PROFILE\.conda"
+    CopyFiles /silent /filesonly "$FakeHome\.conda\environments.txt" "$PROFILE\.conda"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$PROFILE")".r0'
+    RMDir /r "$FakeHome"
 
     # Cleanup
     SetOutPath "$INSTDIR"
-    RMDir /r "$INSTDIR\pkgs\.fake"
     Delete "$INSTDIR\pkgs\env.txt"
 
     @WRITE_CONDARC@

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -861,6 +861,16 @@ Section "Install"
     File /nonfatal /r __INDEX_CACHE__
     File /r __REPODATA_RECORD__
 
+    # Create and stage a fake home directory. This enables us to isolate conda from existing
+    # settings that might disrupt the expected operation of the installer. The one wrinkle in
+    # this strategy is that it also interrupts the modificaton of ~/.conda/environments.txt.
+    # So we copy the existing value into our fake home directory, let conda modify it, and
+    # then copy it back.
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PREFIX", "$INSTDIR\pkgs\.fake").r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$INSTDIR\pkgs\.fake").r0'
+    CreateDirectory "$INSTDIR\pkgs\.fake\.conda"
+    CopyFiles /silent /filesonly "$PROFILE\.conda\environments.txt" "$INSTDIR\pkgs\.fake\.conda"
+
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_CHANNELS", __CHANNELS__).r0'
@@ -880,8 +890,14 @@ Section "Install"
     Pop $0
     SetDetailsPrint both
 
+    # Copy the modified environments.txt file into place
+    CreateDirectory "$PROFILE\.conda"
+    CopyFiles /silent /filesonly "$INSTDIR\pkgs\.fake\.conda\environments.txt" "$PROFILE\.conda"
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$PROFILE")".r0'
+
     # Cleanup
     SetOutPath "$INSTDIR"
+    RMDir /r "$INSTDIR\pkgs\.fake"
     Delete "$INSTDIR\pkgs\env.txt"
 
     @WRITE_CONDARC@

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -861,14 +861,10 @@ Section "Install"
     File /nonfatal /r __INDEX_CACHE__
     File /r __REPODATA_RECORD__
 
-    # Create and stage a fake home directory. This enables us to isolate conda from existing
-    # settings that might disrupt the expected operation of the installer. The one wrinkle in
-    # this strategy is that it also interrupts the modificaton of ~/.conda/environments.txt.
-    # So we copy the existing value into our fake home directory, let conda modify it, and
-    # then copy it back.
+    # See https://github.com/conda/constructor/issues/302
+    CreateDirectory "$INSTDIR\pkgs\.fake\.conda"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PREFIX", "$INSTDIR\pkgs\.fake").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$INSTDIR\pkgs\.fake").r0'
-    CreateDirectory "$INSTDIR\pkgs\.fake\.conda"
     CopyFiles /silent /filesonly "$PROFILE\.conda\environments.txt" "$INSTDIR\pkgs\.fake\.conda"
 
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
@@ -890,7 +886,7 @@ Section "Install"
     Pop $0
     SetDetailsPrint both
 
-    # Copy the modified environments.txt file into place
+    # See https://github.com/conda/constructor/issues/302
     CreateDirectory "$PROFILE\.conda"
     CopyFiles /silent /filesonly "$INSTDIR\pkgs\.fake\.conda\environments.txt" "$PROFILE\.conda"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("USERPROFILE", "$PROFILE")".r0'

--- a/constructor/osx/post_extract.sh
+++ b/constructor/osx/post_extract.sh
@@ -18,22 +18,23 @@ touch $PREFIX/conda-meta/history
 
 # Extract the conda packages but avoiding the overwriting of the
 # custom metadata we have already put in place
-"$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs
-if (( $? )); then
-    echo "ERROR: could not extract the conda packages"
-    exit 1
-fi
+"$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs || exit 1
 
-# Perform the conda install
+# See https://github.com/conda/constructor/issues/302
+FAKE_HOME="$PREFIX/pkgs/.fake"
+mkdir -p "$FAKE_HOME/.conda" $HOME/.conda 2>/dev/null
+cp -p $HOME/.conda/environments.txt $FAKE_HOME/.conda/environments.txt 2>/dev/null
+
+HOME="$FAKE_HOME" \
+CONDA_PREFIX="$FAKE_HOME" \
 CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=__CHANNELS__ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
 "$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" || exit 1
-if (( $? )); then
-    echo "ERROR: could not complete the conda install"
-    exit 1
-fi
+
+cp -p $FAKE_HOME/.conda/environments.txt $HOME/.conda/environments.txt 2>/dev/null
+rm -rf $FAKE_HOME
 
 # Move the prepackaged history file into place
 mv "$PREFIX/pkgs/conda-meta/history" "$PREFIX/conda-meta/history"
@@ -45,16 +46,8 @@ find "$PREFIX/pkgs" -type d -empty -exec rmdir {} \; 2>/dev/null || :
 
 __WRITE_CONDARC__
 
-"$PREFIX/bin/python" -V
-if (( $? )); then
-    echo "ERROR running Python"
-    exit 1
-fi
+"$PREFIX/bin/python" -V || exit 1
 
 # This is unneeded for the default install to ~, but if the user changes the
 # install location, the permissions will default to root unless this is done.
 chown -R $USER "$PREFIX"
-
-echo "installation finished."
-
-exit 0


### PR DESCRIPTION
Fixes #302 (hopefully).

The embedded conda executable inside constructor can be influenced by `~/.condarc`, `$CONDA_PREFIX/.condarc`, etc. But this is not desirable. For example, it has been reported that some settings can actually cause conda to fail.

For additional "protection" we could actually populate this fake home directory with a `.condarc` containing all default values. 