### PR TITLE
New `check_path_spaces` config param

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -372,6 +372,13 @@ Check the length of the path where the distribution is installed to ensure nodej
 can be installed.  Raise a message to request shorter path (less than 46 character)
 or enable long path on windows > 10 (require admin right). Default is True. (Windows only)
 
+## `check_path_spaces`
+
+_required:_ no<br/>
+_type:_ boolean<br/>
+Check if the path where the distribution is installed contains spaces and show a warning
+if any spaces are found. Default is True. (Windows only)
+
 
 ## Available selectors
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -286,6 +286,11 @@ Check the length of the path where the distribution is installed to ensure nodej
 can be installed.  Raise a message to request shorter path (less than 46 character)
 or enable long path on windows > 10 (require admin right). Default is True. (Windows only)
 '''),
+
+    ('check_path_spaces',     False, bool, '''
+Check if the path where the distribution is installed contains spaces and show a warning
+if any spaces are found. Default is True. (Windows only)
+'''),
 ]
 
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -729,6 +729,7 @@ Function OnDirectoryLeave
     Call CheckForSpaces
     Pop $R0 # The function returns the number of spaces found in the input string.
 
+#if check_path_spaces is True
     # Check if any spaces exist in $INSTDIR.
     StrCmp $R0 0 NoSpaces
 
@@ -745,6 +746,7 @@ Function OnDirectoryLeave
              Please consider removing the space$R1."
 
     NoSpaces:
+#endif
 
     # List of characters not allowed anywhere in $INSTDIR
     Push "^%!=,"

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -97,6 +97,7 @@ def make_nsi(info, dir_path):
     ppd['initialize_by_default'] = info.get('initialize_by_default', None)
     ppd['register_python_default'] = info.get('register_python_default', None)
     ppd['check_path_length'] = info.get('check_path_length', None)
+    ppd['check_path_spaces'] = info.get('check_path_spaces', True)
     ppd['keep_pkgs'] = info.get('keep_pkgs') or False
     ppd['post_install_exists'] = bool(info.get('post_install'))
     data = preprocess(data, ppd)


### PR DESCRIPTION
New config parameter to suppress the "Destination Folder contains spaces" warning on Windows.
```
check_path_spaces: False
```
_Parameter name inspired by the `check_path_length` parameter._