### PR TITLE
Expose the installer metadata to pre/post install scripts

### DIFF
--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -198,7 +198,9 @@ Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 Path to a pre-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. This option is not supported for Windows `.exe` or macOS
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. This option is not supported for Windows `.exe` or macOS
 `.pkg` installers.
 '''),
 
@@ -206,7 +208,9 @@ the installer. This option is not supported for Windows `.exe` or macOS
 Path to a post-install script. For Unix `.sh` installers, the shebang
 line is respected if present; otherwise, the script is run by the POSIX
 shell `sh`. Note that the use of a shebang can reduce the portability of
-the installer. For Windows `.exe` installers, this must be a `.bat` file.
+the installer. Metadata about the installer can be found in the
+`${INSTALLER_NAME}`/`${INSTALLER_VER}`/`${INSTALLER_PLAT}` environment
+variables. For Windows `.exe` installers, this must be a `.bat` file.
 This option is not supported for macOS `.pkg` installers.
 '''),
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -17,6 +17,11 @@ if ! echo "$0" | grep '\.sh$' > /dev/null; then
     return 1
 fi
 
+# Export variables to make installer metadata available to pre/post install scripts
+export INSTALLER_NAME="__NAME__"
+export INSTALLER_VER="__VERSION__"
+export INSTALLER_PLAT="__PLAT__"
+
 THIS_DIR=$(DIRNAME=$(dirname "$0"); cd "$DIRNAME"; pwd)
 THIS_FILE=$(basename "$0")
 THIS_PATH="$THIS_DIR/$THIS_FILE"


### PR DESCRIPTION
I've ran into a couple of cases where I want to use the installer's name, version and platform as part of an post-install script. I could hard code it in the post-install script but that's messy to manage for the version and platform.

Extracted from https://github.com/conda/constructor/pull/486