### PR TITLE
Fix constructor test install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,6 @@ jobs:
           source ../conda/etc/profile.d/conda.sh
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
           conda build conda.recipe --python=${{ matrix.pyver }}
-          mv ../conda/conda-bld .
       - name: Upload the packages as artifact
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
@@ -56,7 +55,7 @@ jobs:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
           name: package-${{ github.sha }}
-          path: conda-bld/*/*.tar.bz2
+          path: ../conda/conda-bld/*/*.tar.bz2
       - name: Run examples and prepare artifacts
         run: |
           source ../conda/etc/profile.d/conda.sh

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -46,10 +46,10 @@ test:
     - pytest -v --cov=constructor tests
     - coverage run --append -m constructor -V
     - if [%CODECOV_TOKEN%] neq [] codecov --commit %CODECOV_COMMIT% # [win]
-    - if ["$CODECOV_TOKEN"]; then codecov --commit $CODECOV_COMMIT; fi # [unix]
+    - if [ -n "$CODECOV_TOKEN" ]; then codecov --commit $CODECOV_COMMIT; fi # [unix]
     - coverage report
     - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py      # [win]
-    - if ["$RUN_EXAMPLES"]; then python scripts/run_examples.py; fi  # [unix]
+    - if [ -n "$RUN_EXAMPLES" ]; then python scripts/run_examples.py; fi  # [unix]
 
 about:
   home: https://conda.io


### PR DESCRIPTION
#498 had an issue with the test env installation because `conda-bld` had been moved for the artifact upload (reasons unclear). This tries to fix it so the installed version is the locally built one, not a random from defaults.