### PR TITLE
Force use of nsis 3.01 on Windows

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - ruamel_yaml >=0.11.14,<0.16
     - conda-standalone
     - pillow >=3.1     # [win]
-    - nsis >=3.01      # [win]
+    - nsis ==3.01      # [win]
 
 test:
   source_files:


### PR DESCRIPTION
Temporary workaround for the CI issues we are seeing as part of #526 