### PR TITLE
Fix default install folder domain user

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -279,6 +279,23 @@ _type:_ string<br/>
 Path to a pre uninstall script. This is only supported for on Windows,
 and must be a `.bat` file.
 
+## `default_prefix`
+
+_required:_ no<br/>
+_type:_ string<br/>
+Set default install prefix. On Linux, if not provided, the default prefix is
+`${HOME}/${NAME}`. On windows, if not provided, the default prefix is
+`${USERPROFILE}\${NAME}`.
+
+## `default_prefix_domain_user`
+
+_required:_ no<br/>
+_type:_ string<br/>
+Set default installation prefix for domain user. If not provided, the
+installation prefix for domain user will be `${LOCALAPPDATA}\${NAME}`.
+By default, it is different from the `default_prefix` value to avoid installing
+the distribution in the roaming profile. Windows only.
+
 ## `welcome_image`
 
 _required:_ no<br/>

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -218,7 +218,18 @@ Path to a pre uninstall script. This is only supported for on Windows,
 and must be a `.bat` file.
 '''),
 
-    ('default_prefix',         False, str, 'XXX'),
+    ('default_prefix',         False, str, '''
+Set default install prefix. On Linux, if not provided, the default prefix is
+`${HOME}/${NAME}`. On windows, if not provided, the default prefix is
+`${USERPROFILE}\${NAME}`.
+'''),
+
+    ('default_prefix_domain_user', False, str, '''
+Set default installation prefix for domain user. If not provided, the
+installation prefix for domain user will be `${LOCALAPPDATA}\${NAME}`.
+By default, it is different from the `default_prefix` value to avoid installing
+the distribution in the roaming profile. Windows only.
+'''),
 
     ('welcome_image',          False, str, '''
 Path to an image in any common image format (`.png`, `.jpg`, `.tif`, etc.)

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -30,6 +30,7 @@ Unicode "true"
 !define PYVERSION __PYVERSION__
 !define PYVERSION_MAJOR __PYVERSION_MAJOR__
 !define DEFAULT_PREFIX __DEFAULT_PREFIX__
+!define DEFAULT_PREFIX_DOMAIN_USER __DEFAULT_PREFIX_DOMAIN_USER__
 !define POST_INSTALL_DESC __POST_INSTALL_DESC__
 !define PRODUCT_NAME "${NAME} ${VERSION} (${ARCH})"
 !define UNINSTALL_NAME "@UNINSTALL_NAME@"
@@ -495,7 +496,8 @@ Function .onInit
         ExpandEnvStrings $0 ${DEFAULT_PREFIX}
         StrCpy $INSTDIR_JUSTME $0
     ${ElseIf} $IsDomainUser = 1
-        StrCpy $INSTDIR_JUSTME "$Profile\${NAME}"
+        ExpandEnvStrings $0 ${DEFAULT_PREFIX_DOMAIN_USER}
+        StrCpy $INSTDIR_JUSTME $0
     ${Else}
         # Should never happen; indicates a logic error above.
         MessageBox MB_OK "Internal error: IsUserDomain not set properly!"

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -64,6 +64,8 @@ def make_nsi(info, dir_path):
         'PYVERSION': py_version,
         'PYVERSION_MAJOR': py_version.split('.')[0],
         'DEFAULT_PREFIX': info.get('default_prefix', join('%USERPROFILE%', name.lower())),
+        'DEFAULT_PREFIX_DOMAIN_USER': info.get('default_prefix_domain_user',
+                                               join('%LOCALAPPDATA%', name.lower())),
         'POST_INSTALL_DESC': info['post_install_desc'],
         'OUTFILE': info['_outpath'],
         'VIPV': make_VIProductVersion(info['version']),


### PR DESCRIPTION
As per one of @benpapworth's suggestion in #412: 
- change the default prefix for domain user to %LOCALAPPDATA%
- add an option to set its default value.

Closes #412.