### PR TITLE
Provide a way for users to customize the location of the NSIS template file.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+2020-XX-XX   X.X.X: (unreleased)
+--------------------------------
+
+  * NSIS:
+    - Support for custom ``nsis_templates`` through the ``nsis_template``
+      variable.
+
 2020-09-31   3.1.0:
 -------------------
   * COMMON:

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -290,6 +290,12 @@ or enable long path on windows > 10 (require admin right). Default is True. (Win
 Check if the path where the distribution is installed contains spaces and show a warning
 if any spaces are found. Default is True. (Windows only)
 '''),
+    ('nsis_template',           False, str, '''
+
+If ``nsis_template`` is not provided, constructor uses its default
+NSIS template. For more complete customization for the installation experience,
+provide an NSIS template file. (Windows only)
+'''),
 ]
 
 

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -89,7 +89,8 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             info[key] = info['name']
 
     for key in ('license_file', 'welcome_image', 'header_image', 'icon_image',
-                'pre_install', 'post_install', 'pre_uninstall', 'environment_file'):
+                'pre_install', 'post_install', 'pre_uninstall', 'environment_file',
+                'nsis_template'):
         if key in info:
             info[key] = abspath(join(dir_path, info[key]))
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -31,8 +31,8 @@ def str_esc(s):
     return '"%s"' % s
 
 
-def read_nsi_tmpl():
-    path = join(NSIS_DIR, 'main.nsi.tmpl')
+def read_nsi_tmpl(info):
+    path = abspath(info.get('nsis_template', join(NSIS_DIR, 'main.nsi.tmpl')))
     print('Reading: %s' % path)
     with open(path) as fi:
         return fi.read()
@@ -92,7 +92,7 @@ def make_nsi(info, dir_path):
             value = join(dir_path, value[1:])
         replace[key] = str_esc(value)
 
-    data = read_nsi_tmpl()
+    data = read_nsi_tmpl(info)
     ppd = ns_platform(info['_platform'])
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
     ppd['register_python_default'] = info.get('register_python_default', None)

--- a/docs/source/construct_yaml.rst
+++ b/docs/source/construct_yaml.rst
@@ -356,6 +356,17 @@ Default choice for whether to register the installed Python instance as the
 system's default Python. The user is still able to change this during
 interactive installation. (Windows only)
 
+~~~~~~~~~~~~~
+nsis_template
+~~~~~~~~~~~~~
+
+required: False
+
+argument type(s): ``str``,
+
+If ``nsis_template`` is not provided, constructor uses its default
+NSIS template. For more complete customization for the installation experience,
+provide an NSIS template file. (Windows only)
 
 ---------------------------
 List of available selectors


### PR DESCRIPTION
Seems like windows builds are failing no matter what i do:
https://github.com/conda/constructor/pull/424

This seems to be working for me. ~~The challenge is the specified NSIS template is relative to where you run the command, and not to the yaml file like other files are.~~