### PR TITLE
Fix uninstaller error

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -993,8 +993,12 @@ Section "Uninstall"
     !insertmacro ExecWaitLibNsisCmd "pre_uninstall"
     !insertmacro ExecWaitLibNsisCmd "rmpath"
     !insertmacro ExecWaitLibNsisCmd "rmreg"
-    !insertmacro ExecWaitLibNsisCmd 'del "$INSTDIR"'
+    DetailPrint "Removing files..."
+    nsExec::Exec 'cmd.exe /k DEL /F/Q/S "$INSTDIR"\*.*'
+    DetailPrint "Removing folders..."
+    nsExec::Exec 'cmd.exe /k RD /S/Q "$INSTDIR"'
 
+    # In case the last two commands fail, fall back to slow method to remove leftover
     RMDir /r /REBOOTOK "$INSTDIR"
 
     DeleteRegKey SHCTX "${UNINSTREG}"

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -993,12 +993,10 @@ Section "Uninstall"
     !insertmacro ExecWaitLibNsisCmd "pre_uninstall"
     !insertmacro ExecWaitLibNsisCmd "rmpath"
     !insertmacro ExecWaitLibNsisCmd "rmreg"
-    DetailPrint "Removing files..."
-    nsExec::Exec 'cmd.exe /k DEL /F/Q/S "$INSTDIR"\*.*'
-    DetailPrint "Removing folders..."
-    nsExec::Exec 'cmd.exe /k RD /S/Q "$INSTDIR"'
+    DetailPrint "Removing files and folders..."
+    nsExec::Exec 'cmd.exe /k RMDIR /Q/S "$INSTDIR"'
 
-    # In case the last two commands fail, fall back to slow method to remove leftover
+    # In case the last command fails, run the slow method to remove leftover
     RMDir /r /REBOOTOK "$INSTDIR"
 
     DeleteRegKey SHCTX "${UNINSTREG}"


### PR DESCRIPTION
Use `nsExec:Exec` to remove files and folders instead of using a [python subprocess](https://github.com/conda/constructor/blob/f14fa91e1e363a029fffccb74c81618d27285bfb/constructor/nsis/_nsis.py#L294-L327), which fails when removing files still being used:

![image](https://user-images.githubusercontent.com/11851990/135722416-28f38721-e74f-4e75-ac05-d6e528491baa.png)

After the fast uninstall fails with the error above, `RMDir /r /REBOOTOK "$INSTDIR"` which remove everything but is slow. The log shows that two files are not deleted (`libffi-7.dll` and `_ctypes.pyd`) using the fast approach:
```
Deleting MinicondaX menus...
Processed C:\Users\Eric\minicondax\Menu\console_shortcut.json successfully.
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" pre_uninstall
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmpath
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmreg
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" del "C:\Users\Eric\minicondax"
Remove folder: C:\Users\Eric\minicondax\conda-meta\
Remove folder: C:\Users\Eric\minicondax\condabin\
Delete file: C:\Users\Eric\minicondax\DLLs\libffi-7.dll
Delete file: C:\Users\Eric\minicondax\DLLs\_ctypes.pyd
Remove folder: C:\Users\Eric\minicondax\DLLs\
Remove folder: C:\Users\Eric\minicondax\envs\
Remove folder: C:\Users\Eric\minicondax\etc\fish\conf.d\
Remove folder: C:\Users\Eric\minicondax\etc\fish\
Remove folder: C:\Users\Eric\minicondax\etc\profile.d\
Remove folder: C:\Users\Eric\minicondax\etc\
Remove folder: C:\Users\Eric\minicondax\include\cpython\
Remove folder: C:\Users\Eric\minicondax\include\internal\
Remove folder: C:\Users\Eric\minicondax\include\
Remove folder: C:\Users\Eric\minicondax\Lib\asyncio\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\asyncio\
Remove folder: C:\Users\Eric\minicondax\Lib\collections\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\collections\
Remove folder: C:\Users\Eric\minicondax\Lib\concurrent\futures\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\concurrent\futures\
Remove folder: C:\Users\Eric\minicondax\Lib\concurrent\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\concurrent\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\macholib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\macholib\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\test\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\ctypes\
Remove folder: C:\Users\Eric\minicondax\Lib\curses\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\curses\
Remove folder: C:\Users\Eric\minicondax\Lib\dbm\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\dbm\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\command\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\command\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\tests\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\tests\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\distutils\
Remove folder: C:\Users\Eric\minicondax\Lib\email\mime\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\email\mime\
Remove folder: C:\Users\Eric\minicondax\Lib\email\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\email\
Remove folder: C:\Users\Eric\minicondax\Lib\encodings\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\encodings\
Remove folder: C:\Users\Eric\minicondax\Lib\ensurepip\_bundled\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\ensurepip\_bundled\
Remove folder: C:\Users\Eric\minicondax\Lib\ensurepip\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\ensurepip\
Remove folder: C:\Users\Eric\minicondax\Lib\html\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\html\
Remove folder: C:\Users\Eric\minicondax\Lib\http\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\http\
Remove folder: C:\Users\Eric\minicondax\Lib\idlelib\Icons\
Remove folder: C:\Users\Eric\minicondax\Lib\idlelib\idle_test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\idlelib\idle_test\
Remove folder: C:\Users\Eric\minicondax\Lib\idlelib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\idlelib\
Remove folder: C:\Users\Eric\minicondax\Lib\importlib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\importlib\
Remove folder: C:\Users\Eric\minicondax\Lib\json\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\json\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\fixes\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\fixes\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\pgen2\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\pgen2\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\lib2to3\
Remove folder: C:\Users\Eric\minicondax\Lib\logging\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\logging\
Remove folder: C:\Users\Eric\minicondax\Lib\msilib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\msilib\
Remove folder: C:\Users\Eric\minicondax\Lib\multiprocessing\dummy\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\multiprocessing\dummy\
Remove folder: C:\Users\Eric\minicondax\Lib\multiprocessing\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\multiprocessing\
Remove folder: C:\Users\Eric\minicondax\Lib\pydoc_data\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\pydoc_data\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\examples\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\examples\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\adodbapi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\brotli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\brotli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\brotlipy-0.7.0-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\certifi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\certifi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\certifi-2021.5.30-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cffi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cffi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cffi-1.14.6.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\metadata\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\metadata\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\chardet-4.0.0.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\assets\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\assets\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\charset_normalizer-2.0.0.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\colorama\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\colorama\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\colorama-0.4.4.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\base\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\base\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\pkg_formats\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\pkg_formats\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\_os\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\_os\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\common\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\core\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\core\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\connection\adapters\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\connection\adapters\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\connection\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\connection\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\disk\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\disk\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\gateways\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\models\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\models\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\bin\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\condabin\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\etc\fish\conf.d\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\etc\fish\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\etc\profile.d\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\etc\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\Library\bin\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\Library\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\Scripts\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\shell\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\_vendor\boltons\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\_vendor\boltons\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\_vendor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\_vendor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\auxlib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\boltons\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\boltons\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\toolz\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\toolz\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\tqdm\contrib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\tqdm\contrib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\tqdm\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\tqdm\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\urllib3\util\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\urllib3\util\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\urllib3\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\urllib3\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\_vendor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda-4.10.3-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\installers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\installers\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\specs\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\specs\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_env\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_package_handling\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_package_handling\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\conda_package_handling-1.7.3.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\backends\openssl\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\backends\openssl\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\backends\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\backends\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\bindings\openssl\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\bindings\openssl\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\bindings\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\bindings\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\asymmetric\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\asymmetric\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\ciphers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\ciphers\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\kdf\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\kdf\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\serialization\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\serialization\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\twofactor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\twofactor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\primitives\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\hazmat\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\x509\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\x509\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\cryptography-3.4.7.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\idna\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\idna\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\idna-3.1.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\doc\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\samples\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\samples\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\isapi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\menuinst\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\menuinst\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\menuinst-1.4.18.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\OpenSSL\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\OpenSSL\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\commands\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\commands\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\distributions\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\distributions\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\index\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\index\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\locations\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\locations\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\metadata\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\metadata\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\models\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\models\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\network\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\network\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\build\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\build\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\install\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\install\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\operations\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\req\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\req\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\legacy\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\legacy\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\resolvelib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\resolvelib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\resolution\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\utils\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\utils\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\vcs\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\vcs\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_internal\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\cachecontrol\caches\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\cachecontrol\caches\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\cachecontrol\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\cachecontrol\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\certifi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\certifi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\metadata\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\metadata\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\chardet\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\colorama\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\colorama\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\distlib\_backport\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\distlib\_backport\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\distlib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\distlib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\filters\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\filters\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treeadapters\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treeadapters\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treebuilders\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treebuilders\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treewalkers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\treewalkers\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\_trie\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\_trie\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\html5lib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\idna\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\idna\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\msgpack\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\msgpack\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\packaging\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\packaging\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pep517\in_process\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pep517\in_process\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pep517\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pep517\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pkg_resources\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\pkg_resources\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\progress\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\progress\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\requests\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\requests\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\resolvelib\compat\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\resolvelib\compat\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\resolvelib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\resolvelib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\tenacity\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\tenacity\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\tomli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\tomli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\contrib\_securetransport\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\contrib\_securetransport\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\contrib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\contrib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\backports\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\backports\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\ssl_match_hostname\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\ssl_match_hostname\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\packages\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\util\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\util\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\urllib3\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\webencodings\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\webencodings\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\_vendor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pip-21.2.4-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\extern\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\extern\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\tests\data\my-test-package-source\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\tests\data\my-test-package-source\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\tests\data\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\tests\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\_vendor\packaging\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\_vendor\packaging\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\_vendor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\_vendor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pkg_resources\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycosat-0.6.3.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\ply\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\ply\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\arpa\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\asm-generic\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\linux\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\mir_toolkit\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\net\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\netinet\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\openssl\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\sys\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\X11\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\xcb\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\fake_libc_include\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\utils\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pycparser-2.20.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pyOpenSSL-20.0.1.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\PySocks-1.7.1.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\debugger\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\debugger\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\app\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\app\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\ocx\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\ocx\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\Demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\dialogs\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\dialogs\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\docking\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\docking\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\editor\color\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\editor\color\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\editor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\editor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\framework\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\idle\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\idle\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\mfc\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\mfc\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\scintilla\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\scintilla\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\tools\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\tools\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\pywin\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pythonwin\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pywin32-301-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\pywin32_system32\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\requests\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\requests\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\requests-2.26.0.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\ruamel_yaml\ext\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\ruamel_yaml\ext\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\ruamel_yaml\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\ruamel_yaml\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\ruamel_yaml_conda-0.15.80.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\command\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\command\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\extern\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\extern\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_distutils\command\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_distutils\command\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_distutils\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_distutils\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\more_itertools\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\more_itertools\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\packaging\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\packaging\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\_vendor\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\setuptools-58.0.4-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\six-1.16.0.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\test_data\env_metadata\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\test_data\env_metadata\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\test_data\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\test_data\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\tqdm\contrib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\tqdm\contrib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\tqdm\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\tqdm\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\tqdm-4.62.3.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\contrib\_securetransport\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\contrib\_securetransport\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\contrib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\contrib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\backports\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\backports\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\ssl_match_hostname\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\ssl_match_hostname\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\packages\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\util\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\util\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\urllib3-1.26.7.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\cli\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\cli\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\vendored\packaging\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\vendored\packaging\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\vendored\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\vendored\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\wheel-0.37.0-py3.9.egg-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\c_extension\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\c_extension\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\dde\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\dde\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\images\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\pipes\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\pipes\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\security\sspi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\security\sspi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\security\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\security\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\service\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\service\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\win32wnet\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\win32wnet\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\Demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\include\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\lib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\lib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\libs\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\ce\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\ce\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\VersionStamp\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\VersionStamp\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\scripts\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\test\win32rcparser\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\client\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\client\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\HTML\image\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\HTML\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\include\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\libs\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\makegw\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\makegw\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\server\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\server\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\servers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\servers\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32com\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\adsi\demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\adsi\demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\adsi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\adsi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\authorization\demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\authorization\demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\authorization\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\authorization\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axcontrol\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axcontrol\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axdebug\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axdebug\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\client\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\client\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\client\asp\interrupt\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\client\asp\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\client\ie\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\client\wsh\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\client\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\Demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\server\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\server\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\axscript\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\bits\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\bits\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\bits\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\bits\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\directsound\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\directsound\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\directsound\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\directsound\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\ifilter\demo\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\ifilter\demo\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\ifilter\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\ifilter\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\internet\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\internet\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\mapi\demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\mapi\demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\mapi\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\mapi\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\propsys\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\propsys\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\propsys\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\propsys\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\demos\servers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\demos\servers\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\demos\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\demos\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\shell\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\taskscheduler\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\taskscheduler\test\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\taskscheduler\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\taskscheduler\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win32comext\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\win_inet_pton-1.1.0.dist-info\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\xontrib\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\_distutils_hack\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\_distutils_hack\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\site-packages\
Remove folder: C:\Users\Eric\minicondax\Lib\sqlite3\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\sqlite3\test\
Remove folder: C:\Users\Eric\minicondax\Lib\sqlite3\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\sqlite3\
Remove folder: C:\Users\Eric\minicondax\Lib\test\support\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\test\support\
Remove folder: C:\Users\Eric\minicondax\Lib\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\test\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\test_tkinter\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\test_tkinter\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\test_ttk\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\test_ttk\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\test\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\tkinter\
Remove folder: C:\Users\Eric\minicondax\Lib\turtledemo\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\turtledemo\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\test\testmock\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\test\testmock\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\test\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\test\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\unittest\
Remove folder: C:\Users\Eric\minicondax\Lib\urllib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\urllib\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\scripts\common\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\scripts\nt\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\scripts\posix\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\scripts\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\venv\
Remove folder: C:\Users\Eric\minicondax\Lib\wsgiref\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\wsgiref\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\dom\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\dom\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\etree\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\etree\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\parsers\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\parsers\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\sax\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\sax\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xml\
Remove folder: C:\Users\Eric\minicondax\Lib\xmlrpc\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\xmlrpc\
Remove folder: C:\Users\Eric\minicondax\Lib\zoneinfo\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\zoneinfo\
Remove folder: C:\Users\Eric\minicondax\Lib\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Lib\
Remove folder: C:\Users\Eric\minicondax\Library\bin\
Remove folder: C:\Users\Eric\minicondax\Library\cmake\
Remove folder: C:\Users\Eric\minicondax\Library\include\openssl\
Remove folder: C:\Users\Eric\minicondax\Library\include\
Remove folder: C:\Users\Eric\minicondax\Library\lib\engines-1_1\
Remove folder: C:\Users\Eric\minicondax\Library\lib\
Remove folder: C:\Users\Eric\minicondax\Library\misc\
Remove folder: C:\Users\Eric\minicondax\Library\ssl\
Remove folder: C:\Users\Eric\minicondax\Library\
Remove folder: C:\Users\Eric\minicondax\libs\
Remove folder: C:\Users\Eric\minicondax\Menu\
Delete file: C:\Users\Eric\minicondax\python3.dll
Delete file: C:\Users\Eric\minicondax\python39.dll
Delete file: C:\Users\Eric\minicondax\pythonw.exe
Remove folder: C:\Users\Eric\minicondax\Scripts\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Africa\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\America\Argentina\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\America\Indiana\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\America\Kentucky\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\America\North_Dakota\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\America\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Antarctica\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Arctic\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Asia\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Atlantic\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Australia\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Brazil\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\build\etc\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\build\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Canada\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Chile\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Etc\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Europe\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Indian\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Mexico\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\Pacific\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\US\
Remove folder: C:\Users\Eric\minicondax\share\zoneinfo\
Remove folder: C:\Users\Eric\minicondax\share\
Remove folder: C:\Users\Eric\minicondax\shell\condabin\
Remove folder: C:\Users\Eric\minicondax\shell\
Remove folder: C:\Users\Eric\minicondax\tcl\dde1.4\
Remove folder: C:\Users\Eric\minicondax\tcl\nmake\
Remove folder: C:\Users\Eric\minicondax\tcl\reg1.3\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8\8.4\platform\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8\8.4\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8\8.5\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8\8.6\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\encoding\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\http1.0\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\msgs\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\opt0.4\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Africa\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\America\Argentina\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\America\Indiana\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\America\Kentucky\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\America\North_Dakota\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\America\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Antarctica\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Arctic\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Asia\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Atlantic\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Australia\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Brazil\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Canada\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Chile\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Etc\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Europe\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Indian\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Mexico\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\Pacific\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\SystemV\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\US\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\tzdata\
Remove folder: C:\Users\Eric\minicondax\tcl\tcl8.6\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\bitmaps\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\demos\bitmaps\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\demos\samples\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\demos\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\pref\
Remove folder: C:\Users\Eric\minicondax\tcl\tix8.4.3\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\demos\images\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\demos\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\images\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\msgs\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\ttk\
Remove folder: C:\Users\Eric\minicondax\tcl\tk8.6\
Remove folder: C:\Users\Eric\minicondax\tcl\
Remove folder: C:\Users\Eric\minicondax\Tools\demo\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Tools\demo\
Remove folder: C:\Users\Eric\minicondax\Tools\i18n\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Tools\i18n\
Remove folder: C:\Users\Eric\minicondax\Tools\pynche\X\
Remove folder: C:\Users\Eric\minicondax\Tools\pynche\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Tools\pynche\
Remove folder: C:\Users\Eric\minicondax\Tools\scripts\__pycache__\
Remove folder: C:\Users\Eric\minicondax\Tools\scripts\
Remove folder: C:\Users\Eric\minicondax\Tools\
Delete file: C:\Users\Eric\minicondax\vcruntime140.dll
Remove folder: C:\Users\Eric\minicondax\
Completed
```

With this PR, the fast uninstall is fixed:
```
Deleting MinicondaX menus...
Processed C:\Users\Eric\minicondax\Menu\console_shortcut.json successfully.
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" pre_uninstall
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmpath
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmreg
Removing files and folders...
Completed
```

Example of uninstall with a python process still running, in which case, the fallback is used:
```
Deleting MinicondaX menus...
Processed C:\Users\Eric\minicondax\Menu\console_shortcut.json successfully.
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" pre_uninstall
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmpath
Execute: "C:\Users\Eric\minicondax\pythonw.exe" -E -s "C:\Users\Eric\minicondax\Lib\_nsis.py" rmreg
Removing files and folders...
Delete on reboot: C:\Users\Eric\minicondax\python.exe
Delete on reboot: C:\Users\Eric\minicondax\python39.dll
Delete on reboot: C:\Users\Eric\minicondax\vcruntime140.dll
Delete on reboot: C:\Users\Eric\minicondax\
Completed
```

Relevant PRs: #245, #277, #345.