### PR TITLE
Add current shell env to jinja2 globals

### DIFF
--- a/constructor/jinja.py
+++ b/constructor/jinja.py
@@ -27,6 +27,7 @@ class FilteredLoader(BaseLoader):
 def render_jinja(data, directory, content_filter):
     loader = FilteredLoader(FileSystemLoader(directory), content_filter)
     env = Environment(loader=loader)
+    env.globals['environ'] = os.environ.copy()
     env.globals['os'] = os
     try:
         template = env.from_string(data)

--- a/docs/source/construct_yaml.rst
+++ b/docs/source/construct_yaml.rst
@@ -13,6 +13,13 @@ which contains one item per line (excluding lines starting with `#`).
 Also note, that any line in `construct.yaml` may contain a selector at the
 end, in order to allow customization for selected platforms.
 
+Finally, `construct.yaml` is parsed as a `jinja2` template and so any valid
+`jinja2` templating directives may be used. The current shell environment
+is available as the `jinja2` variable `environ`. As an example, setting the
+`version` key from an environment variable called `VERSION` would look like:
+`version: {{ environ["VERSION"] }}`. Note that the special environment variables
+available in `meta.yaml` when running `conda-build` are not available here.
+
 
 ----
 Keys


### PR DESCRIPTION
This PR adds the ability to access current environment variables from within `construct.yaml`. The is is accomplished by passing the dict from `os.environ` into the template as a dict called `environ`. Then keys within the yaml file may be set as `key: {{ environ["FOO"] }}`.

This also adds a note to the `construct.yaml` documentation about the change.