### PR TITLE
Include cache metadata on the first line of the repodata cache

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -90,17 +90,27 @@ if conda_interface_type == 'conda':
     def write_repodata(cache_dir, url, full_repodata, used_packages):
         used_repodata = {k: full_repodata[k] for k in
                          set(full_repodata.keys()) - {'packages', 'packages.conda', 'removed'}}
-        repodata_filename = _cache_fn_url(used_repodata['_url'].rstrip("/"))
         used_repodata['packages.conda'] = {}
         used_repodata['removed'] = []
-        # arbitrary old, expired date, so that conda will want to immediately update it
-        # when not being run in offline mode
-        used_repodata['_mod'] = "Mon, 07 Jan 2019 15:22:15 GMT"
         used_repodata['packages'] = {
             k: v for k, v in full_repodata['packages'].items() if v['name'] in NAV_APPS}
         for package in used_packages:
             for key in ('packages', 'packages.conda'):
                 if package in full_repodata.get(key, {}):
                     used_repodata[key][package] = full_repodata[key][package]
+
+        # The first line of the JSON should contain cache metadata
+        # Choose an arbitrary old, expired date, so that conda will want to
+        # immediately update it when not being run in offline mode
+        url = used_repodata.pop('_url').rstrip("/")
+        repodata = json.dumps(used_repodata, indent=2)
+        repodata_header = json.dumps(
+            {
+                "_mod": "Mon, 07 Jan 2019 15:22:15 GMT",
+                "_url": url,
+            }
+        )
+        repodata = repodata_header[:-1] + "," + repodata[1:]
+        repodata_filename = _cache_fn_url(url)
         with open(join(cache_dir, repodata_filename), 'w') as fh:
-            json.dump(used_repodata, fh, indent=2)
+            fh.write(repodata)


### PR DESCRIPTION
Currently when constructor writes the repodata cache for conda it neglects to add some of the cache headers. Conda is forgiving about this however micromamba is stricter about this and I think it makes sense to make constructor more correct rather than making mamba more lenient.

For reference this is where conda adds these fields to the repodata for `pkgs/cache/*.json`:

https://github.com/conda/conda/blob/05b3e799daba158b74c892bf3aeb60ffe7485e3c/conda/core/subdir_data.py#L822-L834