### PR TITLE
Allow cleaning of environment variables to be disabled during installation

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -5,13 +5,6 @@
 # PLAT:  __PLAT__
 # MD5:   __MD5__
 
-#if osx
-unset DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
-#else
-export OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-unset LD_LIBRARY_PATH
-#endif
-
 if ! echo "$0" | grep '\.sh$' > /dev/null; then
     printf 'Please run using "bash"/"dash"/"sh"/"zsh", but not "." or "source".\n' >&2
     return 1
@@ -26,6 +19,7 @@ THIS_DIR=$(DIRNAME=$(dirname "$0"); cd "$DIRNAME"; pwd)
 THIS_FILE=$(basename "$0")
 THIS_PATH="$THIS_DIR/$THIS_FILE"
 PREFIX=__DEFAULT_PREFIX__
+CLEAN_ENV=1
 #if batch_mode
 BATCH=1
 #else
@@ -59,13 +53,14 @@ Installs __NAME__ __VERSION__
 -p PREFIX    install prefix, defaults to $PREFIX, must not contain spaces.
 -s           skip running pre/post-link/install scripts
 -u           update an existing installation
+-e           disable cleaning of environment variables that may interfer with the installation
 #if has_conda
 -t           run package tests after installation (may install conda-build)
 #endif
 "
 
 if which getopt > /dev/null 2>&1; then
-    OPTS=$(getopt bifhkp:sut "$*" 2>/dev/null)
+    OPTS=$(getopt bifhkp:suet "$*" 2>/dev/null)
     if [ ! $? ]; then
         printf "%s\\n" "$USAGE"
         exit 2
@@ -108,6 +103,10 @@ if which getopt > /dev/null 2>&1; then
                 FORCE=1
                 shift
                 ;;
+            e)
+                CLEAN_ENV=0
+                shift
+                ;;
 #if has_conda
             -t)
                 TEST=1
@@ -125,7 +124,7 @@ if which getopt > /dev/null 2>&1; then
         esac
     done
 else
-    while getopts "bifhkp:sut" x; do
+    while getopts "bifhkp:suet" x; do
         case "$x" in
             h)
                 printf "%s\\n" "$USAGE"
@@ -152,6 +151,9 @@ else
             u)
                 FORCE=1
                 ;;
+            e)
+                CLEAN_ENV=0
+                ;;
 #if has_conda
             t)
                 TEST=1
@@ -163,6 +165,15 @@ else
                 ;;
         esac
     done
+fi
+
+if [ "$CLEAN_ENV" = "1" ]; then
+#if osx
+    unset DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
+#else
+    export OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+    unset LD_LIBRARY_PATH
+#endif
 fi
 
 # For testing, keep the package cache around longer
@@ -427,8 +438,10 @@ fi
 
 cd "$PREFIX"
 
-# disable sysconfigdata overrides, since we want whatever was frozen to be used
-unset PYTHON_SYSCONFIGDATA_NAME _CONDA_PYTHON_SYSCONFIGDATA_NAME
+if [ "$CLEAN_ENV" = "1" ]; then
+    # disable sysconfigdata overrides, since we want whatever was frozen to be used
+    unset PYTHON_SYSCONFIGDATA_NAME _CONDA_PYTHON_SYSCONFIGDATA_NAME
+fi
 
 # the first binary payload: the standalone conda executable
 CONDA_EXEC="$PREFIX/conda.exe"


### PR DESCRIPTION
When running the installer from a different architecture via qemu and binfmt_misc I find I need to set `LD_LIBRARY_PATH` so that `conda.exe` can find `libz.so`. 

```bash
$ QEMU_LD_PREFIX="$CONDA_ROOT/envs/sysroot_linux-ppc64le/powerpc64le-conda-linux-gnu/sysroot" \
    "$CONDA_ROOT/envs/constructor-linux-ppc64le/standalone_conda/conda.exe" -V
conda.exe: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
```

The easiest solution I found is to set `LD_LIBRARY_PATH` pointing at a conda environment for ppc64le, i.e.

```bash
$ LD_LIBRARY_PATH="$CONDA_ROOT/envs/sysroot_linux-ppc64le/lib" \
    QEMU_LD_PREFIX="$CONDA_ROOT/envs/sysroot_linux-ppc64le/powerpc64le-conda-linux-gnu/sysroot" \
    "$CONDA_ROOT/envs/constructor-linux-ppc64le/standalone_conda/conda.exe" -V
conda 4.10.3
```

Obviously this is a horrible hack and their are other hacky ways of doing this. Despite this I think it's useful to be able to do these kind of tricks for the handful of people that need them. As such I propose to add an option to the installer so that it the unsetting of environment variables can be disabled.

If there are worries we could:
1. Show a big loud message that here-be-dragons and you should probably remove the option again
2. Hide it from the help menu

Extracted from https://github.com/conda/constructor/pull/486