### PR TITLE
Better handling of no conda in Linux constructor

### DIFF
--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -50,6 +50,7 @@ def get_header(conda_exec, tarball, info):
         if key in info:
             ppd['direct_execute_%s' % key] = has_shebang(info[key])
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
+    ppd['has_conda'] = info['_has_conda']
     install_lines = list(add_condarc(info))
     # Needs to happen first -- can be templated
     replace = {


### PR DESCRIPTION
This PR disables the following if there is no conda package in the installer:

 * Entirely removes the shell initialisation if no conda found (currently it is just skipped in an if)
 * Test (require conda-build more specifically)


It also makes a more specific message about batch mode whether there is a license or not (happy to revert this if desired).