### PR TITLE
Add parameter to make batch mode the default

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -102,8 +102,8 @@ supplying this list allows a subset to be selected instead.
 
 _required:_ no<br/>
 _type:_ boolean<br/>
-By default, constructor will error out when adding packages with duplicate
-files in them. Enable this option to warn instead and continue.
+By default, constructor will warn you when adding packages with duplicate
+files in them. Setting this option to false will raise an error instead.
 
 ## `install_in_dependency_order`
 
@@ -194,6 +194,14 @@ when the installation process is complete. If `True`, this subdirectory and
 its contents are preserved. If `keep_pkgs` is `False`, Unix `.sh` and Windows `.msi`
 installers offer a command-line option (`-k` and `/KeepPkgCache`, respectively)
 to preserve the package cache.
+
+## `batch_mode`
+
+_required:_ no<br/>
+_type:_ boolean<br/>
+Only affects ``.sh`` installers. If ``False`` (default), the installer launches
+an interactive wizard guiding the user through the available options. If
+``True``, the installer runs automatically as if ``-b`` was passed.
 
 ## `signing_identity_name`
 
@@ -378,6 +386,15 @@ _required:_ no<br/>
 _type:_ boolean<br/>
 Check if the path where the distribution is installed contains spaces and show a warning
 if any spaces are found. Default is True. (Windows only)
+
+## `nsis_template`
+
+_required:_ no<br/>
+_type:_ string<br/>
+
+If ``nsis_template`` is not provided, constructor uses its default
+NSIS template. For more complete customization for the installation experience,
+provide an NSIS template file. (Windows only)
 
 
 ## Available selectors

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -153,6 +153,12 @@ installers offer a command-line option (`-k` and `/KeepPkgCache`, respectively)
 to preserve the package cache.
 '''),
 
+    ('batch_mode',             False, bool, '''
+Only affects ``.sh`` installers. If ``False`` (default), the installer launches
+an interactive wizard guiding the user through the available options. If
+``True``, the installer runs automatically as if ``-b`` was passed.
+'''),
+
     ('signing_identity_name',  False, str, '''
 By default, the MacOS pkg installer isn't signed. If an identity name is specified
 using this option, it will be used to sign the installer. Note that you will need

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -21,7 +21,11 @@ THIS_DIR=$(DIRNAME=$(dirname "$0"); cd "$DIRNAME"; pwd)
 THIS_FILE=$(basename "$0")
 THIS_PATH="$THIS_DIR/$THIS_FILE"
 PREFIX=__DEFAULT_PREFIX__
+#if batch_mode
+BATCH=1
+#else
 BATCH=0
+#endif
 FORCE=0
 #if keep_pkgs
 KEEP_PKGS=1
@@ -36,11 +40,13 @@ usage: $0 [options]
 
 Installs __NAME__ __VERSION__
 
-#if has_license
+#if not batch_mode
+  #if has_license
 -b           run install in batch mode (without manual intervention),
              it is expected the license terms are agreed upon
-#else
+  #else
 -b           run install in batch mode (without manual intervention)
+  #endif
 #endif
 -f           no error if install prefix already exists
 -h           print this help message and exit

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -40,7 +40,9 @@ usage: $0 [options]
 
 Installs __NAME__ __VERSION__
 
-#if not batch_mode
+#if batch_mode
+-i           run install in interactive mode
+#else
   #if has_license
 -b           run install in batch mode (without manual intervention),
              it is expected the license terms are agreed upon
@@ -62,7 +64,7 @@ Installs __NAME__ __VERSION__
 "
 
 if which getopt > /dev/null 2>&1; then
-    OPTS=$(getopt bfhkp:sut "$*" 2>/dev/null)
+    OPTS=$(getopt bifhkp:sut "$*" 2>/dev/null)
     if [ ! $? ]; then
         printf "%s\\n" "$USAGE"
         exit 2
@@ -78,6 +80,10 @@ if which getopt > /dev/null 2>&1; then
                 ;;
             -b)
                 BATCH=1
+                shift
+                ;;
+            -i)
+                BATCH=0
                 shift
                 ;;
             -f)
@@ -118,7 +124,7 @@ if which getopt > /dev/null 2>&1; then
         esac
     done
 else
-    while getopts "bfhkp:sut" x; do
+    while getopts "bifhkp:sut" x; do
         case "$x" in
             h)
                 printf "%s\\n" "$USAGE"
@@ -126,6 +132,9 @@ else
             ;;
             b)
                 BATCH=1
+                ;;
+            i)
+                BATCH=0
                 ;;
             f)
                 FORCE=1

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -44,7 +44,13 @@ def get_header(conda_exec, tarball, info):
     has_license = bool('license_file' in info)
     ppd = ns_platform(info['_platform'])
     ppd['keep_pkgs'] = bool(info.get('keep_pkgs', False))
+    ppd['batch_mode'] = bool(info.get('batch_mode', False))
     ppd['has_license'] = has_license
+    if ppd['batch_mode'] and has_license:
+        raise Exception(
+            "It is not possible to use both the 'batch_mode' and "
+            "'license_file' options together."
+        )
     for key in 'pre_install', 'post_install', 'pre_uninstall':
         ppd['has_%s' % key] = bool(key in info)
         if key in info:

--- a/docs/source/construct_yaml.rst
+++ b/docs/source/construct_yaml.rst
@@ -183,9 +183,23 @@ required: False
 
 argument type(s): ``bool``,
 
-By default, no conda packages are preserved after running the created
-installer in the `pkgs` directory.  Using this option changes the default
-behavior.
+If ``False`` (default), the package cache in the ``pkgs`` subdirectory is removed
+when the installation process is complete. If ``True``, this subdirectory and
+its contents are preserved. If ``keep_pkgs`` is ``False``, Unix ``.sh`` and Windows ``.msi``
+installers offer a command-line option (``-k`` and ``/KeepPkgCache``, respectively)
+to preserve the package cache.
+
+~~~~~~~~~~
+batch_mode
+~~~~~~~~~~
+
+required: False
+
+argument type(s): ``bool``,
+
+Only affects ``.sh`` installers. If ``False`` (default), the installer launches
+an interactive wizard guiding the user through the available options. If
+``True``, the installer runs automatically as if ``-b`` was passed.
 
 ~~~~~~~~~~~~~~~~~~~~~
 signing_identity_name


### PR DESCRIPTION
This PR adds a parameter (`batch_mode`) to `construct.yaml` to make batch mode (`-b`) the default when running the installer. If both `batch_mode` and `license_file` are set an exception is raise as there isn't really a way to "agree" to the license.

Any thoughts?