### PR TITLE
3.3.2 changelog prerelease

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -11,7 +11,7 @@
   email: jjhelmus@gmail.com
   aliases:
   - Jonathan Helmus
-  num_commits: 2
+  num_commits: 9
   first_commit: 2014-06-09 17:25:05
   github: jjhelmus
 - name: Aaron Stevens
@@ -39,7 +39,7 @@
   github: soapy1
   aliases:
   - soapy1
-  num_commits: 2
+  num_commits: 11
   first_commit: 2019-01-21 16:30:21
 - name: Matthew Newville
   email: newville@cars.uchicago.edu
@@ -148,7 +148,7 @@
   email: mgrant@anaconda.com
   alternate_emails:
   - mcg@cvxr.com
-  num_commits: 56
+  num_commits: 58
   first_commit: 2016-06-13 12:15:26
   github: schrodinger
 - name: Forrest Waters
@@ -184,7 +184,7 @@
   first_commit: 2020-05-04 20:34:58
 - name: Eric Prestat
   email: eric.prestat@gmail.com
-  num_commits: 19
+  num_commits: 26
   first_commit: 2019-09-20 04:38:09
   github: ericpre
 - name: Phil Elson
@@ -194,7 +194,7 @@
   github: pelson
 - name: Mark Harfouche
   email: mark.harfouche@gmail.com
-  num_commits: 6
+  num_commits: 11
   first_commit: 2020-08-29 16:45:08
   github: hmaarrfk
 - name: Rachel Rigdon
@@ -232,7 +232,29 @@
   num_commits: 20
   first_commit: 2020-02-08 00:55:25
   github: isuruf
-- name: Tom Hören
+# - name: Tom Hören
+#   email: horen.tom@gmail.com
+#   num_commits: 1
+#   first_commit: 2020-07-19 09:44:03
+#   github: nerohmot
+- name: Jannis Leidel
+  email: jannis@leidel.info
+  num_commits: 0
+  first_commit: 2021-08-26 05:18:15
+- name: Wolf Vollprecht
+  email: w.vollprecht@gmail.com
+  num_commits: 1
+  first_commit: 2021-05-12 14:49:58
+  github: wolfv
+- name: XuehaiPan
+  email: XuehaiPan@pku.edu.cn
+  num_commits: 1
+  first_commit: 2021-10-28 00:49:35
+- name: Cheng H. Lee
+  email: chenghlee@users.noreply.github.com
+  num_commits: 0
+  first_commit: 2021-05-24 08:52:40
+- name: Tom H�ren
   email: horen.tom@gmail.com
   num_commits: 1
   first_commit: 2020-07-19 09:44:03

--- a/.authors.yml
+++ b/.authors.yml
@@ -232,11 +232,6 @@
   num_commits: 20
   first_commit: 2020-02-08 00:55:25
   github: isuruf
-# - name: Tom Hören
-#   email: horen.tom@gmail.com
-#   num_commits: 1
-#   first_commit: 2020-07-19 09:44:03
-#   github: nerohmot
 - name: Jannis Leidel
   email: jannis@leidel.info
   num_commits: 0
@@ -254,7 +249,7 @@
   email: chenghlee@users.noreply.github.com
   num_commits: 0
   first_commit: 2021-05-24 08:52:40
-- name: Tom H�ren
+- name: Tom Hören
   email: horen.tom@gmail.com
   num_commits: 1
   first_commit: 2020-07-19 09:44:03

--- a/.mailmap
+++ b/.mailmap
@@ -14,10 +14,13 @@ Nehal J Wani <nehaljw.kkd1@gmail.com>
 Michael C. Grant <mgrant@anaconda.com> Michael C. Grant <mcg@cvxr.com>
 Ray Donnelly <mingw.android@gmail.com>
 Michael Sarahan <msarahan@gmail.com> Mike Sarahan <msarahan@continuum.io>
-Isuru Fernando <isuruf@gmail.com>
 Eric Prestat <eric.prestat@gmail.com>
+Isuru Fernando <isuruf@gmail.com>
 Marcel Bargull <marcel.bargull@udo.edu>
 Kale Franz <kfranz@continuum.io> Kale Franz <kalefranz@users.noreply.github.com>
+Sophia Castellarin <scastellarin@anaconda.com> soapy1 <scastellarin@anaconda.com>
+Mark Harfouche <mark.harfouche@gmail.com>
+Jonathan J. Helmus <jjhelmus@gmail.com> Jonathan Helmus <jjhelmus@gmail.com>
 Forrest Waters <forrestwaters65@gmail.com> Forrest Waters <fwaters@0609.local>
 Forrest Waters <forrestwaters65@gmail.com> Forrest Waters <person@example.com>
 Forrest Waters <forrestwaters65@gmail.com> Forrest Waters <fwaters@anaconda.com>
@@ -25,14 +28,11 @@ Angela Gloyna <angela.gloyna@gmail.com>
 Chris Burr <christopher.burr@cern.ch>
 Anthony Scopatz <scopatz@gmail.com>
 Faustin Carter <faustin.carter@gmail.com> Faustin Carter <fwcarter@hrl.com>
-Mark Harfouche <mark.harfouche@gmail.com>
 Martin Durant <martin.durant@utoronto.ca>
 Aaron Stevens <bheklilr2@gmail.com>
 Thomas Holder <thomas.holder@schrodinger.com>
 Eric Dill <thedizzle@gmail.com>
-Jonathan J. Helmus <jjhelmus@gmail.com> Jonathan Helmus <jjhelmus@gmail.com>
 Tobias Megies <megies@geophysik.uni-muenchen.de>
-Sophia Castellarin <scastellarin@anaconda.com> soapy1 <scastellarin@anaconda.com>
 Matthew Newville <newville@cars.uchicago.edu>
 Jean-Luc Stevens <jlstevens@ed.ac.uk> jlstevens <jlrstevens@gmail.com>
 Wolfgang Ulmer <wulmer@web.de> Ulmer Wolfgang (CR/AEE3) <wolfgang.Ulmer@de.bosch.com>
@@ -53,4 +53,8 @@ Mariana Meireles <marian.meireles@gmail.com>
 astaric <anze.staric@gmail.com>
 Pradipta Ghosh <pradghos@in.ibm.com>
 Connor Martin <connormartin7@gmail.com>
-Tom HÃ¶ren <horen.tom@gmail.com>
+Wolf Vollprecht <w.vollprecht@gmail.com>
+XuehaiPan <XuehaiPan@pku.edu.cn>
+Tom Hören <horen.tom@gmail.com>
+Jannis Leidel <jannis@leidel.info>
+Cheng H. Lee <chenghlee@users.noreply.github.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -45,6 +45,6 @@ Authors are sorted by number of commits.
 * Connor Martin
 * Wolf Vollprecht
 * XuehaiPan
-* Tom Hören
+* Tom HÃ¶ren
 * Jannis Leidel
 * Cheng H. Lee

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,23 +6,23 @@ Authors are sorted by number of commits.
 * Michael C. Grant
 * Ray Donnelly
 * Michael Sarahan
-* Isuru Fernando
 * Eric Prestat
+* Isuru Fernando
 * Marcel Bargull
 * Kale Franz
+* Sophia Castellarin
+* Mark Harfouche
+* Jonathan J. Helmus
 * Forrest Waters
 * Angela Gloyna
 * Chris Burr
 * Anthony Scopatz
 * Faustin Carter
-* Mark Harfouche
 * Martin Durant
 * Aaron Stevens
 * Thomas Holder
 * Eric Dill
-* Jonathan J. Helmus
 * Tobias Megies
-* Sophia Castellarin
 * Matthew Newville
 * Jean-Luc Stevens
 * Wolfgang Ulmer
@@ -43,4 +43,8 @@ Authors are sorted by number of commits.
 * astaric
 * Pradipta Ghosh
 * Connor Martin
-* Tom HÃ¶ren
+* Wolf Vollprecht
+* XuehaiPan
+* Tom Hören
+* Jannis Leidel
+* Cheng H. Lee

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,21 @@
+2022-01-02   3.2.2:
+-------------------
+  * Common:
+    - Fix crashes due to pyyaml >= 6 deprecating automatic use of SafeLoader; it is now safe to run constructor with pyyaml >= 6 #473
+    - 
+
+  * Shell:
+    - Extract pre-conda before extracting conda packages #450
+    - Add tests for header template preprocessing and fix initialize by default #459
+
+  * PKG:
+    - Unset DYLD_FALLBACK_LIBRARY_PATH in header on macOS; installer now works with bash >= 5.1.4 #472
+
+  * NSIS:
+    - Use nsExec:Exec to remove files and folders instead of using a python subprocess, which fails when removing files still being used #467
+    - Add option to disable creation of start menu shortcuts and generally fix shortcut creation #455, #466
+
+
 2020-03-30   3.2.1:
 -------------------
   * Common:


### PR DESCRIPTION
# New changelog entries:

2022-01-02   3.2.2:
-------------------
  * Common:
    - Fix crashes due to pyyaml >= 6 deprecating automatic use of SafeLoader; it is now safe to run constructor with pyyaml >= 6 #473
    - 

  * Shell:
    - Extract pre-conda before extracting conda packages #450
    - Add tests for header template preprocessing and fix initialize by default #459

  * PKG:
    - Unset DYLD_FALLBACK_LIBRARY_PATH in header on macOS; installer now works with bash >= 5.1.4 #472

  * NSIS:
    - Use nsExec:Exec to remove files and folders instead of using a python subprocess, which fails when removing files still being used #467
    - Add option to disable creation of start menu shortcuts and generally fix shortcut creation #455, #466

# New authors
- Jannis Leidel
- Wolf Vollprecht
- XuehaiPan
- Cheng H. Lee