### PR TITLE
Fix string conversion issue in verbose mode

### DIFF
--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -248,7 +248,7 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
     # probably want to add conda too.
     specs = (*specs, "python")
     if verbose:
-        print("specs: %r" % specs)
+        print("specs:", specs)
 
     # Append channels_remap srcs to channel_urls
     channel_urls = (*channel_urls, *(x['src'] for x in channels_remap))


### PR DESCRIPTION
If `--verbose` is enabled, `constructor` will print more stuff to STDOUT. However, under certain circumstances, the `specs` tuple will have non `%r`-formattable objects, which makes everything fail horribly. Replacing this `print()` with the default syntax provides the same verbosity requirements while being safe.