### PR TITLE
Avoid yaml warnings (and ensure compatibility with pyyaml 6)

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -375,7 +375,7 @@ def yamlize(data, directory, content_filter):
         except ImportError as ex:
             raise UnableToParseMissingJinja2(original=ex)
         data = render_jinja(data, directory, content_filter)
-        return yaml.load(data, Loader=yaml.FullLoader)
+        return yaml.load(data, Loader=yaml.SafeLoader)
 
 
 def parse(path, platform):

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -375,7 +375,7 @@ def yamlize(data, directory, content_filter):
         except ImportError as ex:
             raise UnableToParseMissingJinja2(original=ex)
         data = render_jinja(data, directory, content_filter)
-        return yaml.load(data)
+        return yaml.load(data, Loader=yaml.FullLoader)
 
 
 def parse(path, platform):


### PR DESCRIPTION
I had to manually downgrade pyyaml. Not sure if this is the only place where yaml load is used.