### PR TITLE
Fixed indentation in env.txt header

### DIFF
--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -227,8 +227,8 @@ def write_env_txt(info, dst_dir, urls):
         # $ conda create --name <env> --file <this file>
         # platform: {info['_platform']}
         @EXPLICIT
-        """.lstrip()
-    )
+        """
+    ).lstrip()
     with open(join(dst_dir, "env.txt"), "w") as envf:
         envf.write(header)
         envf.write('\n'.join([f"{url}#{md5}" for url, md5 in urls]))


### PR DESCRIPTION
### Description

The header for the `env.txt` file that is generated in `write_env_txt()` contains leading whitespace that `libmamba` is not able to parse. This causes it to use a blank string for a matchspec, resulting in the following critical error:

`critical libmamba Invalid spec, no package name found:`

This issue occurs because `lstrip()` is called on a multi-line f-string before `dedent()`, which causes leading whitespace to only be removed up to the beginning of the first non-blank line. Calling `dedent()` _before_ `lstrip()` will ensure all leading whitespace is stripped out for all lines.

Without this fix, the `header` in `write_env_txt()` is written out as:

```
# This file may be used to create an environment using:
        # $ conda create --name <env> --file <this file>
        # platform: osx-arm64
        @EXPLICIT
```

After the fix, the `header` is written out without leading whitespace:

```
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-arm64
@EXPLICIT
```

