### PR TITLE
Add `text_errors` option to `build_outputs.licenses`

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -655,8 +655,11 @@ Allowed keys are:
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
-    - `include_text` (optional, default=`False`): Whether to dump the license text in the JSON.
+    - `include_text` (optional bool, default=`False`): Whether to dump the license text in the JSON.
       If false, only the path will be included.
+    - `text_errors` (optional str, default=`None`): How to handle decoding errors when reading the
+      license text. Only relevant if include_text is True. Any str accepted by open()'s 'errors' 
+      argument is valid. See https://docs.python.org/3/library/functions.html#open.
 
 
 ## Available selectors

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -524,8 +524,11 @@ Allowed keys are:
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
-    - `include_text` (optional, default=`False`): Whether to dump the license text in the JSON.
+    - `include_text` (optional bool, default=`False`): Whether to dump the license text in the JSON.
       If false, only the path will be included.
+    - `text_errors` (optional str, default=`None`): How to handle decoding errors when reading the
+      license text. Only relevant if include_text is True. Any str accepted by open()'s 'errors' 
+      argument is valid. See https://docs.python.org/3/library/functions.html#open.
 ''')
 ]
 

--- a/examples/extra_envs/construct.yaml
+++ b/examples/extra_envs/construct.yaml
@@ -28,4 +28,6 @@ build_outputs:
   - pkgs_list
   - pkgs_list:
       env: py38
-  - licenses
+  - licenses:
+      include_text: True
+      text_errors: replace

--- a/news/595-extra-outputs
+++ b/news/595-extra-outputs
@@ -1,7 +1,7 @@
 ### Enhancements
 
 * A new key `build_outputs` allows to generate extra artifacts besides the installer,
-  like JSON metadata files, solved environments lock files, or licensing reports (#595).
+  like JSON metadata files, solved environments lock files, or licensing reports (#595, #602).
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Continued work from #595

Some bundled license texts can be malformed, which leads to decoding errors. ([see examples on Windows here](https://github.com/napari/packaging/actions/runs/3884299816/jobs/6626915682#step:14:14906)). This allows users to specify how to handle that through the `open()` `errors` argument directly. Normally, you'd set this to `replace`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
