### PR TITLE
Add new 'build_outputs' key for non-installer artifacts

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -644,6 +644,20 @@ This setting can be passed as a list of:
 - `str`: each found file will be copied to the root prefix
 - `Mapping[str, str]`: map of path in disk to path in prefix.
 
+## `build_outputs`
+
+_required:_ no<br/>
+_type:_ list<br/>
+Additional artifacts to be produced after building the installer.
+It expects either a list of strings or single-key dictionaries:
+Allowed keys are:
+- `info.json`: The internal `info` object, serialized to JSON. Takes no options.
+- `pkgs_list`: The list of packages contained in a given environment. Options:
+    - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
+- `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
+    - `include_text` (optional, default=`False`): Whether to dump the license text in the JSON.
+      If false, only the path will be included.
+
 
 ## Available selectors
 

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -1,0 +1,86 @@
+"""
+Additional artifacts to be produced after building the installer.
+
+Update documentation in `construct.py` if any changes are made.
+"""
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+
+
+def _validate_output(output):
+    if isinstance(output, str):
+        output = {output: None}
+    if not isinstance(output, dict):
+        raise ValueError("'build_outputs' must be a list of str or a list of dicts.")
+    if len(output) > 1:
+        raise ValueError("'build_outputs' dicts can only have one key.")
+    return {key: (value or {}) for (key, value) in output.items()}
+
+
+def process_build_outputs(info):
+    for output in info.get("build_outputs", ()):
+        output = _validate_output(output)
+        name, config = output.popitem()
+        handler = OUTPUT_HANDLERS.get(name)
+        if not handler:
+            raise ValueError(
+                f"'output_builds' key {name} is not recognized! "
+                f"Available keys: {tuple(OUTPUT_HANDLERS.keys())}"
+            )
+        outpath = handler(info, **config)
+        print(f"build_outputs: '{name}' created '{os.path.abspath(outpath)}'.")
+
+
+def dump_info(info):
+    outpath = os.path.join(info["_output_dir"], "info.json")
+    with open(outpath, "w") as f:
+        json.dump(info, f, indent=2, default=repr)
+    return outpath
+
+
+def dump_packages_list(info, env="base"):
+    if env == "base":
+        dists = info["_dists"]
+    elif env in info["_extra_envs_info"]:
+        dists = info["_extra_envs_info"][env]["_dists"]
+    else:
+        raise ValueError(f"env='{env}' is not a valid env name.")
+
+    outpath = os.path.join(info["_output_dir"], f'pkg-list.{env}.txt')
+    with open(outpath, 'w') as fo:
+        fo.write(f"# {info['name']} {info['version']}, env={env}\n")
+        fo.write("\n".join(dists))
+    return outpath
+
+
+def dump_licenses(info, include_text=False):
+    licenses = defaultdict(dict)
+    for pkg_record in info["_all_pkg_records"]:
+        extracted_package_dir = pkg_record.extracted_package_dir
+        licenses_dir = os.path.join(extracted_package_dir, "info", "licenses")
+        licenses[pkg_record.dist_str()]["type"] = pkg_record.license
+        licenses[pkg_record.dist_str()]["files"] = license_files = []
+        if not os.path.isdir(licenses_dir):
+            continue
+
+        for directory, _, files in os.walk(licenses_dir):
+            for filepath in files:
+                license_path = os.path.join(directory, filepath)
+                license_file = {"path": license_path}
+                if include_text:
+                    license_file["text"] = Path(license_path).read_text()
+                license_files.append(license_file)
+    
+    outpath = os.path.join(info["_output_dir"], "licenses.json")
+    with open(outpath, "w") as f:
+        json.dump(licenses, f, indent=2, default=repr)
+    return outpath
+
+
+OUTPUT_HANDLERS = {
+    "info.json": dump_info,
+    "pkgs_list": dump_packages_list,
+    "licenses": dump_licenses,
+}

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -521,7 +521,7 @@ Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
-- `pkgs-list`: The list of packages contained in a given environment. Options:
+- `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
     - `include_text` (optional, default=`False`): Whether to dump the license text in the JSON.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -515,6 +515,18 @@ This setting can be passed as a list of:
 - `str`: each found file will be copied to the root prefix
 - `Mapping[str, str]`: map of path in disk to path in prefix.
 '''),
+
+    ('build_outputs', False, list, '''
+Additional artifacts to be produced after building the installer.
+It expects either a list of strings or single-key dictionaries:
+Allowed keys are:
+- `info.json`: The internal `info` object, serialized to JSON. Takes no options.
+- `pkgs-list`: The list of packages contained in a given environment. Options:
+    - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
+- `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
+    - `include_text` (optional, default=`False`): Whether to dump the license text in the JSON.
+      If false, only the path will be included.
+''')
 ]
 
 

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -396,7 +396,7 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
             extra_env=True,
         )
     if dry_run:
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None
     pc_recs, _urls, dists, has_conda = _fetch_precs(
         precs, download_dir, transmute_file_type=transmute_file_type
     )
@@ -420,8 +420,15 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
         pc_recs, platform, duplicate_files=duplicate_files
     )
 
-    return _urls, dists, approx_tarballs_size, approx_pkgs_size, has_conda, extra_envs_data
-
+    return (
+        all_pc_recs,
+        _urls,
+        dists,
+        approx_tarballs_size,
+        approx_pkgs_size,
+        has_conda,
+        extra_envs_data
+    )
 
 def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
     name = info["name"]
@@ -456,13 +463,14 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
         conda_context.proxy_servers = proxy_servers
         conda_context.ssl_verify = ssl_verify
 
-        (_urls, dists, approx_tarballs_size, approx_pkgs_size,
+        (pkg_records, _urls, dists, approx_tarballs_size, approx_pkgs_size,
         has_conda, extra_envs_info) = _main(
             name, version, download_dir, platform, channel_urls, channels_remap, specs,
             exclude, menu_packages, ignore_duplicate_files, environment, environment_file,
             verbose, dry_run, conda_exe, transmute_file_type, extra_envs
         )
 
+    info["_all_pkg_records"] = pkg_records  # full PackageRecord objects
     info["_urls"] = _urls  # needed to mock the repodata cache
     info["_dists"] = dists  # needed to tell conda what to install
     info["_approx_tarballs_size"] = approx_tarballs_size

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -12,6 +12,7 @@ import sys
 import argparse
 from textwrap import dedent, indent
 
+from .build_outputs import process_build_outputs
 from .conda_interface import cc_platform
 from .construct import parse as construct_parse, verify as construct_verify, \
     generate_key_info_list, ns_platform
@@ -76,6 +77,8 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     construct_path = join(dir_path, 'construct.yaml')
     info = construct_parse(construct_path, platform)
     construct_verify(info)
+    info['_input_dir'] = dir_path
+    info['_output_dir'] = output_dir
     info['_platform'] = platform
     info['_download_dir'] = join(cache_dir, platform)
     info['_conda_exe'] = abspath(conda_exe)
@@ -139,7 +142,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     info['installer_type'] = itypes[0]
     fcp_main(info, verbose=verbose, dry_run=dry_run, conda_exe=conda_exe)
     if dry_run:
-        print("Dry run, no installer created.")
+        print("Dry run, no installers or build outputs created.")
         return
 
     # info has keys
@@ -165,17 +168,8 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
         info['_outpath'] = abspath(join(output_dir, get_output_filename(info)))
         create(info, verbose=verbose)
         print("Successfully created '%(_outpath)s'." % info)
-    if 0:
-        with open(join(output_dir, 'pkg-list.txt'), 'w') as fo:
-            fo.write('# installer: %s\n' % basename(info['_outpath']))
-            for dist in info['_dists']:
-                fo.write('%s\n' % dist)
-            for env_name, env_info in info["_extra_envs_info"].items():
-                fo.write(f"# extra_env: {env_name}\n")
-                for dist_ in env_info["_dists"]:
-                    fo.write('%s\n' % dist_)
-
-
+    
+    process_build_outputs(info)
 
 class _HelpConstructAction(argparse.Action):
     def __init__(

--- a/examples/extra_envs/construct.yaml
+++ b/examples/extra_envs/construct.yaml
@@ -23,3 +23,9 @@ extra_envs:
 
 post_install: test_install.sh  # [unix]
 post_install: test_install.bat  # [win]
+build_outputs:
+  - info.json
+  - pkgs_list
+  - pkgs_list:
+      env: py38
+  - licenses

--- a/news/595-extra-outputs
+++ b/news/595-extra-outputs
@@ -1,0 +1,20 @@
+### Enhancements
+
+* A new key `build_outputs` allows to generate extra artifacts besides the installer,
+  like JSON metadata files, solved environments lock files, or licensing reports (#595).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->


Supersedes https://github.com/conda/constructor/pull/508, with better control of what's produced, and without affecting conda's verbosity.

This introduces a new key, `build_outputs`, which takes a list of "plugin" names (and optionally their configurations). Each plugin (as defined in `build_outputs.py`) is allowed to generate one or more "non-installer" artifacts, like JSON files or text files.

This allows us to ask `constructor` for additional metadata usually not available:
- The internal `info` dictionary
- The solved environments
- Included licenses (super convenient for legal audits of the generated artifacts).

I've designed in a way that it can be extended with more outputs if needed. For example, one common need in corporate environments: CVE scans (although this possibly involves external tooling, which is a bit too much maybe).

I was a bit unsure about the `build_outputs` name (I also considered `build_artifacts` or `extra_outputs`), so I welcome suggestions if there are any.