### PR TITLE
run examples outside conda build to upload installers as artifacts for local testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,96 +4,118 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - "*"
   pull_request:
     branches:
       - master
+defaults:
+  run:
+    shell: bash
 jobs:
   package:
-    defaults:
-      run:
-        shell: bash
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,ubuntu-latest,windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         pyver: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - name: Print github context
-      run: |
-        echo "EVENT_NAME:" "$GITHUB_EVENT_NAME"
-        echo "       REF:" "$GITHUB_REF"
-        echo "  HEAD_REF:" "$GITHUB_HEAD_REF"
-        echo "  BASE_REF:" "$GITHUB_BASE_REF"
-        echo "       SHA:" "$GITHUB_SHA"
-    - name: Retrieve the source code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Build the build environment
-      run: |
+      - name: Print github context
+        run: |
+          echo "EVENT_NAME:" "$GITHUB_EVENT_NAME"
+          echo "       REF:" "$GITHUB_REF"
+          echo "  HEAD_REF:" "$GITHUB_HEAD_REF"
+          echo "  BASE_REF:" "$GITHUB_BASE_REF"
+          echo "       SHA:" "$GITHUB_SHA"
+      - name: Retrieve the source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Build the build environment
+        run: |
           [ $RUNNER_OS = 'Windows' ] && CONDA_EXE=$CONDA/Scripts/conda.exe
           [ $RUNNER_OS == macOS ] && export CONDA_PKGS_DIRS=~/.pkgs
           ${CONDA_EXE:-conda} create -p ../conda conda conda-build conda-verify
-    - name: Build the package
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        PYTHONIOENCODING: utf-8
-        PYTHONUNBUFFERED: True
-      run: |
+      - name: Build the package
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          PYTHONIOENCODING: utf-8
+          PYTHONUNBUFFERED: True
+          # Uncomment to run within conda build
+          # RUN_EXAMPLES: "1"
+        run: |
           source ../conda/etc/profile.d/conda.sh
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
           conda build conda.recipe --python=${{ matrix.pyver }}
           mv ../conda/conda-bld .
-    - name: Upload the build artifact
-      if: github.event_name == 'push'
-      uses: actions/upload-artifact@v2
-      with:
-        # By uploading to the same artifact we can download all of the packages
-        # and upload them all to anaconda.org in a single job
-        name: package-${{ github.sha }}
-        path: conda-bld/*/*.tar.bz2
+      - name: Upload the packages as artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v2
+        with:
+          # By uploading to the same artifact we can download all of the packages
+          # and upload them all to anaconda.org in a single job
+          name: package-${{ github.sha }}
+          path: conda-bld/*/*.tar.bz2
+      - name: Run examples and prepare artifacts
+        run: |
+          source ../conda/etc/profile.d/conda.sh
+          conda create -n constructor -c local constructor
+          conda activate constructor
+          python scripts/run_examples.py
+          mkdir -p examples_artifacts/
+          for path in $(cat run_examples_output.txt); do
+            mv "$path" examples_artifacts/
+          done
+      - name: Upload the example installers as artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        retention-days: 7
+        with:
+          # By uploading to the same artifact we can download all of the packages
+          # and upload them all to anaconda.org in a single job
+          name: installers-${{ github.sha }}
+          path: examples_artifacts/
+
   upload:
     needs: package
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-    - name: Retrieve the source code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Download the build artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: package-${{ github.sha }}
-        path: conda-bld
-    - name: Install conda packages
-      run: |
-        source $CONDA/bin/activate
-        conda install -y sphinx anaconda-client
-    - name: Build the documentation for deployment
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        source $CONDA/bin/activate
-        cd docs
-        make html
-    - name: Deploy the documentation
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/build/html
-    - name: Upload to anaconda.org
-      env:
-        ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        GITHUB_REF: ${{ github.ref }}
-      run: |
-        source $CONDA/bin/activate
-        [[ "$GITHUB_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev"
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/*.tar.bz2 --force
-    - name: Clean up older artifacts
-      uses: glassechidna/artifact-cleaner@master
-      with:
-        minimumAge: 86400
+      - name: Retrieve the source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Download the build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: package-${{ github.sha }}
+          path: conda-bld
+      - name: Install conda packages
+        run: |
+          source $CONDA/bin/activate
+          conda install -y sphinx anaconda-client
+      - name: Build the documentation for deployment
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          source $CONDA/bin/activate
+          cd docs
+          make html
+      - name: Deploy the documentation
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html
+      - name: Upload to anaconda.org
+        env:
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          source $CONDA/bin/activate
+          [[ "$GITHUB_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev"
+          anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/*.tar.bz2 --force
+      - name: Clean up older artifacts
+        uses: glassechidna/artifact-cleaner@master
+        with:
+          minimumAge: 86400

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,11 +62,8 @@ jobs:
           source ../conda/etc/profile.d/conda.sh
           conda create -n constructor -c local constructor
           conda activate constructor
-          python scripts/run_examples.py
           mkdir -p examples_artifacts/
-          for path in $(cat run_examples_output.txt); do
-            mv "$path" examples_artifacts/
-          done
+          python scripts/run_examples.py --keep-artifacts=examples_artifacts/
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request' && matrix.pyver == '3.9'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,6 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.pyver == '3.9'
         uses: actions/upload-artifact@v2
         with:
-          # By uploading to the same artifact we can download all of the packages
-          # and upload them all to anaconda.org in a single job
           name: installers-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: examples_artifacts/
           retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
-          name: installers-${{ github.sha }}
+          name: installers-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: examples_artifacts/
           retention-days: 7
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,12 +70,12 @@ jobs:
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v2
-        retention-days: 7
         with:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
           name: installers-${{ github.sha }}
           path: examples_artifacts/
+          retention-days: 7
 
   upload:
     needs: package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
             mv "$path" examples_artifacts/
           done
       - name: Upload the example installers as artifacts
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.pyver == '3.9'
         uses: actions/upload-artifact@v2
         with:
           # By uploading to the same artifact we can download all of the packages

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
   script_env:
     - CODECOV_TOKEN
     - CODECOV_COMMIT
+    - RUN_EXAMPLES
 
 requirements:
   host:
@@ -44,10 +45,11 @@ test:
   commands:
     - pytest -v --cov=constructor tests
     - coverage run --append -m constructor -V
-    - python scripts/run_examples.py
     - if [%CODECOV_TOKEN%] neq [] codecov --commit %CODECOV_COMMIT% # [win]
     - if ["$CODECOV_TOKEN"]; then codecov --commit $CODECOV_COMMIT; fi # [unix]
     - coverage report
+    - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py  # [win]
+    - if ["$RUN_EXAMPLES"]; then python scripts/run_examples.py  # [unix]
 
 about:
   home: https://conda.io

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -48,8 +48,8 @@ test:
     - if [%CODECOV_TOKEN%] neq [] codecov --commit %CODECOV_COMMIT% # [win]
     - if ["$CODECOV_TOKEN"]; then codecov --commit $CODECOV_COMMIT; fi # [unix]
     - coverage report
-    - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py  # [win]
-    - if ["$RUN_EXAMPLES"]; then python scripts/run_examples.py  # [unix]
+    - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py      # [win]
+    - if ["$RUN_EXAMPLES"]; then python scripts/run_examples.py; fi  # [unix]
 
 about:
   home: https://conda.io

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import platform
+from shutil import move
 
 from constructor.utils import rm_rf
 
@@ -94,8 +95,14 @@ def run_examples():
         return False, tested_files_full_paths
 
 
+def _move_artifacts(artifacts, destination):
+    for artifact in artifacts:
+        move(artifact, destination)
+
+
 if __name__ == '__main__':
     failed, artifacts = run_examples()
-    with open("run_examples_output.txt", "w") as f:
-        print(*artifacts, sep="\n", file=f)
+    if sys.argv[1].startswith('--keep-artifacts='):
+        destination = sys.argv[1].split("=")[1]
+        _move_artifacts(artifacts, destination)
     sys.exit(failed)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -56,6 +56,7 @@ def run_examples():
 
     output_dir = tempfile.mkdtemp()
     tested_files = set()
+    tested_files_full_paths = set()
     for i, example_path in enumerate(sorted(example_paths)):
         print(example_path)
         print('-' * len(example_path))
@@ -71,6 +72,7 @@ def run_examples():
             rm_rf(env_dir)
             print('---- testing %s' % fpath)
             fpath = os.path.join(output_dir, fpath)
+            tested_files_full_paths.add(fpath)
             if ext == 'sh':
                 cmd = ['bash', fpath, '-b', '-p', env_dir]
             elif ext == 'pkg':
@@ -86,10 +88,10 @@ def run_examples():
     if errored:
         print('Some examples failed!')
         print('Assets saved in: %s' % output_dir)
-        return True, tested_files
+        return True, tested_files_full_paths
     else:
         print('All examples ran successfully!')
-        return False, tested_files
+        return False, tested_files_full_paths
 
 
 if __name__ == '__main__':

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -112,5 +112,7 @@ def run_examples(keep_artifacts=None):
 if __name__ == '__main__':
     if sys.argv[1].startswith('--keep-artifacts='):
         keep_artifacts = sys.argv[1].split("=")[1]
+    else:
+        keep_artifacts = None
     n_errors = run_examples(keep_artifacts)
     sys.exit(n_errors)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -86,11 +86,14 @@ def run_examples():
     if errored:
         print('Some examples failed!')
         print('Assets saved in: %s' % output_dir)
-        sys.exit(1)
+        return True, tested_files
     else:
         print('All examples ran successfully!')
-        rm_rf(output_dir)
+        return False, tested_files
 
 
 if __name__ == '__main__':
-    run_examples()
+    failed, artifacts = run_examples()
+    with open("run_examples_output.txt", "w") as f:
+        print(*artifacts, sep="\n", file=f)
+    sys.exit(failed)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 import platform
-from shutil import move
+import shutil
 
 from constructor.utils import rm_rf
 
@@ -40,13 +40,27 @@ def _execute(cmd):
     return p.returncode != 0
 
 
-def run_examples():
-    """Run examples bundled with the repository."""
+def run_examples(keep_artifacts=None):
+    """Run examples bundled with the repository.
+
+    Parameters
+    ----------
+    keep_artifacts: str, optional=None
+        Path where the generated installers will be moved to.
+        Will be created if it doesn't exist.
+
+    Returns
+    -------
+    int
+        Number of failed examples
+    """
     example_paths = []
     errored = 0
 
     if platform.system() != 'Darwin':
         BLACKLIST.append(os.path.join(EXAMPLES_DIR, "osxpkg"))
+    if keep_artifacts:
+        os.makedirs(keep_artifacts, exist_ok=True)
 
     whitelist = [os.path.join(EXAMPLES_DIR, p) for p in WHITELIST]
     for fname in os.listdir(EXAMPLES_DIR):
@@ -55,13 +69,12 @@ def run_examples():
             if os.path.exists(os.path.join(fpath, 'construct.yaml')):
                 example_paths.append(fpath)
 
-    output_dir = tempfile.mkdtemp()
+    parent_output = tempfile.mkdtemp()
     tested_files = set()
-    tested_files_full_paths = set()
-    for i, example_path in enumerate(sorted(example_paths)):
+    for example_path in sorted(example_paths):
         print(example_path)
         print('-' * len(example_path))
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=parent_output)
         cmd = COV_CMD + ['constructor', example_path, '--output-dir', output_dir]
         errored += _execute(cmd)
         for fpath in os.listdir(output_dir):
@@ -73,7 +86,6 @@ def run_examples():
             rm_rf(env_dir)
             print('---- testing %s' % fpath)
             fpath = os.path.join(output_dir, fpath)
-            tested_files_full_paths.add(fpath)
             if ext == 'sh':
                 cmd = ['bash', fpath, '-b', '-p', env_dir]
             elif ext == 'pkg':
@@ -84,25 +96,21 @@ def run_examples():
             elif ext == 'exe':
                 cmd = ['cmd.exe', '/c', 'start', '/wait', fpath, '/S', '/D=%s' % env_dir]
             errored += _execute(cmd)
+            if keep_artifacts:
+                shutil.move(fpath, keep_artifacts)
         print('')
 
     if errored:
         print('Some examples failed!')
-        print('Assets saved in: %s' % output_dir)
-        return True, tested_files_full_paths
+        print('Assets saved in: %s' % parent_output)
     else:
         print('All examples ran successfully!')
-        return False, tested_files_full_paths
-
-
-def _move_artifacts(artifacts, destination):
-    for artifact in artifacts:
-        move(artifact, destination)
+        shutil.rmtree(parent_output)
+    return errored
 
 
 if __name__ == '__main__':
-    failed, artifacts = run_examples()
     if sys.argv[1].startswith('--keep-artifacts='):
-        destination = sys.argv[1].split("=")[1]
-        _move_artifacts(artifacts, destination)
-    sys.exit(failed)
+        keep_artifacts = sys.argv[1].split("=")[1]
+    n_errors = run_examples(keep_artifacts)
+    sys.exit(n_errors)


### PR DESCRIPTION
Since a lot of changes are incoming, this should simplify testing things locally, especially those that require visual inspection.