### PR TITLE
Fix constructor failures when the repo/subchannel only has noarch packages

### DIFF
--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -92,7 +92,15 @@ if conda_interface_type == 'conda':
 
         # noarch-only repos are valid. In this case, the architecture specific channel will return None
         if raw_repodata_str is None:
-            full_repodata = None
+            full_repodata = {
+                '_url': url,
+                'info': {
+                    'subdir': cc_platform
+                },
+                'packages': {},
+                'packages.conda': {},
+                'removed': []
+            }
         else:
             full_repodata = json.loads(raw_repodata_str)
 


### PR DESCRIPTION
When the full_repodata is set to None it causes write_repodata to throw an AttributeError exception because it immediately tries to treat it as an initialized dictionary.

Instead of returning none this change returns an initialized repodata dictionary with the minimum expected data which allows constructor to continue properly.