### PR TITLE
Add new options to the generated installers

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -257,7 +257,9 @@ _type:_ string<br/>
 Path to a pre-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. This option is not supported for Windows `.exe` or macOS
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. This option is not supported for Windows `.exe` or macOS
 `.pkg` installers.
 
 ## `post_install`
@@ -267,7 +269,9 @@ _type:_ string<br/>
 Path to a post-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. For Windows `.exe` installers, this must be a `.bat` file.
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. For Windows `.exe` installers, this must be a `.bat` file.
 This option is not supported for macOS `.pkg` installers.
 
 ## `post_install_desc`

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -198,7 +198,9 @@ Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 Path to a pre-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. This option is not supported for Windows `.exe` or macOS
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. This option is not supported for Windows `.exe` or macOS
 `.pkg` installers.
 '''),
 
@@ -206,7 +208,9 @@ the installer. This option is not supported for Windows `.exe` or macOS
 Path to a post-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. For Windows `.exe` installers, this must be a `.bat` file.
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. For Windows `.exe` installers, this must be a `.bat` file.
 This option is not supported for macOS `.pkg` installers.
 '''),
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -10,6 +10,11 @@ if ! echo "$0" | grep '\.sh$' > /dev/null; then
     return 1
 fi
 
+# Export variables to make installer metadata available to pre/post install scripts
+export INSTALLER_NAME="__NAME__"
+export INSTALLER_VER="__VERSION__"
+export INSTALLER_PLAT="__PLAT__"
+
 THIS_DIR=$(DIRNAME=$(dirname "$0"); cd "$DIRNAME"; pwd)
 THIS_FILE=$(basename "$0")
 THIS_PATH="$THIS_DIR/$THIS_FILE"


### PR DESCRIPTION
I've found myself wanting to use three these commits of functionality when using custom installers generating with constructor.

* Optionally disable the cleaning of `LD_LIBRARY_PATH`
* Allow the path to `conda.exe` to be replaced
* Allow pre/post installer scripts to see the installer's name/version/platform

To be more specific, I'm finding 81cab9eedecb043641a4fbb66efbf70b13cfd412 and de6c23db76a4cb063dd7ab2e7a55c581a9708267 to be useful when installing from a different architecture (in my case, to a read-only networked file system that is only writeable from a single x86 machine).

I considered adding this as environment variables instead to avoid bloating the number of CLI flags but I guess this way is more idiomatic.