### PR TITLE
Modify regex that finds platform selectors

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -310,7 +310,7 @@ def ns_platform(platform):
     )
 
 
-sel_pat = re.compile(r'(.+?)\s*\[(.+)\]$')
+sel_pat = re.compile(r'(.+?)\s*# \[(.+)\]$')
 
 
 def select_lines(data, namespace):

--- a/examples/grin/construct.yaml
+++ b/examples/grin/construct.yaml
@@ -11,13 +11,13 @@ channels: &id1
 specs:
   - python
   - grin
-  - sample                            [osx]
+  - sample                           # [osx]
 
 # exclude these packages (list of names)
 exclude:
-  - openssl                           [unix]
-  - readline                          [unix]
-  - tk                                [unix]
+  - openssl                          # [unix]
+  - readline                         # [unix]
+  - tk                               # [unix]
   - python
 
 # explicitly listed packages
@@ -29,9 +29,9 @@ packages:
 
 keep_pkgs: True
 
-pre_install: hello.sh                 [unix]
-post_install: goodbye.sh              [unix]
-post_install: test-post.bat           [win]
+pre_install: hello.sh                # [unix]
+post_install: goodbye.sh             # [unix]
+post_install: test-post.bat          # [win]
 
 # The conda default channels which are used when running a conda which
 # was installed be the constructor created (requires conda in the
@@ -40,7 +40,7 @@ conda_default_channels: *id1
 
 # type of the installer being created.  Possible values are "sh", "pkg",
 # and "exe".  By default, the type is "sh" on Unix, and "exe" on Windows.
-installer_type: pkg                   [osx]
+installer_type: pkg                  # [osx]
 
 # installer filename (a reasonable default filename will determined by
 # the `name`, (optional) `version`, OS and installer type)

--- a/examples/jetsonconda/construct.yaml
+++ b/examples/jetsonconda/construct.yaml
@@ -6,15 +6,15 @@ channels:
 
 specs:
   - python 3.6*
-  - conda  [aarch64]
-  - numpy  [aarch64]
-  - scipy  [aarch64]
-  - pandas [aarch64]
-  - notebook [aarch64]
-  - matplotlib [aarch64]
-  - freetype [aarch64]
+  - conda # [aarch64]
+  - numpy # [aarch64]
+  - scipy # [aarch64]
+  - pandas # [aarch64]
+  - notebook # [aarch64]
+  - matplotlib # [aarch64]
+  - freetype # [aarch64]
 
 #license_file: EULA.txt
 
 # Welcome image for Windows installer
-welcome_image: bird.png                  [win]
+welcome_image: bird.png                 # [win]

--- a/examples/maxiconda/construct.yaml
+++ b/examples/maxiconda/construct.yaml
@@ -9,13 +9,13 @@ channels:
 specs:
   - python 3.5*
   - conda
-  - nomkl                                [not win]
+  - nomkl                               # [not win]
   - numpy
   - scipy
   - pandas
   - notebook
   - matplotlib
-  - lighttpd                             [unix]
+  - lighttpd                            # [unix]
 
 exclude:
   - qt
@@ -25,4 +25,4 @@ exclude:
 license_file: EULA.txt
 
 # Welcome image for Windows installer
-welcome_image: bird.png                  [win]
+welcome_image: bird.png                # [win]

--- a/examples/osxpkg/construct.yaml
+++ b/examples/osxpkg/construct.yaml
@@ -15,5 +15,5 @@ specs:
     - setuptools
     - numpy
 
-post_install: post_install.sh   [unix]
-installer_type: pkg  [osx]
+post_install: post_install.sh  # [unix]
+installer_type: pkg # [osx]


### PR DESCRIPTION
This fixes the regex that grabs platform selectors to _only_ grab them from the comment at the end of the line, rather than grabbing them from anywhere on the line.

Closes #427 