### PR TITLE
Fix windows CI, update actions versions due to deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build the build environment
         run: |
-          [ $RUNNER_OS = 'Windows' ] && CONDA_EXE=$CONDA/Scripts/conda.exe
+          source $CONDA/etc/profile.d/conda.sh
           [ $RUNNER_OS == macOS ] && export CONDA_PKGS_DIRS=~/.pkgs
-          ${CONDA_EXE:-conda} create -p ../conda conda conda-build conda-verify
+          conda create -p ../conda conda-build conda-verify
       - name: Build the package
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -53,7 +53,8 @@ jobs:
           # Uncomment to run within conda build
           # RUN_EXAMPLES: "1"
         run: |
-          source ../conda/etc/profile.d/conda.sh
+          source $CONDA/etc/profile.d/conda.sh
+          conda activate ../conda
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda build conda.recipe --python=${{ matrix.pyver }}
@@ -67,7 +68,7 @@ jobs:
           path: ${{ runner.temp }}/conda-bld/*/*.tar.bz2
       - name: Install local constructor
         run: |
-          source ../conda/etc/profile.d/conda.sh
+          source $CONDA/etc/profile.d/conda.sh
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda create -n constructor -c local --strict-channel-priority constructor
           conda activate constructor
@@ -82,7 +83,7 @@ jobs:
       - name: Patch NSIS to use logging builds on Windows
         if: startsWith(matrix.os, 'windows')
         run: |
-          source ../conda/etc/profile.d/conda.sh
+          source $CONDA/etc/profile.d/conda.sh
           conda activate constructor
           nsis_version=$(conda list nsis --json | jq -r ".[].version")
           curl -sL "https://sourceforge.net/projects/nsis/files/NSIS%203/${nsis_version}/nsis-${nsis_version}-log.zip/download" -o "nsis-${nsis_version}-log.zip"
@@ -102,7 +103,7 @@ jobs:
           echo CONSTRUCTOR_SIGNTOOL_PATH=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe>> %GITHUB_ENV%
       - name: Run examples and prepare artifacts
         run: |
-          source ../conda/etc/profile.d/conda.sh
+          source $CONDA/etc/profile.d/conda.sh
           conda activate constructor
           mkdir -p examples_artifacts/
           python scripts/run_examples.py --keep-artifacts=examples_artifacts/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
           echo "TMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
       - name: Retrieve the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -59,7 +59,7 @@ jobs:
             conda build conda.recipe --python=${{ matrix.pyver }}
       - name: Upload the packages as artifact
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # By uploading to the same artifact we can download all of the packages
           # and upload them all to anaconda.org in a single job
@@ -108,7 +108,7 @@ jobs:
           python scripts/run_examples.py --keep-artifacts=examples_artifacts/
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request' && matrix.pyver == '3.9'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: installers-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: examples_artifacts/
@@ -120,11 +120,11 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Retrieve the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Download the build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: package-${{ github.sha }}
           path: conda-bld
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install local constructor


### PR DESCRIPTION
Fixes the windows CI errors seen in newer PRs, like https://github.com/conda/constructor/pull/584 see https://github.com/conda/constructor/actions/runs/3632433992/jobs/6146176269

Error in the `Build the package` step on windows:
```
Run source ../conda/etc/profile.d/conda.sh
../conda/etc/profile.d/conda.sh: line 10: /cygdrive/c/b/abs_67xozs_u6y/croot/conda_1670407450197/_h_env/Scripts/conda.exe: No such file or directory
Error: Process completed with exit code 127.
``` 

Also fixes the deprecation warnings coming from old action versions:
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2
