### PR TITLE
Improve testing on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,14 @@ jobs:
           echo "  HEAD_REF:" "$GITHUB_HEAD_REF"
           echo "  BASE_REF:" "$GITHUB_BASE_REF"
           echo "       SHA:" "$GITHUB_SHA"
+      - name: Set temp dirs correctly
+        if: startsWith(matrix.os, 'windows')
+        # https://github.com/actions/virtual-environments/issues/712
+        shell: powershell
+        run: |
+          echo "TMPDIR=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
+          echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
+          echo "TMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
       - name: Retrieve the source code
         uses: actions/checkout@v2
         with:

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -158,12 +158,23 @@ default will determined by the `name`, `version`, platform, and installer type.
     ('installer_type',     False, (str, list), '''
 The type of the installer being created.  Possible values are:
 - `sh`: shell-based installer for Linux or macOS;
-- `pkg`: macOS GUI installer
-- `exe`: Windows GUI installer
+- `pkg`: macOS GUI installer built with Apple's `pkgbuild`
+- `exe`: Windows GUI installer built with NSIS
 
 The default type is `sh` on Linux and macOS, and `exe` on Windows. A special
 value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well
 as `sh` on Linux and `exe` on Windows.
+
+Notes for silent mode `/S` on Windows EXEs: 
+- NSIS Silent mode will not print any error message, but will silently abort the installation.
+  If needed, [NSIS log-builds][nsis-log] can be used to print to `%PREFIX%\\install.log`, which can be 
+  searched for `::error::` strings. Pre- and post- install scripts will only throw an error
+  if the environment variable `NSIS_SCRIPTS_RAISE_ERRORS` is set.
+- The `/D` flag can be used to specify the target location. It must be the last argument in
+  the command and should NEVER be quoted, even if it contains quotes. For example:
+  `CMD.EXE /C START /WAIT myproject.exe /S /D=C:\\path with spaces\\my project`.
+
+[nsis-log]: https://nsis.sourceforge.io/Special_Builds
 '''),
 
     ('license_file',           False, str, '''
@@ -398,11 +409,17 @@ interactive installation. (Windows only).
 Check the length of the path where the distribution is installed to ensure nodejs
 can be installed.  Raise a message to request shorter path (less than 46 character)
 or enable long path on windows > 10 (require admin right). Default is True. (Windows only).
+
+Read notes about the particularities of Windows silent mode `/S` in the
+`installer_type` documentation.
 '''),
 
     ('check_path_spaces',     False, bool, '''
 Check if the path where the distribution is installed contains spaces and show a warning
 if any spaces are found. Default is True. (Windows only).
+
+Read notes about the particularities of Windows silent mode `/S` in the
+`installer_type` documentation.
 '''),
 
     ('nsis_template',           False, str, '''

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -171,7 +171,7 @@ Notes for silent mode `/S` on Windows EXEs:
   searched for `::error::` strings. Pre- and post- install scripts will only throw an error
   if the environment variable `NSIS_SCRIPTS_RAISE_ERRORS` is set.
 - The `/D` flag can be used to specify the target location. It must be the last argument in
-  the command and should NEVER be quoted, even if it contains quotes. For example:
+  the command and should NEVER be quoted, even if it contains spaces. For example:
   `CMD.EXE /C START /WAIT myproject.exe /S /D=C:\\path with spaces\\my project`.
 
 [nsis-log]: https://nsis.sourceforge.io/Special_Builds

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -201,12 +201,16 @@ def run_post_install():
     if not os.path.isfile(cmd_exe):
         err("Error: running %s failed.  cmd.exe could not be found.  "
             "Looked in SystemRoot and windir env vars.\n" % path)
+        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
+            sys.exit(1)
     args = [cmd_exe, '/d', '/c', path]
     import subprocess
     try:
         subprocess.check_call(args, env=env)
     except subprocess.CalledProcessError:
         err("Error: running %s failed\n" % path)
+        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
+            sys.exit(1)
 
 
 def run_pre_uninstall():
@@ -224,12 +228,16 @@ def run_pre_uninstall():
     if not os.path.isfile(cmd_exe):
         err("Error: running %s failed.  cmd.exe could not be found.  "
             "Looked in SystemRoot and windir env vars.\n" % path)
+        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
+            sys.exit(1)
     args = [cmd_exe, '/d', '/c', path]
     import subprocess
     try:
         subprocess.check_call(args, env=env)
     except subprocess.CalledProcessError:
         err("Error: running %s failed\n" % path)
+        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
+            sys.exit(1)
 
 
 allusers = (not exists(join(ROOT_PREFIX, '.nonadmin')))

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -160,6 +160,7 @@ Page Custom mui_AnaCustomOptions_Show
 !insertmacro MUI_LANGUAGE "English"
 
 Function SkipPageIfUACInnerInstance
+    ${LogSet} on
     ${If} ${UAC_IsInnerInstance}
         Abort
     ${EndIf}
@@ -226,8 +227,9 @@ FunctionEnd
                 Install for just me, add to PATH and register as system Python:$\n\
                     $EXEFILE /RegisterPython=1 /AddToPath=1$\n$\n\
                 Install for just me, with no registry modification (for CI):$\n\
-                    $EXEFILE /NoRegistry=1$\n"
-                    Abort
+                    $EXEFILE /NoRegistry=1$\n" \
+            /SD IDOK
+            Abort
      ${EndIf}
 
     ClearErrors
@@ -305,11 +307,13 @@ FunctionEnd
 !macroend
 
 Function OnInit_Release
+    ${LogSet} on
     !insertmacro ParseCommandLineArgs
 
 FunctionEnd
 
 Function InstModePage_RadioButton_OnClick
+    ${LogSet} on
     Exch $0
     Push $1
     Push $2
@@ -325,6 +329,7 @@ Function InstModePage_RadioButton_OnClick
 FunctionEnd
 
 Function InstModePage_Create
+    ${LogSet} on
     Push $0
     Push $1
     Push $2
@@ -371,6 +376,7 @@ Function InstModePage_Create
 FunctionEnd
 
 Function DisableBackButtonIfUACInnerInstance
+    ${LogSet} on
     Push $0
     ${If} ${UAC_IsInnerInstance}
         GetDlgItem $0 $HWNDParent 3
@@ -380,6 +386,7 @@ Function DisableBackButtonIfUACInnerInstance
 FunctionEnd
 
 Function RemoveNextBtnShield
+    ${LogSet} on
     Push $0
     GetDlgItem $0 $HWNDParent 1
     SendMessage $0 ${BCM_SETSHIELD} 0 0
@@ -387,6 +394,7 @@ Function RemoveNextBtnShield
 FunctionEnd
 
 Function InstModeChanged
+    ${LogSet} on
     # When using the installer with /S (silent mode), the /D option sets $INSTDIR,
     # and it is therefore important not to overwrite $INSTDIR here, but it is also
     # important that we do call SetShellVarContext with the appropriate value.
@@ -417,6 +425,7 @@ FunctionEnd
 !macroend
 
 Function InstModePage_Leave
+    ${LogSet} on
     Push $0
     Push $1
     Push $2
@@ -457,7 +466,8 @@ Function .onInit
         MessageBox MB_OK|MB_ICONEXCLAMATION \
             "This installer is for a 64-bit version for @NAME@$\n\
             but your system is 32-bit. Please use the 32-bit Windows$\n\
-            @NAME@ installer."
+            @NAME@ installer." \
+            /SD IDOK
         Abort
     ${EndIf}
 #endif
@@ -543,7 +553,8 @@ Function .onInit
         StrCpy $INSTDIR_JUSTME $0
     ${Else}
         # Should never happen; indicates a logic error above.
-        MessageBox MB_OK "Internal error: IsUserDomain not set properly!"
+        MessageBox MB_OK "Internal error: IsUserDomain not set properly!" \
+                   /SD IDOK
         Abort
     ${EndIf}
 
@@ -650,6 +661,7 @@ FunctionEnd
 
 # http://nsis.sourceforge.net/Check_for_spaces_in_a_directory_path
 Function CheckForSpaces
+    ${LogSet} on
     Exch $R0
     Push $R1
     Push $R2
@@ -673,6 +685,7 @@ FunctionEnd
 
 # http://nsis.sourceforge.net/StrCSpn,_StrCSpnReverse:_Scan_strings_for_characters
 Function StrCSpn
+ ${LogSet} on
  Exch $R0 ; string to check
  Exch
  Exch $R1 ; string of chars
@@ -732,10 +745,13 @@ Pop $0
 
 
 Function OnDirectoryLeave
+    ${LogSet} on
     ${If} ${IsNonEmptyDirectory} "$InstDir"
+        DetailPrint "::error:: Directory '$INSTDIR' is not empty, please choose a different location."
         MessageBox MB_OK|MB_ICONEXCLAMATION \
             "Directory '$INSTDIR' is not empty,$\n\
-             please choose a different location."
+             please choose a different location." \
+            /SD IDOK
         Abort
     ${EndIf}
 
@@ -754,15 +770,22 @@ Function OnDirectoryLeave
                 WriteRegDWORD HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled" 1
             ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
             ${Else}
+                DetailPrint "::error:: The installation path should be shorter than 46 characters or \
+                             the installation requires administrator rights to enable long \
+                             path on Windows."
                 MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 46 characters or \
                                               the installation requires administrator rights to enable long \
-                                              path on Windows."
+                                              path on Windows." \
+                           /SD IDOK
                 Abort
             ${EndIf}
         ; If we don't have admin right, we suggest a shorter path or suggest to run with admin right
         ${Else}
+            DetailPrint "::error:: The installation path should be shorter than 46 characters. \
+                         Please choose another location."
             MessageBox MB_OK|MB_ICONSTOP "The installation path should be shorter than 46 characters. \
-                                          Please choose another location."
+                                          Please choose another location." \
+                       /SD IDOK
             Abort
         ${EndIf}
     ${EndIf}
@@ -786,8 +809,12 @@ Function OnDirectoryLeave
         MessageBox MB_OK|MB_ICONINFORMATION \
             "Warning: 'Destination Folder' contains $R0 space$R1.$\n \
              This can cause problems with several Conda packages.$\n \
-             Please consider removing the space$R1."
-
+             Please consider removing the space$R1." \
+            /SD IDOK
+        ${If} ${Silent}
+            DetailPrint "::error:: 'Destination folder' contains $R0 space$R1."
+            abort
+        ${EndIf}
     NoSpaces:
 #endif
 
@@ -798,16 +825,20 @@ Function OnDirectoryLeave
     Pop $R0
 
     StrCmp $R0 "" NoInvalidCharaceters
+        DetailPrint "::error:: 'Destination Folder' contains the following invalid character: $R0"
         MessageBox MB_OK|MB_ICONEXCLAMATION \
-            "Error: 'Destination Folder' contains the following invalid character: $R0"
+            "Error: 'Destination Folder' contains the following invalid character: $R0" \
+            /SD IDOK
         abort
     NoInvalidCharaceters:
 
     UnicodePathTest::SpecialCharPathTest $INSTDIR
     Pop $R1
     StrCmp $R1 "nothingspecial" nothing_special_path
-        messagebox mb_ok|MB_ICONEXCLAMATION \
-            "Error: 'Destination Folder' contains the following invalid character$R1"
+        DetailPrint "::error:: 'Destination Folder' contains the following invalid character$R1"
+        MessageBox MB_OK|MB_ICONEXCLAMATION \
+            "Error: 'Destination Folder' contains the following invalid character$R1" \
+            /SD IDOK
         abort
     nothing_special_path:
 
@@ -822,10 +853,13 @@ Function OnDirectoryLeave
       StrCmp ${PY_VER} "2.7" not_cp_acp_capable
       StrCmp $R1 "ascii_cp_acp" valid_path
       not_cp_acp_capable:
-
-          messagebox mb_ok|MB_ICONEXCLAMATION "Error: Due to incompatibility with several \
+          DetailPrint "::error:: Due to incompatibility with several \
               Python libraries, 'Destination Folder' cannot contain non-ascii characters \
               (special characters or diacritics).  Please choose another location."
+          MessageBox MB_OK|MB_ICONEXCLAMATION "Error: Due to incompatibility with several \
+              Python libraries, 'Destination Folder' cannot contain non-ascii characters \
+              (special characters or diacritics).  Please choose another location." \
+              /SD IDOK
           abort
 
       valid_path:
@@ -834,9 +868,12 @@ Function OnDirectoryLeave
     ${IsWritable} $INSTDIR $R1
     IntCmp $R1 0 pathgood
     Pop $R1
-    MessageBox mb_ok|MB_ICONEXCLAMATION \
+    DetailPrint "::error: Path $INSTDIR is not writable. Please check permissions or \
+                 try respawning the installer with elevated privileges."
+    MessageBox MB_OK|MB_ICONEXCLAMATION \
         "Error: Path $INSTDIR is not writable. Please check permissions or \
-         try respawning the installer with elevated privileges."
+         try respawning the installer with elevated privileges." \
+        /SD IDOK
     Abort
 
     pathgood:
@@ -845,6 +882,7 @@ Function OnDirectoryLeave
 FunctionEnd
 
 Function .onVerifyInstDir
+    ${LogSet} on
     StrLen $0 $Desktop
     StrCpy $0 $INSTDIR $0
     StrCmp $0 $Desktop 0 PathGood
@@ -853,6 +891,7 @@ Function .onVerifyInstDir
 FunctionEnd
 
 Function AbortRetryNSExecWait
+    ${LogSet} on
     Pop $1
     Pop $2
     ${Do}
@@ -877,6 +916,10 @@ FunctionEnd
 # Installer sections
 Section "Install"
     ${LogSet} on
+
+    ${If} ${Silent}
+        call OnDirectoryLeave
+    ${EndIf}
 
     SetOutPath "$INSTDIR\Lib"
     File "@NSIS_DIR@\_nsis.py"

--- a/constructor/osx/preinstall.sh
+++ b/constructor/osx/preinstall.sh
@@ -8,12 +8,17 @@
 # affected by those restrictions, but it's only executed once the installer has begun
 # so the only way to prevent an action is to abort and start again from the beginning.
 
-if [[ -e "$2/__NAME_LOWER__" ]]; then
+PREFIX="$2/__NAME_LOWER__"
+echo "PREFIX=$PREFIX"
+
+if [[ -e "$PREFIX" ]]; then
     # The OS X installer provides no way to send a message to the user if this
     # script fails. So we use AppleScript to do it.
 
     # By default, osascript doesn't allow user interaction, so we have to work
     # around it.  http://stackoverflow.com/a/11874852/161801
+    logger -p "install.info" "ERROR: __PATH_EXISTS_ERROR_TEXT__" || echo "ERROR: __PATH_EXISTS_ERROR_TEXT__"
+
     (osascript -e "try
 tell application (path to frontmost application as text)
 set theAlertText to \"Chosen path already exists!\"
@@ -27,12 +32,12 @@ end")
 fi
 
 # Check if the path has spaces
-case "$2" in
+case "$PREFIX" in
      *\ * )
            (osascript -e "try
 tell application (path to frontmost application as text)
 set theAlertText to \"Chosen path contain spaces!\"
-set theAlertMessage to \"'$2/__NAME_LOWER__' contains spaces. Please, relaunch the installer and choose another location in the Destination Select step.\"
+set theAlertMessage to \"'$PREFIX' contains spaces. Please, relaunch the installer and choose another location in the Destination Select step.\"
 display alert theAlertText message theAlertMessage as critical buttons {\"OK\"} default button {\"OK\"}
 end
 activate app (path to frontmost application as text)

--- a/examples/extra_envs/test_install.bat
+++ b/examples/extra_envs/test_install.bat
@@ -11,9 +11,6 @@ if not exist "%PREFIX%\envs\dav1d\conda-meta\history" exit 1
 if exist "%PREFIX%\envs\dav1d\python.exe" exit 1
 "%PREFIX%\envs\dav1d\Library\bin\dav1d.exe" --version || goto :error
 
-echo "This is an error on purpose"
-exit 1
-
 goto :EOF
 
 :error

--- a/examples/extra_envs/test_install.bat
+++ b/examples/extra_envs/test_install.bat
@@ -11,6 +11,9 @@ if not exist "%PREFIX%\envs\dav1d\conda-meta\history" exit 1
 if exist "%PREFIX%\envs\dav1d\python.exe" exit 1
 "%PREFIX%\envs\dav1d\Library\bin\dav1d.exe" --version || goto :error
 
+echo "This is an error on purpose"
+exit 1
+
 goto :EOF
 
 :error

--- a/news/509-extra-envs
+++ b/news/509-extra-envs
@@ -1,6 +1,6 @@
 ### Enhancements:
 
-* Add support for multi-environment installs via ``extra_envs`` keyword (#359 via #509)
+* Add support for multi-environment installs via ``extra_envs`` keyword (#359 via #509 and #553)
 
 ### Bug fixes:
 

--- a/news/553-fix-windows-ci
+++ b/news/553-fix-windows-ci
@@ -1,10 +1,10 @@
 ### Enhancements:
 
-* A single installer can now provide multiple environments through the ``extra_envs`` key (#359 via #509 and #553)
+* <news item>
 
 ### Bug fixes:
 
-* Windows CI now correctly detects installation problems (#551)
+* Windows CI now correctly detects installation problems (#551 and #560)
 
 ### Deprecations:
 

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -105,7 +105,7 @@ def run_examples(keep_artifacts=None):
             if fpath in tested_files or ext not in ('sh', 'exe', 'pkg'):
                 continue
             tested_files.add(fpath)
-            env_dir = tempfile.mkdtemp(dir=output_dir)
+            env_dir = tempfile.mkdtemp(suffix="s p a c e s", dir=output_dir)
             rm_rf(env_dir)
             print('--- Testing %s' % fpath)
             fpath = os.path.join(output_dir, fpath)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -105,7 +105,7 @@ def run_examples(keep_artifacts=None):
             if fpath in tested_files or ext not in ('sh', 'exe', 'pkg'):
                 continue
             tested_files.add(fpath)
-            env_dir = tempfile.mkdtemp(suffix="s p a c e s", dir=output_dir)
+            env_dir = tempfile.mkdtemp(dir=output_dir)
             rm_rf(env_dir)
             print('--- Testing %s' % fpath)
             fpath = os.path.join(output_dir, fpath)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -9,6 +9,9 @@ import sys
 import tempfile
 import platform
 import shutil
+import time
+from datetime import timedelta
+
 from pathlib import Path
 
 from constructor.utils import rm_rf
@@ -30,15 +33,20 @@ BLACKLIST = []
 
 def _execute(cmd):
     print(' '.join(cmd))
-    p = subprocess.Popen(cmd, stderr=subprocess.PIPE)
-    print('--- STDOUT ---')
-    _, stderr = p.communicate()
-    if stderr:
-        print('--- STDERR ---')
-        if PY3:
-            stderr = stderr.decode()
-        print(stderr.strip())
-    return p.returncode != 0
+    t0 = time.time()
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    stdout, stderr = p.communicate()
+    t1 = time.time()
+    errored = p.returncode != 0
+    if errored:
+        if stdout:
+            print('--- STDOUT ---')
+            print(stdout)
+        if stderr:
+            print('--- STDERR ---')
+            print(stderr)
+    print('--- Done in', timedelta(seconds=t1 - t0))
+    return errored
 
 
 def run_examples(keep_artifacts=None):
@@ -55,9 +63,16 @@ def run_examples(keep_artifacts=None):
     int
         Number of failed examples
     """
+    if sys.platform.startswith("win") and "NSIS_USING_LOG_BUILD" not in os.environ:
+        print(
+            "! Warning !"
+            "  Windows installers are tested with NSIS in silent mode, which does"
+            "  not report errors on exit. You should use logging-enabled NSIS builds"
+            "  to generate an 'install.log' file this script will search for errors"
+            "  after completion."
+        )
     example_paths = []
     errored = 0
-
     if platform.system() != 'Darwin':
         BLACKLIST.append(os.path.join(EXAMPLES_DIR, "osxpkg"))
     if keep_artifacts:
@@ -70,14 +85,21 @@ def run_examples(keep_artifacts=None):
             if os.path.exists(os.path.join(fpath, 'construct.yaml')):
                 example_paths.append(fpath)
 
+    # NSIS won't error out when running scripts unless we set this custom environment variable
+    os.environ["NSIS_SCRIPTS_RAISE_ERRORS"] = "1"
+    
     parent_output = tempfile.mkdtemp()
     tested_files = set()
+    which_errored = {}
     for example_path in sorted(example_paths):
         print(example_path)
         print('-' * len(example_path))
         output_dir = tempfile.mkdtemp(dir=parent_output)
+        # resolve path to avoid some issues with TEMPDIR on Windows
+        output_dir = str(Path(output_dir).resolve())
         cmd = COV_CMD + ['constructor', example_path, '--output-dir', output_dir]
-        errored += _execute(cmd)
+        creation_errored = _execute(cmd)
+        errored += creation_errored
         for fpath in os.listdir(output_dir):
             ext = fpath.rsplit('.', 1)[-1]
             if fpath in tested_files or ext not in ('sh', 'exe', 'pkg'):
@@ -85,7 +107,7 @@ def run_examples(keep_artifacts=None):
             tested_files.add(fpath)
             env_dir = tempfile.mkdtemp(dir=output_dir)
             rm_rf(env_dir)
-            print('---- testing %s' % fpath)
+            print('--- Testing %s' % fpath)
             fpath = os.path.join(output_dir, fpath)
             if ext == 'sh':
                 cmd = ['bash', fpath, '-b', '-p', env_dir]
@@ -100,28 +122,66 @@ def run_examples(keep_artifacts=None):
                     # This command only expands the PKG, but does not install
                     cmd = ['pkgutil', '--expand', fpath, env_dir]
             elif ext == 'exe':
-                cmd = ['cmd.exe', '/c', 'start', '/wait', fpath, '/S', '/D=%s' % env_dir]
+                # NSIS manual:
+                # > /D sets the default installation directory ($INSTDIR), overriding InstallDir and
+                # > InstallDirRegKey. It must be the last parameter used in the command line and must
+                # > not contain any quotes, even if the path contains spaces. Only absolute paths are
+                # > supported.
+                # Since subprocess.Popen WILL escape the spaces with quotes, we need to provide them
+                # as separate arguments. We don't care about multiple spaces collapsing into one, since
+                # the point is to just have spaces in the installation path -- one would be enough too :)
+                # This is why we have this weird .split() thingy down here:
+                cmd = ['cmd.exe', '/c', 'start', '/wait', fpath, '/S', *f'/D={env_dir}'.split()]
             test_errored = _execute(cmd)
+            # Windows EXEs never throw a non-0 exit code, so we need to check the logs,
+            # which are only written if a special NSIS build is used
+            win_error_lines = []
             if ext == 'exe' and os.environ.get("NSIS_USING_LOG_BUILD"):
                 test_errored = 0
-                with open(os.path.join(env_dir, "install.log"), encoding="utf-16-le") as f:
-                    print('---  LOGS  ---')
-                    for line in f:
-                        if ":error:" in line:
-                            print(line.rstrip())
-                            test_errored = 1
+                try:
+                    log_is_empty = True
+                    with open(os.path.join(env_dir, "install.log"), encoding="utf-16-le") as f:
+                        for line in f:
+                            log_is_empty = False
+                            if ":error:" in line:
+                                win_error_lines.append(line)
+                                test_errored = 1
+                    if log_is_empty:
+                        test_errored = 1
+                        win_error_lines.append("Logfile was unexpectedly empty!")
+                except Exception as exc:
+                    test_errored = 1
+                    win_error_lines.append(
+                        f"Could not read logs! {exc.__class__.__name__}: {exc}\n"
+                        "This usually means that the destination folder could not be created.\n"
+                        "Possible causes: permissions, non-supported characters, long paths...\n"
+                        "Consider setting 'check_path_spaces' and 'check_path_length' to 'False'."
+                        )
             errored += test_errored
+            if test_errored:
+                which_errored.setdefault(example_path, []).append(fpath)
+                if win_error_lines:
+                    print('---  LOGS  ---')
+                    for line in win_error_lines:
+                        print(line.rstrip())
+                if ext == "pkg" and os.environ.get("CI"):
+                    # more complete logs are available under /var/log/install.log
+                    print('---  LOGS  ---')
+                    print("Tip: Debug locally and check the full logs in the Installer UI")
+                    print("     or check /var/log/install.log if run from the CLI.")
             if keep_artifacts:
                 shutil.move(fpath, keep_artifacts)
-            # more complete logs are available under /var/log/install.log
-            if test_errored and ext == "pkg" and os.environ.get("CI"):
-                print('---  LOGS  ---')
-                print("Tip: Debug locally and check the full logs in the Installer UI")
-                print("     or check /var/log/install.log if run from the CLI.")
-        print('')
+        if creation_errored:
+            which_errored.setdefault(example_path, []).append("Could not create installer!")
+        print()
 
+    print("-------------------------------")
     if errored:
-        print('Some examples failed!')
+        print('Some examples failed:')
+        for installer, reasons in which_errored.items():
+            print(f"+ {os.path.basename(installer)}")
+            for reason in reasons:
+                print(f"---> {os.path.basename(reason)}")
         print('Assets saved in: %s' % parent_output)
     else:
         print('All examples ran successfully!')


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

(Comes from #449 and extends #553)

We had some issues with the Windows tests:
  - The NSIS installers always exit with a `0` exit code, regardless it worked or failed. Not a good test 😬 
  - The silent mode `/S` on Windows is REALLY silent. Nothing (and I mean _nothing_) gets printed to stdout or stderr. If something fails, it generally keeps going on (the error dialogs are configured to "ignore" in silent mode; check the `/SD` parameter next to each `MessageBox`). 
  - To make things worse, the `conda install` command was _not_ reporting its possible errors via a dialog, so I changed this to throw an error message that aborts the installation. Again, remember, none of these errors get reported to stdout or stderr.
  - What if we manually print to a file then? Enabling log files with _some_ of the output required using a special build for NSIS, which was added in #553. We then slightly modified our error messages to always include the `::error::` sentinel value, which we can `grep` out of the logfile _after_ the installation has concluded. If we find this sentinel value, then we tell `run_examples.py` to report that installation as failed.
  - Note that these errors won't include the output from the failing command. That output will only appear on the GUI logs due to `nsExec` limitations.  In other words, CI will only report whether the error occurred, but further debugging needs to be done locally on a Windows machine with desktop and graphical installer.
  - Another note: errors due to path issues (spaces if enabled, unicode, permissions, etc) won't appear in the logfile because the destination path does not exist yet at that. Hence, a `FileNotFoundError` could mean an issue with the paths.
  - Lastly, `_nsis.py` was not reporting the error code of the scripts it was running (pre-uninstall or post-install). This might have been done on purpose, so I didn't want to change that default behaviour. Instead, it will only report subprocess errors (via exit code) if a special environment variable is set. We are setting it in our CI, since end users might not need it. That said, I am open to changing this conservative decision and leave it as "always tell me if something went wrong".
  - 
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
