### PR TITLE
Removed deprecated platform.dist()

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - conda-standalone
     - pillow >=3.1     # [win]
     - nsis >=3.01      # [win]
+    - distro
 
 test:
   source_files:

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -4,6 +4,7 @@
 # constructor is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
+import distro
 import os
 from os.path import isdir, join, split as path_split
 import platform
@@ -77,8 +78,7 @@ def system_info():
     if sys.platform == 'darwin':
         out['extra'] = platform.mac_ver()
     elif sys.platform.startswith('linux') and hasattr(platform, 'dist'):
-        # dist() was deprtecated in Python 3.5 and removed in 3.8
-        out['extra'] = platform.dist()
+        out['extra'] = distro.linux_distribution(full_distribution_name=False)
     elif sys.platform.startswith('win'):
         out['extra'] = platform.win32_ver()
         prefix = default_prefix

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
         "conda >=4.6",
         "ruamel_yaml",
         "pillow >=3.1 ; platform_system=='Windows'",
+        "distro",
         # non-python dependency: "nsis >=3.01 ; platform_system=='Windows'",
     ],
     # We could differentiate between operating systems here but that is


### PR DESCRIPTION
Since platform.dist() is deprecated, I have removed that from the code.
It was tested under centos7 and looks fine.

I  am not confident with the dependency part, though.
Any comment is appreciated.
