### PR TITLE
Renaming master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,12 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:
     branches:
-      - master
+      - main
 defaults:
   run:
     shell: bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ the script directly with ``python scripts/make_docs.py``.
 
 ## Build status
 
-| [![Build status](https://github.com/conda/constructor/workflows/Build%20and%20test%20the%20package/badge.svg)](https://github.com/conda/constructor/actions) [![codecov](https://codecov.io/gh/conda/constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/conda/constructor) | [![Anaconda-Server Badge](https://anaconda.org/ctools/constructor/badges/latest_release_date.svg)](https://anaconda.org/ctools/constructor) |
+| [![Build status](https://github.com/conda/constructor/workflows/Build%20and%20test%20the%20package/badge.svg)](https://github.com/conda/constructor/actions) [![codecov](https://codecov.io/gh/conda/constructor/branch/main/graph/badge.svg)](https://codecov.io/gh/conda/constructor) | [![Anaconda-Server Badge](https://anaconda.org/ctools/constructor/badges/latest_release_date.svg)](https://anaconda.org/ctools/constructor) |
 | --- | :-: |
 | [`conda install ctools/label/dev::constructor`](https://anaconda.org/ctools/constructor) | [![Anaconda-Server Badge](https://anaconda.org/ctools/constructor/badges/version.svg)](https://anaconda.org/ctools/constructor) |
 | [`conda install defaults::constructor`](https://anaconda.org/anaconda/constructor) | [![Anaconda-Server Badge](https://anaconda.org/anaconda/constructor/badges/version.svg)](https://anaconda.org/anaconda/constructor) |


### PR DESCRIPTION
The minor modifications needed for renaming the default branch from master to main.

Xref: https://github.com/conda/conda/issues/11517