### PR TITLE
warn by default when duplicates encountered

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -81,8 +81,8 @@ supplying this list allows a subset to be selected instead.
 '''),
 
     ('ignore_duplicate_files',  False, bool, '''
-By default, constructor will error out when adding packages with duplicate
-files in them. Enable this option to warn instead and continue.
+By default, constructor will warn you when adding packages with duplicate
+files in them. Setting this option to false will raise an error instead.
 '''),
 
     ('install_in_dependency_order', False, (bool, str), '''

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -140,7 +140,7 @@ def _fetch(download_dir, precs):
     return tuple(pc.iter_records())
 
 
-def check_duplicates_files(pc_recs, platform, ignore_duplicate_files=False):
+def check_duplicates_files(pc_recs, platform, ignore_duplicate_files=True):
     print('Checking for duplicate files ...')
 
     map_members_scase = defaultdict(set)
@@ -240,7 +240,7 @@ def _precs_from_environment(environment, download_dir, user_conda):
 
 
 def _main(name, version, download_dir, platform, channel_urls=(), channels_remap=(), specs=(),
-          exclude=(), menu_packages=(),  ignore_duplicate_files=False, environment=None,
+          exclude=(), menu_packages=(),  ignore_duplicate_files=True, environment=None,
           environment_file=None, verbose=True, dry_run=False, conda_exe="conda.exe",
           transmute_file_type=''):
     # Add python to specs, since all installers need a python interpreter. In the future we'll
@@ -362,7 +362,7 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
     specs = info.get("specs", ())
     exclude = info.get("exclude", ())
     menu_packages = info.get("menu_packages", ())
-    ignore_duplicate_files = info.get("ignore_duplicate_files", False)
+    ignore_duplicate_files = info.get("ignore_duplicate_files", True)
     environment = info.get("environment", None)
     environment_file = info.get("environment_file", None)
     transmute_file_type = info.get("transmute_file_type", "")

--- a/examples/grin/construct.yaml
+++ b/examples/grin/construct.yaml
@@ -25,8 +25,6 @@ exclude:
 packages:
   - python-2.7.9-0.tar.bz2
 
-#install_in_dependency_order: True
-
 keep_pkgs: True
 
 pre_install: hello.sh                 [unix]

--- a/examples/maxiconda/construct.yaml
+++ b/examples/maxiconda/construct.yaml
@@ -1,8 +1,6 @@
 name: Maxiconda
 version: 2.5.5
 
-install_in_dependency_order: True
-
 channels:
   - http://repo.anaconda.com/pkgs/main/
 

--- a/examples/miniconda/construct.yaml
+++ b/examples/miniconda/construct.yaml
@@ -2,8 +2,6 @@ name: MinicondaX
 version: X
 installer_type: all
 
-install_in_dependency_order: True
-
 channels:
   - http://repo.anaconda.com/pkgs/main/
 


### PR DESCRIPTION
Recent windows failures seem to be caused by the preponderance of duplicate files across conda packages. It should not be constructor users' responsibility to raise these issues with the conda team, and generally the duplicates are benign, so we have changed the default value of `ignore_duplicate_files` to True. We have also removed `install_in_dependency_order` from the examples