### PR TITLE
Set "python_requires='>=3.7'" and apply pyupgrade via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
       - id: mixed-line-ending
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus", "--keep-percent-format"]
+        exclude: ^(constructor/nsis/.*py)
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:

--- a/constructor/__main__.py
+++ b/constructor/__main__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 if __name__ == '__main__':
     import sys
     from constructor.main import main

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import json
 import os
 import sys

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -326,21 +326,21 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 `%INSTALLER_TYPE%` is set to `EXE`.
 '''),
 
-    ('default_prefix',         False, str, '''
+    ('default_prefix',         False, str, r'''
 Set default install prefix. On Linux, if not provided, the default prefix is
 `${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
 for "All Users" installation, use the `default_prefix_all_users` key.
 If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
 '''),  # noqa
 
-    ('default_prefix_domain_user', False, str, '''
+    ('default_prefix_domain_user', False, str, r'''
 Set default installation prefix for domain user. If not provided, the
 installation prefix for domain user will be `${LOCALAPPDATA}\${NAME}`.
 By default, it is different from the `default_prefix` value to avoid installing
 the distribution in the roaming profile. Windows only.
 '''),  # noqa
 
-    ('default_prefix_all_users', False, str, '''
+    ('default_prefix_all_users', False, str, r'''
 Set default installation prefix for All Users installation. If not provided,
 the installation prefix for all users installation will be
 `${ALLUSERSPROFILE}\${NAME}`. Windows only.
@@ -672,7 +672,7 @@ def parse(path, platform):
     try:
         with open(path) as fi:
             data = fi.read()
-    except IOError:
+    except OSError:
         sys.exit("Error: could not open '%s' for reading" % path)
     directory = dirname(path)
     content_filter = partial(select_lines, namespace=ns_platform(platform))

--- a/constructor/exceptions.py
+++ b/constructor/exceptions.py
@@ -13,7 +13,7 @@ class YamlParsingError(Exception):
 
 class UnableToParse(YamlParsingError):
     def __init__(self, original, *args, **kwargs):
-        super(UnableToParse, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.original = original
 
     def error_msg(self):
@@ -31,13 +31,13 @@ class UnableToParse(YamlParsingError):
     def indented_exception(self):
         orig = str(self.original)
         def indent(s): return s.replace("\n", "\n--> ")
-        return "Error Message:\n--> {}\n\n".format(indent(orig))
+        return f"Error Message:\n--> {indent(orig)}\n\n"
 
 
 class UnableToParseMissingJinja2(UnableToParse):
     def error_body(self):
         return "\n".join([
-            super(UnableToParseMissingJinja2, self).error_body(),
+            super().error_body(),
             indent("""\
                 It appears you are missing jinja2.  Please install that
                 package, then attempt to build.

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -6,7 +6,6 @@
 """
 fcp (fetch conda packages) module
 """
-from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
 import json
@@ -39,7 +38,7 @@ def getsize(filename):
 
 
 def warn_menu_packages_missing(precs, menu_packages):
-    all_names = set(prec.name for prec in precs)
+    all_names = {prec.name for prec in precs}
     for name in menu_packages:
         if name not in all_names:
             print("WARNING: no such package (in menu_packages): %s" % name)
@@ -183,9 +182,9 @@ def check_duplicates_files(pc_recs, platform, duplicate_files="error"):
             msg_str = "File '%s' found in multiple packages: %s" % (
                     member, ', '.join(fns))
             if duplicate_files == "warn":
-                print('Warning: {}'.format(msg_str))
+                print(f'Warning: {msg_str}')
             else:
-                sys.exit('Error: {}'.format(msg_str))
+                sys.exit(f'Error: {msg_str}')
 
     for member in map_members_icase:
         # Some filesystems are not case sensitive by default (e.g HFS)
@@ -198,9 +197,9 @@ def check_duplicates_files(pc_recs, platform, duplicate_files="error"):
             msg_str = "Files %s found in the package(s): %s" % (
                 str(files)[1:-1], ', '.join(fns))
             if duplicate_files == "warn" or platform.startswith('linux'):
-                print('Warning: {}'.format(msg_str))
+                print(f'Warning: {msg_str}')
             else:
-                sys.exit('Error: {}'.format(msg_str))
+                sys.exit(f'Error: {msg_str}')
 
     return total_tarball_size, total_extracted_pkgs_size
 
@@ -217,7 +216,7 @@ def _precs_from_environment(environment, download_dir, user_conda):
     # creating a tuple of dist_name, URL, MD5, filename (fn)
     explicit = check_output([user_conda, "list", list_flag, environment,
                              "--explicit", "--json", "--md5"],
-                            universal_newlines=True)
+                            text=True)
     ordering = []
     for line in explicit.splitlines():
         if not line or line.startswith("#") or line.startswith("@"):

--- a/constructor/imaging.py
+++ b/constructor/imaging.py
@@ -105,7 +105,7 @@ def write_images(info, dir_path, os="windows"):
             ('welcome', welcome_size_osx, mk_welcome_image_osx, '.png'),
         ]
     else:
-        raise ValueError("OS {} not supported. Choose `windows` or `osx`.".format(os))
+        raise ValueError(f"OS {os} not supported. Choose `windows` or `osx`.")
 
     for name, size, function, ext in instructions:
         key = name + '_image'

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -4,7 +4,6 @@
 # constructor is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
-from __future__ import absolute_import, division, print_function
 
 import os
 from os.path import abspath, expanduser, isdir, join
@@ -293,7 +292,7 @@ def main():
     p.add_argument('-V', '--version',
                    help="display the version being used and exit",
                    action="version",
-                   version='%(prog)s {version}'.format(version=__version__))
+                   version=f'%(prog)s {__version__}')
 
     p.add_argument('--conda-exe',
                    help="path to conda executable (conda-standalone, micromamba)",

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -204,7 +204,7 @@ def write_repodata_record(info, dst_dir):
         record_file = join(_dist, 'info', 'repodata_record.json')
         record_file_src = join(info['_download_dir'], record_file)
 
-        with open(record_file_src, 'r') as rf:
+        with open(record_file_src) as rf:
             rr_json = json.load(rf)
 
         rr_json['url'] = get_final_url(info, rr_json['url'])

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -4,7 +4,6 @@
 # constructor is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
-from __future__ import absolute_import, division, print_function
 
 import os
 from os.path import basename, dirname, getsize, isdir, join, relpath

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -184,7 +184,7 @@ def rm_rf(path):
             unlink(path)
         elif isdir(path):
             rmtree(path)
-    except (OSError, IOError):
+    except OSError:
         pass
 
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -4,7 +4,6 @@
 # constructor is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
-from __future__ import absolute_import, division, print_function
 
 import os
 from os.path import abspath, dirname, isfile, join
@@ -93,7 +92,7 @@ def custom_nsi_insert_from_file(filepath: os.PathLike) -> str:
 
 
 def setup_envs_commands(info, dir_path):
-    template = """
+    template = r"""
         # Set up {name} env
         SetDetailsPrint TextOnly
         DetailPrint "Setting up the {name} environment ..."
@@ -407,7 +406,7 @@ def create(info, verbose=False):
     verbosity = f"{'/' if sys.platform == 'win32' else '-'}V{4 if verbose else 2}"
     args = [MAKENSIS_EXE, verbosity, nsi]
     print('Calling: %s' % args)
-    process = run(args, stdout=PIPE, stderr=PIPE, text=True)
+    process = run(args, capture_output=True, text=True)
     if verbose:
         print("makensis stdout:", process.stdout, sep="\n")
         print("makensis stderr:", process.stderr, sep="\n")

--- a/news/606-require-py37
+++ b/news/606-require-py37
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Officially require Python>=3.7 via setup.py. Older Python versions are EOL and not part of the test matrix since #479.
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/606-require-py37
+++ b/news/606-require-py37
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Officially require Python>=3.7 via setup.py. Older Python versions are EOL and not part of the test matrix since #479.
+* Officially require Python>=3.7 via setup.py. Older Python versions are EOL and not part of the test matrix since #479. (#606)
 
 ### Docs
 


### PR DESCRIPTION
Python versions <3.7 are not supported and also got removed from the test matrix since a while. Stating this in the setup.py makes this more clear.

pyupgrade: Removes future imports, updates to f-strings, removes utf-8 pragmas (utf8 is default in py3), updates exceptions which are aliases and more.

pyupgrade was also applied without issues to conda/conda-build/conda-pack.

No logic changes.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
