### PR TITLE
Fix tk grep tests

### DIFF
--- a/examples/extra_envs/test_install.sh
+++ b/examples/extra_envs/test_install.sh
@@ -13,7 +13,7 @@ test -f "$PREFIX/conda-meta/history"
 "$PREFIX/bin/python" -c "from sys import version_info; assert version_info[:2] == (3, 7)"
 "$PREFIX/bin/pip" -V
 # tk(inter) shouldn't be listed by conda!
-"$PREFIX/bin/conda" list -p "$PREFIX" | grep tk && exit 1
+"$PREFIX/bin/conda" list -p "$PREFIX" | grep -E '^tk\s+' && exit 1
 echo "Previous test failed as expected"
 
 # extra env named 'py38' uses python 3.8, has tk, but we removed setuptools

--- a/examples/extra_envs/test_install.sh
+++ b/examples/extra_envs/test_install.sh
@@ -13,14 +13,14 @@ test -f "$PREFIX/conda-meta/history"
 "$PREFIX/bin/python" -c "from sys import version_info; assert version_info[:2] == (3, 7)"
 "$PREFIX/bin/pip" -V
 # tk(inter) shouldn't be listed by conda!
-"$PREFIX/bin/conda" list -p "$PREFIX" | grep -E '^tk\s+' && exit 1
+"$PREFIX/bin/conda" list -p "$PREFIX" | jq -e '.[] | select(.name == "tk")' && exit 1
 echo "Previous test failed as expected"
 
 # extra env named 'py38' uses python 3.8, has tk, but we removed setuptools
 test -f "$PREFIX/envs/py38/conda-meta/history"
 "$PREFIX/envs/py38/bin/python" -c "from sys import version_info; assert version_info[:2] == (3, 8)"
 # setuptools shouldn't be listed by conda!
-"$PREFIX/bin/conda" list -p "$PREFIX/envs/py38" | grep setuptools && exit 1
+"$PREFIX/bin/conda" list -p "$PREFIX/envs/py38" | jq -e '.[] | select(.name == "setuptools")' && exit 1
 "$PREFIX/envs/py38/bin/python" -c "import setuptools" && exit 1
 echo "Previous test failed as expected"
 

--- a/news/570-fix-tk-tests
+++ b/news/570-fix-tk-tests
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix tests that check for the presence of the `tk` package in a given environment (#570)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


In the `extra_envs` example we check that we can indeed exclude `tk` from the installed packages in the `base` environment. For that we pipe `conda list` into `grep` and check if we match a line with `tk`. However the query can also match the temporary path of the environment if we are unlucky enough to have a `$TMP` that contains `*tk*` in it. This the reason why some tests are failing in the opened PRs. To fix it, we will instead use `--json` plus `jq` to find keys more robustly.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
