### PR TITLE
Update CONSTRUCT.md

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -333,18 +333,18 @@ or enable long path on windows > 10 (require admin right). Default is True. (Win
 
 ## Available selectors
 
-- `aarch64`
-- `arm64`
+- `arch-64`
+- `arm-64`
 - `armv7l`
 - `linux`
-- `linux32`
-- `linux64`
-- `osx`
+- `linux-32`
+- `linux-64`
+- `osx-64`
 - `ppc64le`
 - `s390x`
 - `unix`
 - `win`
-- `win32`
-- `win64`
+- `win-32`
+- `win-64`
 - `x86`
 - `x86_64`


### PR DESCRIPTION
I believe there were some typos here, because if I use `win64` instead of `win-64` for example I get `Error: invalid platform string 'win64'` but when I use `win-64` it works.