### PR TITLE
Micromamba and transcoding fixes

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -142,6 +142,15 @@ File type extension for the files to be transmuted into. Currently supports
 only '.conda'. See conda-package-handling for supported extension names.
 If left empty, no transumating is done.
 
+## `write_cache_types`
+
+_required:_ no<br/>
+_type:_ list<br/>
+Which types of repodata cache should be included in the installer. Supported
+values are `conda` and `mamba`. By default this will try to detect if the
+value of `--conda-exe` is `conda-standalone` or `micromamba`, falling back to
+`["conda"]` if this detection fails.
+
 ## `conda_default_channels`
 
 _required:_ no<br/>

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -2,8 +2,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-from os.path import join
+import os
 import sys
+from copy import deepcopy
+from os.path import join
+
+from constructor.utils import hash_files
 
 NAV_APPS = ['glueviz', 'jupyterlab', 'notebook',
             'orange3', 'qtconsole', 'rstudio', 'spyder', 'vscode']
@@ -87,10 +91,9 @@ if conda_interface_type == 'conda':
 
         return full_repodata
 
-    def write_repodata(cache_dir, url, full_repodata, used_packages):
+    def write_repodata(cache_dir, url, full_repodata, used_packages, info):
         used_repodata = {k: full_repodata[k] for k in
                          set(full_repodata.keys()) - {'packages', 'packages.conda', 'removed'}}
-        repodata_filename = _cache_fn_url(used_repodata['_url'].rstrip("/"))
         used_repodata['packages.conda'] = {}
         used_repodata['removed'] = []
         # arbitrary old, expired date, so that conda will want to immediately update it
@@ -98,9 +101,31 @@ if conda_interface_type == 'conda':
         used_repodata['_mod'] = "Mon, 07 Jan 2019 15:22:15 GMT"
         used_repodata['packages'] = {
             k: v for k, v in full_repodata['packages'].items() if v['name'] in NAV_APPS}
+
+        # Minify the included repodata
         for package in used_packages:
-            for key in ('packages', 'packages.conda'):
-                if package in full_repodata.get(key, {}):
-                    used_repodata[key][package] = full_repodata[key][package]
+            key = 'packages.conda' if package.endswith(".conda") else 'packages'
+            if package in full_repodata.get(key, {}):
+                used_repodata[key][package] = full_repodata[key][package]
+                continue
+            # If we're transcoding packages, fix-up the metadata
+            if package.endswith(".conda"):
+                original_package = package[:-len(".conda")] + ".tar.bz2"
+                original_key = "packages"
+            elif package.endswith(".tar.bz2"):
+                original_package = package[:-len(".tar.bz2")] + ".conda"
+                original_key = "packages.conda"
+            else:
+                print("WARNING: package type is unknown for: %s" % package)
+                continue
+            if original_package in full_repodata.get(original_key, {}):
+                data = deepcopy(full_repodata[original_key][original_package])
+                pkg_fn = join(info["_download_dir"], package)
+                data["size"] = os.stat(pkg_fn).st_size
+                data["sha256"] = hash_files([pkg_fn], algorithm='sha256')
+                data["md5"] = hash_files([pkg_fn])
+                used_repodata[key][package] = data
+
+        repodata_filename = _cache_fn_url(used_repodata['_url'].rstrip("/"))
         with open(join(cache_dir, repodata_filename), 'w') as fh:
             json.dump(used_repodata, fh, indent=2)

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -113,6 +113,13 @@ only '.conda'. See conda-package-handling for supported extension names.
 If left empty, no transumating is done.
 '''),
 
+    ('write_cache_types',      False, list, '''
+Which types of repodata cache should be included in the installer. Supported
+values are `conda` and `mamba`. By default this will try to detect if the
+value of `--conda-exe` is `conda-standalone` or `micromamba`, falling back to
+`["conda"]` if this detection fails.
+'''),
+
     ('conda_default_channels', False, list, '''
 If this value is provided as well as `write_condarc`, then the channels
 in this list will be included as the value of the `default_channels:`

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -339,8 +339,13 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
                 new_file_name = os.path.join(download_dir, new_file_name)
                 if not os.path.exists(new_file_name):
                     print("transmuting %s" % dist)
-                    conda_package_handling.api.transmute(os.path.join(download_dir, dist),
-                        transmute_file_type, out_folder=download_dir)
+                    failed_files = conda_package_handling.api.transmute(
+                        os.path.join(download_dir, dist),
+                        transmute_file_type,
+                        out_folder=download_dir,
+                    )
+                    if failed_files:
+                        raise RuntimeError("Transmution failed:", failed_files)
                 url, md5 = _urls[dist]
                 assert url.endswith(".tar.bz2")
                 url = url[:-len(".tar.bz2")] + transmute_file_type

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -15,7 +15,7 @@ from os.path import isdir, isfile, join, splitext
 import sys
 import tempfile
 
-from constructor.utils import md5_files, filename_dist
+from constructor.utils import hash_files, filename_dist
 from .conda_interface import (PackageCacheData, PackageCacheRecord, Solver, SubdirData,
                               VersionOrder, concatv, conda_context, conda_replace_context_default,
                               download, env_vars, groupby, read_paths_json, all_channel_urls,
@@ -117,7 +117,7 @@ def _fetch(download_dir, precs):
             extracted_package_dir = package_tarball_full_path[:-6]
 
         if not (isfile(package_tarball_full_path)
-                and md5_files([package_tarball_full_path]) == prec.md5):
+                and hash_files([package_tarball_full_path]) == prec.md5):
             print('fetching: %s' % prec.fn)
             download(prec.url, join(download_dir, prec.fn))
 
@@ -326,6 +326,7 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
     dists = list(prec.fn for prec in precs)
 
     if transmute_file_type != '':
+        _urls = {os.path.basename(url): (url, md5) for url, md5 in _urls}
         new_dists = []
         import conda_package_handling.api
         for dist in dists:
@@ -336,14 +337,19 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
                 new_file_name = "%s%s" % (dist[:-8], transmute_file_type)
                 new_dists.append(new_file_name)
                 new_file_name = os.path.join(download_dir, new_file_name)
-                if os.path.exists(new_file_name):
-                    continue
-                print("transmuting %s" % dist)
-                conda_package_handling.api.transmute(os.path.join(download_dir, dist),
-                    transmute_file_type, out_folder=download_dir)
+                if not os.path.exists(new_file_name):
+                    print("transmuting %s" % dist)
+                    conda_package_handling.api.transmute(os.path.join(download_dir, dist),
+                        transmute_file_type, out_folder=download_dir)
+                url, md5 = _urls[dist]
+                assert url.endswith(".tar.bz2")
+                url = url[:-len(".tar.bz2")] + transmute_file_type
+                md5 = hash_files([new_file_name])
+                _urls[dist] = (url, md5)
             else:
                 new_dists.append(dist)
         dists = new_dists
+        _urls = list(_urls.values())
 
     if environment_file:
         import shutil

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -34,9 +34,13 @@ def write_index_cache(info, dst_dir, used_packages):
     _platforms = info['_platform'], 'noarch'
     _remaps = {url['src'].rstrip('/'): url['dest'].rstrip('/')
                for url in info.get('channels_remap', [])}
-    _urls = all_channel_urls(url.rstrip('/') for url in list(_remaps) +
-                             info.get('channels', []) +
-                             info.get('conda_default_channels', []))
+    _channels = [
+        url.rstrip("/")
+        for url in list(_remaps)
+        + info.get("channels", [])
+        + info.get("conda_default_channels", [])
+    ]
+    _urls = all_channel_urls(_channels, subdirs=_platforms)
     repodatas = {url: get_repodata(url) for url in _urls if url is not None}
 
     for url, _ in info['_urls']:

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -60,7 +60,7 @@ def write_index_cache(info, dst_dir, used_packages):
             del repodatas['%s/%s' % (src, subdir)]
 
     for url, repodata in repodatas.items():
-        write_repodata(cache_dir, url, repodata, used_packages)
+        write_repodata(cache_dir, url, repodata, used_packages, info)
 
     for cache_file in os.listdir(cache_dir):
         if not cache_file.endswith(".json"):

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -15,7 +15,7 @@ import tempfile
 
 from .construct import ns_platform
 from .preconda import files as preconda_files, write_files as preconda_write_files
-from .utils import add_condarc, filename_dist, fill_template, md5_files, preprocess, \
+from .utils import add_condarc, filename_dist, fill_template, hash_files, preprocess, \
     read_ascii_only, get_final_channels
 
 THIS_DIR = dirname(__file__)
@@ -66,7 +66,7 @@ def get_header(conda_exec, tarball, info):
         'PLAT': info['_platform'],
         'DEFAULT_PREFIX': info.get('default_prefix',
                                    '$HOME/%s' % name.lower()),
-        'MD5': md5_files([conda_exec, tarball]),
+        'MD5': hash_files([conda_exec, tarball]),
         'FIRST_PAYLOAD_SIZE': str(getsize(conda_exec)),
         'SECOND_PAYLOAD_SIZE': str(getsize(tarball)),
         'INSTALL_COMMANDS': '\n'.join(install_lines),

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -35,8 +35,8 @@ def fill_template(data, d):
     return pat.sub(replace, data)
 
 
-def md5_files(paths):
-    h = hashlib.new('md5')
+def hash_files(paths, algorithm='md5'):
+    h = hashlib.new(algorithm)
     for path in paths:
         with open(path, 'rb') as fi:
             while True:


### PR DESCRIPTION
When transcoding to `.conda` and using `--conda-exe=/path/to/micromamba` I found that the installer would fail with a lot of error messages along the lines of:

```
Encountered problems while solving:
  - nothing provides ncurses >=6.2,<6.3.0a0 needed by python-3.9.9-h62f1059_0_cpython
  - nothing provides ncurses >=6.2,<6.3.0a0 needed by libedit-3.1.20191231-he28a2e2_2
  - nothing provides ncurses >=6.2,<6.3.0a0 needed by readline-8.1-h46c0cb4_0
  - nothing provides ncurses >=6.2,<6.3.0a0 needed by sqlite-3.37.0-h9cd32fc_0
  - nothing provides ncurses >=6.2,<6.3.0a0 needed by xrootd-5.4.0-py39hf708bbc_0
```

Initially this could be fixed by writing the cache filenames that `micromamba` expects to find. I think hit errors with the extracted `pkgs/*/info/repodata_record.json` files being invalid. This was caused by `micromamba` failing to find the [package name](https://github.com/mamba-org/mamba/blob/129920a304084a59bdfbe026b036185a83d94e40/micromamba/src/constructor.cpp#L100-L117) as the repodata wasn't being modified to look replace `.tar.bz2` names with `.conda` (and the fix the size/md5/sha256).

With this PR `constructor --conda-exe=/path/to/micromamba` works fully for every combination of options I can think of.

cc @wolfv 