### PR TITLE
DNM: Build matrix: drop 2.7, 3.6; add 3.9, 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest,ubuntu-latest,windows-latest]
-        pyver: [2.7,3.6,3.7,3.8]
+        pyver: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Print github context
       run: |


### PR DESCRIPTION
https://endoflife.date/python
https://numpy.org/neps/nep-0029-deprecation_policy.html

In theory, we could just expand the build matrix here, without dropping Python 2.7 and Python 3.6. But while I support the continued use of Python 2.7 in legacy code, constructor is not really a legacy application.