### PR TITLE
Cache header.sh and use loops to speedup unit tests

### DIFF
--- a/news/625-speedup-test
+++ b/news/625-speedup-test
@@ -1,3 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
 ### Other
 
 * Speedup unit tests by factor 5. (#625)

--- a/news/625-speedup-test
+++ b/news/625-speedup-test
@@ -1,0 +1,3 @@
+### Other
+
+* Speedup unit tests by factor 5. (#625)

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -92,7 +92,7 @@ def test_linux_template_processing():
                 errors.append(f"Found '{template_string}' after "
                               f"processing header.sh with '{params}'.")
 
-    assert errors == []
+    assert not errors
 
 
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,3 +1,4 @@
+import itertools
 from functools import lru_cache
 from pathlib import Path
 import subprocess
@@ -33,48 +34,65 @@ def run_shellcheck(script):
     return findings, p.returncode
 
 
-@pytest.mark.parametrize('osx', [False, True])
-@pytest.mark.parametrize('direct_execute_post_install', [False, True])
-@pytest.mark.parametrize('direct_execute_pre_install', [False, True])
-@pytest.mark.parametrize('batch_mode', [False, True])
-@pytest.mark.parametrize('keep_pkgs', [False, True])
-@pytest.mark.parametrize('has_conda', [False, True])
-@pytest.mark.parametrize('has_license', [False, True])
-@pytest.mark.parametrize('initialize_conda', [False, True])
-@pytest.mark.parametrize('initialize_by_default', [False, True])
-@pytest.mark.parametrize('has_post_install', [False, True])
-@pytest.mark.parametrize('has_pre_install', [False, True])
-@pytest.mark.parametrize('check_path_spaces', [False, True])
-@pytest.mark.parametrize('arch', ['x86', 'x86_64', ' ppc64le', 's390x', 'aarch64'])
-def test_linux_template_processing(
-        osx, arch, has_pre_install, has_post_install, initialize_conda,
-        initialize_by_default, has_license, has_conda, keep_pkgs, batch_mode,
-        direct_execute_pre_install, direct_execute_post_install, check_path_spaces):
+def test_linux_template_processing():
     template = read_header_template()
-    processed = preprocess(template, {
-       'has_license': has_license,
-       'osx': osx,
-       'batch_mode': batch_mode,
-       'keep_pkgs': keep_pkgs,
-       'has_conda': has_conda,
-       'x86': arch == 'x86',
-       'x86_64': arch == 'x86_64',
-       'ppc64le': arch == 'ppc64le',
-       's390x': arch == 's390x',
-       'aarch64': arch == 'aarch64',
-       'linux': not osx,
-       'has_pre_install': has_pre_install,
-       'direct_execute_pre_install': direct_execute_pre_install,
-       'has_post_install': has_post_install,
-       'direct_execute_post_install': direct_execute_post_install,
-       'initialize_conda': initialize_conda,
-       'initialize_by_default': initialize_by_default,
-       'check_path_spaces': check_path_spaces,
+    errors = []
+    for (
+        osx,
+        direct_execute_post_install,
+        direct_execute_pre_install,
+        batch_mode,
+        keep_pkgs,
+        has_conda,
+        has_license,
+        initialize_conda,
+        initialize_by_default,
+        has_post_install,
+        has_pre_install,
+        check_path_spaces,
+        arch,
+    ) in itertools.product(
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        [False, True],
+        ["x86", "x86_64", " ppc64le", "s390x", "aarch64"],
+    ):
+        params = {
+            "has_license": has_license,
+            "osx": osx,
+            "batch_mode": batch_mode,
+            "keep_pkgs": keep_pkgs,
+            "has_conda": has_conda,
+            "x86": arch == "x86",
+            "x86_64": arch == "x86_64",
+            "ppc64le": arch == "ppc64le",
+            "s390x": arch == "s390x",
+            "aarch64": arch == "aarch64",
+            "linux": not osx,
+            "has_pre_install": has_pre_install,
+            "direct_execute_pre_install": direct_execute_pre_install,
+            "has_post_install": has_post_install,
+            "direct_execute_post_install": direct_execute_post_install,
+            "initialize_conda": initialize_conda,
+            "initialize_by_default": initialize_by_default,
+            "check_path_spaces": check_path_spaces,
+        }
+        processed = preprocess(template, params)
+        for template_string in ["#if", "#else", "#endif"]:
+            if template_string in processed:
+                errors.append(f"Found '{template_string}' after "
+                              f"processing header.sh with '{params}'.")
 
-    })
-    assert '#if' not in processed
-    assert '#else' not in processed
-    assert '#endif' not in processed
+    assert errors == []
 
 
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])


### PR DESCRIPTION
### Description

The test case `test_linux_template_processing` was producing ~20k test cases by being parametrised via lots of parameters and `@pytest.mark.parametrize`.  A lot of execution time was spent by pytest for orchestrating that many tests. By turning the parameters into a loop, the test cases could be reduced to 67 and the overall execution time from ~4:30 to 47 sec (macOS), ~2:15 to 22 sec (linux), 4:30 to 38 sec (windows).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
