### PR TITLE
init all

### DIFF
--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -6,9 +6,4 @@
 # change.
 PREFIX="$2/__NAME_LOWER__"
 
-if [[ $SHELL = *zsh ]]
-then
-    $PREFIX/bin/conda init zsh
-else
-    $PREFIX/bin/conda init
-fi
+$PREFIX/bin/conda init --all


### PR DESCRIPTION
Init all shells so that the user can have a better experience if they are switching between shells. 

This was brought up due to osx's change to zsh as the default shell.