### PR TITLE
FIX: `conda_interface` should be able to handle alpha, beta, rc versions

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 from os.path import join
+from itertools import chain
 import sys
 
 NAV_APPS = ['glueviz', 'jupyterlab', 'notebook',
@@ -20,7 +21,8 @@ if conda_interface_type == 'conda':
     from conda.models.version import VersionOrder
 
     _conda_version = VersionOrder(CONDA_INTERFACE_VERSION).version
-    CONDA_MAJOR_MINOR = _conda_version[1][0], _conda_version[2][0]
+    # Flatten VersionOrder.version, skip epoch, and keep only major and minor
+    CONDA_MAJOR_MINOR = tuple(chain.from_iterable(_conda_version))[1:3]
 
     from conda._vendor.toolz.itertoolz import (
         concatv as _concatv, get as _get, groupby as _groupby,

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -16,7 +16,11 @@ except ImportError:
                        "with sys.prefix: %s" % sys.prefix)
 
 if conda_interface_type == 'conda':
-    CONDA_MAJOR_MINOR = tuple(int(x) for x in CONDA_INTERFACE_VERSION.split('.')[:2])
+    # This import path has been stable since 2016
+    from conda.models.version import VersionOrder
+
+    _conda_version = VersionOrder(CONDA_INTERFACE_VERSION).version
+    CONDA_MAJOR_MINOR = _conda_version[1][0], _conda_version[2][0]
 
     from conda._vendor.toolz.itertoolz import (
         concatv as _concatv, get as _get, groupby as _groupby,


### PR DESCRIPTION
The previous approach will fail with non-final conda versions (e.g. 4.12a1). This uses `conda.models.VersionOrder` instead, which has been stable since 2016, so I'd say it's safe to use.