### PR TITLE
Burn-in constructor version into installers

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# Created by constructor __CONSTRUCTOR_VERSION__
+#
 # NAME:  __NAME__
 # VER:   __VERSION__
 # PLAT:  __PLAT__

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -76,6 +76,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     construct_path = join(dir_path, 'construct.yaml')
     info = construct_parse(construct_path, platform)
     construct_verify(info)
+    info['CONSTRUCTOR_VERSION'] = __version__
     info['_input_dir'] = dir_path
     info['_output_dir'] = output_dir
     info['_platform'] = platform

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -47,6 +47,7 @@ Unicode "true"
 !define COMPANY __COMPANY__
 !define ARCH __ARCH__
 !define PLATFORM __PLATFORM__
+!define CONSTRUCTOR_VERSION __CONSTRUCTOR_VERSION__
 !define PY_VER __PY_VER__
 !define PYVERSION_JUSTDIGITS __PYVERSION_JUSTDIGITS__
 !define PYVERSION __PYVERSION__
@@ -117,6 +118,7 @@ VIAddVersionKey "ProductVersion" "${VERSION}"
 VIAddVersionKey "CompanyName" "${COMPANY}"
 VIAddVersionKey "LegalCopyright" "(c) ${COMPANY}"
 VIAddVersionKey "FileDescription" "${NAME} Installer"
+VIAddVersionKey "Comments" "Created by constructor ${CONSTRUCTOR_VERSION}"
 VIProductVersion __VIPV__
 BrandingText /TRIMLEFT "${COMPANY}"
 

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -2,6 +2,8 @@
 # Copyright (c) 2017 Anaconda, Inc.
 # All rights reserved.
 
+# Created by constructor __CONSTRUCTOR_VERSION__
+
 # COMMON UTILS
 # If you update this block, please propagate changes to the other scripts using it
 set -euo pipefail

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -282,6 +282,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
         'PATH_EXISTS_ERROR_TEXT': path_exists_error_text,
         'PROGRESS_NOTIFICATIONS': str(info.get('progress_notifications', False)),
         'PRE_OR_POST': user_script_type or '__PRE_OR_POST__',
+        'CONSTRUCTOR_VERSION': info['CONSTRUCTOR_VERSION'],
     }
     data = preprocess(data, ppd)
     data = fill_template(data, replace)

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -70,6 +70,7 @@ def get_header(conda_exec, tarball, info):
     install_lines = list(add_condarc(info))
     # Needs to happen first -- can be templated
     replace = {
+        'CONSTRUCTOR_VERSION': info['CONSTRUCTOR_VERSION'],
         'NAME': name,
         'name': name.lower(),
         'VERSION': info['version'],

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -229,6 +229,7 @@ def make_nsi(info, dir_path, extra_files=None, temp_extra_files=None):
         'SHOW_ADD_TO_PATH': "yes" if info.get("initialize_conda", True) else "no",
         'OUTFILE': info['_outpath'],
         'VIPV': make_VIProductVersion(info['version']),
+        'CONSTRUCTOR_VERSION': info['CONSTRUCTOR_VERSION'],
         'ICONFILE': '@icon.ico',
         'HEADERIMAGE': '@header.bmp',
         'WELCOMEIMAGE': '@welcome.bmp',

--- a/docs/source/howto.md
+++ b/docs/source/howto.md
@@ -61,3 +61,13 @@ This happens by default for _all packages_. If you only want this to happen for 
 use the [`menu_packages`](construct-yaml.md#menu_packages) key.
 
 To learn more about `menuinst`, visit [`conda/menuinst`](https://github.com/conda/menuinst).
+
+## Find out the used constructor version
+
+Recent constructor versions (>=3.4.2) burn-in their version into created installers in order to be able to trace back bugs in created installers to the constructor code base.
+
+The burned-in version can be retrieved in different ways depending on the installer type:
+
+- For `.sh` intallers (via cli): `head $installer.sh | grep "Created by constructor"`
+- For `.exe` installers (via Windows Explorer): `$installer.exe` → Properties → Details → Comments
+- For `.pkg` installers (via cli on macOS): `xar -xf $installer.pkg -n run_installation.pkg/Scripts; zgrep run_installation.pkg/Scripts "Created by constructor"`

--- a/news/626-burn-in-version
+++ b/news/626-burn-in-version
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Burn-in constructor version into installers to be able to better support faulty uninstallers. (#626)
+* Burn-in constructor version into installers to be able to better support faulty uninstallers. (#604 via #626)
 
 ### Bug fixes
 

--- a/news/626-burn-in-version
+++ b/news/626-burn-in-version
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Burn-in constructor version into installers to be able to better support faulty uninstallers. (#626)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Having the constructor version burned into the installers allows to better support faulty installers by knowing from which version of constructor they originate from. The version makes it clear if it is a released version or a canary release.

closes https://github.com/conda/constructor/issues/604

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
