### PR TITLE
Use `CMD /D /C` to be more resilient against Windows registry issues

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1096,7 +1096,7 @@ Section "Uninstall"
     !insertmacro ExecWaitLibNsisCmd "rmpath"
     !insertmacro ExecWaitLibNsisCmd "rmreg"
     DetailPrint "Removing files and folders..."
-    nsExec::Exec 'cmd.exe /k RMDIR /Q/S "$INSTDIR"'
+    nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR"'
 
     # In case the last command fails, run the slow method to remove leftover
     RMDir /r /REBOOTOK "$INSTDIR"

--- a/news/566-prevent-cmd-errors
+++ b/news/566-prevent-cmd-errors
@@ -1,0 +1,20 @@
+### Enhancements:
+
+* <news item>
+
+### Bug fixes:
+
+* Make sure `cmd` calls in the Windows uninstaller use `/D` for added resilience against Registry issues (#566)
+
+### Deprecations:
+
+* <news item>
+
+### Docs:
+
+* <news item>
+
+### Other:
+
+* <news item>
+


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


Addresses extra concerns raised in #561 

This PR makes that last `cmd` call a bit more robust against registry issues similar to #521. The `/D` flag makes CMD run without executing the `AutoRun` directives in the Windows registry. `/C` is preferred to `/K` because there's no need to <b>k</b>eep the CMD process open in the background. Note that `nsExec` will wait for the process to complete, regardless.

Given your work on https://github.com/conda/constructor/pull/467, @ericpre: do you agree with this assessment? I don't want to undo any advances in this area in case `/K` was chosen over `/C` deliberately.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
