### PR TITLE
enable debugging and include license info in the dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _cenv/
 rever/
 .idea
 docs/build/
+pkgs-list.txt
+info.json

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 import os
 from os.path import abspath, basename, expanduser, isdir, join
 import sys
+import json
 
 from .conda_interface import cc_platform
 from .construct import parse as construct_parse, verify as construct_verify
@@ -60,7 +61,7 @@ def get_output_filename(info):
 
 def main_build(dir_path, output_dir='.', platform=cc_platform,
                verbose=True, cache_dir=DEFAULT_CACHE_DIR,
-               dry_run=False, conda_exe="conda.exe"):
+               dry_run=False, conda_exe="conda.exe", debug=False):
     print('platform: %s' % platform)
     if not os.path.isfile(conda_exe):
         sys.exit("Error: Conda executable '%s' does not exist!" % conda_exe)
@@ -137,11 +138,13 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
         info['_outpath'] = abspath(join(output_dir, get_output_filename(info)))
         create(info, verbose=verbose)
         print("Successfully created '%(_outpath)s'." % info)
-    if 0:
+    if debug:
         with open(join(output_dir, 'pkg-list.txt'), 'w') as fo:
             fo.write('# installer: %s\n' % basename(info['_outpath']))
             for dist in info['_dists']:
                 fo.write('%s\n' % dist)
+        with open(join(output_dir, "info.json"), "w") as fo:
+            json.dump(info, fo)
 
 
 def main():
@@ -243,7 +246,8 @@ downloaded from https://repo.anaconda.com/pkgs/misc/conda-execs/""".lstrip())
     out_dir = normalize_path(args.output_dir)
     main_build(dir_path, output_dir=out_dir, platform=args.platform,
                verbose=args.verbose, cache_dir=args.cache_dir,
-               dry_run=args.dry_run, conda_exe=conda_exe)
+               dry_run=args.dry_run, conda_exe=conda_exe,
+               debug=args.debug)
 
 
 if __name__ == '__main__':

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+from pathlib import Path
+from subprocess import check_call
+from tempfile import TemporaryDirectory
+import os
+import json
+
+here = Path(__file__).parent
+examples = here / ".." / "examples"
+
+
+@contextmanager
+def working_directory(path):
+    wd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(wd)
+
+
+def test_debug_licenses():
+    with TemporaryDirectory() as tmp:
+        with working_directory(tmp):
+            check_call(["constructor", str(examples / "noconda"), "--debug"])
+            with open("info.json") as f:
+                data = json.load(f)
+                assert "_licenses" in data


### PR DESCRIPTION
Debugging flag was not fully implemented (guarded by `if 0:`, who knows). This PR fixes that and also adds a dictionary with a mapping of package-license-filenames so downstream users can quickly review which licenses are being bundled in the app (some of them DO require showing them in the EULA, specially proprietary packages).

As a result, when run with `--debug`, users will obtain a `pkgs-list.txt` and a `info.json` file in their working directory (added to gitignore too).