### PR TITLE
fix upload path for artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         pyver: ["3.7", "3.8", "3.9", "3.10"]
-    env:
-      CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
     steps:
       - name: Print github context
         run: |
@@ -49,7 +47,7 @@ jobs:
         run: |
           source ../conda/etc/profile.d/conda.sh
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
-          conda build conda.recipe --python=${{ matrix.pyver }}
+          conda build conda.recipe --python=${{ matrix.pyver }} --croot ${{ runner.temp }}/conda-bld
       - name: Upload the packages as artifact
         # if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
@@ -57,7 +55,7 @@ jobs:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
           name: package-${{ github.sha }}
-          path: ${{ env.CONDA_BLD_PATH }}/*/*.tar.bz2
+          path: ${{ runner.temp }}/conda-bld/*/*.tar.bz2
       - name: Run examples and prepare artifacts
         run: |
           source ../conda/etc/profile.d/conda.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,12 @@ jobs:
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda create -n constructor -c local constructor
           conda activate constructor
+          installed_channel=$(conda list --json | jq '.[] | select(.name=="constructor") | .channel')
+          echo $installed_channel
+          if [[ ! "$installed_channel" =~ *conda-bld* ]]; then
+            echo "Installed constructor is not local!"
+            exit 1
+          fi
           mkdir -p examples_artifacts/
           python scripts/run_examples.py --keep-artifacts=examples_artifacts/
       - name: Upload the example installers as artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           source ../conda/etc/profile.d/conda.sh
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
-            conda create -n constructor -c local constructor
+            conda create -n constructor -c local --strict-channel-priority constructor
           conda activate constructor
           installed_channel=$(conda list --json | jq '.[] | select(.name=="constructor") | .channel')
           echo $(conda list --json | jq '.[] | select(.name=="constructor")')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,8 @@ jobs:
             conda create -n constructor -c local constructor
           conda activate constructor
           installed_channel=$(conda list --json | jq '.[] | select(.name=="constructor") | .channel')
-          echo $installed_channel
-          if [[ ! "$installed_channel" =~ *conda-bld* ]]; then
+          echo $(conda list --json | jq '.[] | select(.name=="constructor")')
+          if [[ "$installed_channel" != "conda-bld" ]]; then
             echo "Installed constructor is not local!"
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         pyver: ["3.7", "3.8", "3.9", "3.10"]
+    env:
+      CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
     steps:
       - name: Print github context
         run: |
@@ -49,13 +51,13 @@ jobs:
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
           conda build conda.recipe --python=${{ matrix.pyver }}
       - name: Upload the packages as artifact
-        if: github.event_name == 'push'
+        # if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
         with:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
           name: package-${{ github.sha }}
-          path: ../conda/conda-bld/*/*.tar.bz2
+          path: ${{ env.CONDA_BLD_PATH }}/*/*.tar.bz2
       - name: Run examples and prepare artifacts
         run: |
           source ../conda/etc/profile.d/conda.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,9 @@ jobs:
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda create -n constructor -c local --strict-channel-priority constructor
           conda activate constructor
-          installed_channel=$(conda list --json | jq '.[] | select(.name=="constructor") | .channel')
-          echo $(conda list --json | jq '.[] | select(.name=="constructor")')
+          installed_channel=$(conda list --json | jq -r '.[] | select(.name=="constructor") | .channel')
           if [[ "$installed_channel" != "conda-bld" ]]; then
+            echo $(conda list --json | jq '.[] | select(.name=="constructor")')
             echo "Installed constructor is not local!"
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           source ../conda/etc/profile.d/conda.sh
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
-          conda build conda.recipe --python=${{ matrix.pyver }} --croot ${{ runner.temp }}/conda-bld
+          CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
+            conda build conda.recipe --python=${{ matrix.pyver }}
       - name: Upload the packages as artifact
         # if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
@@ -59,7 +60,8 @@ jobs:
       - name: Run examples and prepare artifacts
         run: |
           source ../conda/etc/profile.d/conda.sh
-          conda create -n constructor -c local constructor
+          CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
+            conda create -n constructor -c local constructor
           conda activate constructor
           mkdir -p examples_artifacts/
           python scripts/run_examples.py --keep-artifacts=examples_artifacts/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda build conda.recipe --python=${{ matrix.pyver }}
       - name: Upload the packages as artifact
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
         with:
           # By uploading to the same artifact we can download all of the packages


### PR DESCRIPTION
One more fix for #498 , since apparently the artifacts action doesn't support `../xxx` relative paths.

Checks

- [X] Artifacts are uploaded
- [X] Local constructor is installed in tests
- [X] Packages can also be uploaded