### PR TITLE
Fix help and conda init

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -42,13 +42,13 @@ Installs __NAME__ __VERSION__
 
 #if batch_mode
 -i           run install in interactive mode
-#else
-  #if has_license
+#endif
+#if not batch_mode and has_license
 -b           run install in batch mode (without manual intervention),
              it is expected the license terms are agreed upon
-  #else
+#endif
+#if not batch_mode and not has_license
 -b           run install in batch mode (without manual intervention)
-  #endif
 #endif
 -f           no error if install prefix already exists
 -h           print this help message and exit

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -550,23 +550,22 @@ if [ "$PYTHONPATH" != "" ]; then
     printf "    in __NAME__: $PREFIX\\n"
 fi
 
-if [ "$BATCH" = "0" ]; then
 #if has_conda
-    # Interactive mode.
-  #if osx
+if [ "$BATCH" = "0" ]; then
+#endif
+#if has_conda and osx
     BASH_RC="$HOME"/.bash_profile
-    DEFAULT=yes
-  #else
+#endif
+#if has_conda and not osx
     BASH_RC="$HOME"/.bashrc
-    DEFAULT=no
-  #endif
-  #if initialize_by_default is True
+#endif
+#if has_conda and initialize_by_default
     DEFAULT=yes
   #endif
-  #if initialize_by_default is False
+#if has_conda and not initialize_by_default
     DEFAULT=no
-  #endif
-
+#endif
+#if has_conda
     printf "Do you wish the installer to initialize __NAME__\\n"
     printf "by running conda init? [yes|no]\\n"
     printf "[%s] >>> " "$DEFAULT"


### PR DESCRIPTION
- [x] Fix help shell installer - the shell header wasn't parse correctly
- [x] Fix `initialize_by_default` constructor option - same as previous point
- [x] Add option to shell installer not to run conda init and don't ask the corresponding question when this option is used
- [x] Ready for review 