### PR TITLE
Hardcode paths to Apple's system tools

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -237,10 +237,10 @@ an interactive wizard guiding the user through the available options. If
 _required:_ no<br/>
 _type:_ string<br/>
 By default, the MacOS pkg installer isn't signed. If an identity name is specified
-using this option, it will be used to sign the installer. Note that you will need
-to have a certificate (usually an "Installer certificate") and corresponding
-private key together called an 'identity' in one of your accessible keychains.
-Common values for this option follow this format
+using this option, it will be used to sign the installer with Apple's `productsign`. 
+Note that you will need to have a certificate (usually an "Installer certificate")
+and the corresponding private key, together called an 'identity', in one of your 
+accessible keychains. Common values for this option follow this format
 `Developer ID Installer: Name of the owner (XXXXXX)`.
 
 ## `notarization_identity_name`
@@ -248,9 +248,9 @@ Common values for this option follow this format
 _required:_ no<br/>
 _type:_ string<br/>
 If the pkg installer is going to be signed with `signing_identity_name`, you
-can also prepare the bundle for notarization. This will use `codesign` to sign `conda.exe`.
-For this, you need an "Application certificate" (different from the "Installer certificate"
-mentioned above). Common values for this option follow this format
+can also prepare the bundle for notarization. This will use Apple's `codesign` 
+to sign `conda.exe`. For this, you need an "Application certificate" (different from the 
+"Installer certificate" mentioned above). Common values for this option follow the format
 `Developer ID Application: Name of the owner (XXXXXX)`.
 
 ## `attempt_hardlinks`

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -188,18 +188,18 @@ an interactive wizard guiding the user through the available options. If
 
     ('signing_identity_name',  False, str, '''
 By default, the MacOS pkg installer isn't signed. If an identity name is specified
-using this option, it will be used to sign the installer. Note that you will need
-to have a certificate (usually an "Installer certificate") and corresponding
-private key together called an 'identity' in one of your accessible keychains.
-Common values for this option follow this format
+using this option, it will be used to sign the installer with Apple's `productsign`. 
+Note that you will need to have a certificate (usually an "Installer certificate")
+and the corresponding private key, together called an 'identity', in one of your 
+accessible keychains. Common values for this option follow this format
 `Developer ID Installer: Name of the owner (XXXXXX)`.
 '''),
 
     ('notarization_identity_name', False, str, '''
 If the pkg installer is going to be signed with `signing_identity_name`, you
-can also prepare the bundle for notarization. This will use `codesign` to sign `conda.exe`.
-For this, you need an "Application certificate" (different from the "Installer certificate"
-mentioned above). Common values for this option follow this format
+can also prepare the bundle for notarization. This will use Apple's `codesign` 
+to sign `conda.exe`. For this, you need an "Application certificate" (different from the 
+"Installer certificate" mentioned above). Common values for this option follow the format
 `Developer ID Application: Name of the owner (XXXXXX)`.
 '''),
 

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -374,8 +374,9 @@ def create(info, verbose=False):
             }
             plist_dump(plist, f)
         check_call(
-            [
-                "/usr/bin/codesign",
+            [   
+                # hardcode to system location to avoid accidental clobber in PATH
+                "/usr/bin/codesign",  
                 "--verbose",
                 '--sign', notarization_identity_name,
                 "--prefix", info.get("reverse_domain_identifier", info['name']),
@@ -411,7 +412,8 @@ def create(info, verbose=False):
     # The default distribution file needs to be modified, so we create
     # it to a temporary location, edit it, and supply it to the final call.
     xml_path = join(PACKAGES_DIR, 'distribution.xml')
-    args = ["productbuild", "--synthesize"]
+    # hardcode to system location to avoid accidental clobber in PATH
+    args = ["/usr/bin/productbuild", "--synthesize"]
     for name in names:
         args.extend(['--package', join(PACKAGES_DIR, "%s.pkg" % name)])
     args.append(xml_path)
@@ -428,6 +430,7 @@ def create(info, verbose=False):
     ])
     if identity_name:
         check_call([
+            # hardcode to system location to avoid accidental clobber in PATH
             '/usr/bin/productsign', '--sign', identity_name,
             "tmp.pkg",
             info['_outpath'],

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -375,7 +375,7 @@ def create(info, verbose=False):
             plist_dump(plist, f)
         check_call(
             [
-                'codesign',
+                "/usr/bin/codesign",
                 "--verbose",
                 '--sign', notarization_identity_name,
                 "--prefix", info.get("reverse_domain_identifier", info['name']),
@@ -420,7 +420,7 @@ def create(info, verbose=False):
 
     identity_name = info.get('signing_identity_name')
     check_call([
-        "productbuild",
+        "/usr/bin/productbuild",
         "--distribution", xml_path,
         "--package-path", PACKAGES_DIR,
         "--identifier", info.get("reverse_domain_identifier", info['name']),
@@ -428,7 +428,7 @@ def create(info, verbose=False):
     ])
     if identity_name:
         check_call([
-            'productsign', '--sign', identity_name,
+            '/usr/bin/productsign', '--sign', identity_name,
             "tmp.pkg",
             info['_outpath'],
         ])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We ran into this issue in the https://github.com/napari/packaging/issues/11. Apparently some package in the dependency tree includes a `codesign` binary too, with a different CLI. This can get in the way of our signing process, resulting in a 109 error.

This happened because we let `subprocess` pick the first `codesign` in PATH. The fix is to hardcode the location to `/usr/bin/codesign`, as [`conda` itself does](https://github.com/conda/conda/blob/fdbedc49d4a61fb2121614de22795cfccc562b0b/conda/core/portability.py#L67).

I also applied the same patch to `productbuild` and `productsign`, just in case.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
