### PR TITLE
Allow shortcut removal on uninstall even if `.conda/environments.txt` does not exist

### DIFF
--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -158,9 +158,8 @@ get_conda_envs = get_conda_envs_from_python_api
 
 def rm_menus(prefix=None, root_prefix=None):
     try:
-        import menuinst
+        import menuinst  # noqa
         from conda.base.context import context
-        menuinst
     except (ImportError, OSError):
         return
     try:
@@ -170,18 +169,21 @@ def rm_menus(prefix=None, root_prefix=None):
         out("Failed to get conda environments list\n")
         err("Error: %s\n" % str(e))
         err("Traceback:\n%s\n" % traceback.format_exc(20))
-        return
-    envs_dirs = list(context.envs_dirs)
-    if prefix is not None:
-        envs_dirs.append(prefix)
-    for env in envs:
-        env = str(env)  # force `str` so that `os.path.join` doesn't fail
-        for envs_dir in envs_dirs:
-            # Make sure the environment is from one of the directory in
-            # `envs_dirs` to avoid picking up environment from other
-            # distributions. Not perfect but better than no checking
-            if envs_dir in env:
-                mk_menus(remove=True, prefix=env, root_prefix=root_prefix)
+        if prefix is not None:
+            out("Will only remove shortcuts created from '%s'" % prefix)
+            mk_menus(remove=True, prefix=prefix, root_prefix=root_prefix)
+    else:
+        envs_dirs = list(context.envs_dirs)
+        if prefix is not None:
+            envs_dirs.append(prefix)
+        for env in envs:
+            env = str(env)  # force `str` so that `os.path.join` doesn't fail
+            for envs_dir in envs_dirs:
+                # Make sure the environment is from one of the directory in
+                # `envs_dirs` to avoid picking up environment from other
+                # distributions. Not perfect but better than no checking
+                if envs_dir in env:
+                    mk_menus(remove=True, prefix=env, root_prefix=root_prefix)
 
 
 def run_post_install():

--- a/news/546-uninstaller-shortcuts
+++ b/news/546-uninstaller-shortcuts
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Shortcuts will be removed in installations that do not require `conda` (#461)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fixes #461 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
