### PR TITLE
add doc build workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,0 +1,33 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install Sphinx
+        run: pip install sphinx
+
+      - name: Build Site
+        run: |
+          cd docs/
+          make html
+          touch build/.nojekyll
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html/
+          publish_branch: gh-pages


### PR DESCRIPTION
This PR addresses #398 

Documentation will be deployed to https://conda.github.io/constructor using the `gh-pages` branch.

An example on my fork: https://epassaro.github.io/constructor.