### PR TITLE
extract pre-conda before extracting conda packages

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -443,11 +443,11 @@ printf "Unpacking payload ...\n"
 extract_range $boundary1 $boundary2 | \
     "$CONDA_EXEC" constructor --extract-tarball --prefix "$PREFIX"
 
-"$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs || exit 1
-
 PRECONDA="$PREFIX/preconda.tar.bz2"
 "$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-tarball < "$PRECONDA" || exit 1
 rm -f "$PRECONDA"
+
+"$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs || exit 1
 
 #The templating doesn't support nested if statements
 #if has_pre_install


### PR DESCRIPTION
Hi, 

this PR moves the extraction of the contents of $PRECONDA before the extraction of the tarballs. I just changed micromamba to take the `pkgs/urls` file into account to create proper `repodata_record.json` files that include `fn`, `md5` and `url`.
Please let me know if there would be any downsides to this order change and I can try to find another way in micromamba.

I've been running tests for miniforge using micromamba 0.13.0 here: https://github.com/wolfv/miniforge/runs/2570642719?check_suite_focus=true