### PR TITLE
Require conda <23.1.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     # FIXME: Workaround for xz 5.2.10 issue on py310
     - xz !=5.2.10       # [win and py == 310]
   run:
-    - conda >=4.6
+    - conda >=4.6,<23.1.0
     - python
     - ruamel_yaml >=0.11.14,<0.16
     - conda-standalone

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -42,11 +42,13 @@ test:
     - examples
     - .coveragerc
   requires:
+    - pip
     - pillow >=3.1
     - pytest
     - pytest-cov
     - codecov
   commands:
+    - pip check
     - pytest -v --cov=constructor tests
     - coverage run --append -m constructor -V
     - if [%CODECOV_TOKEN%] neq [] codecov --commit %CODECOV_COMMIT% # [win]

--- a/news/627-restrict-conda-version
+++ b/news/627-restrict-conda-version
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Add upper conda version bound as with conda >=23.1.0 the local repodata format has changed and `write_repodata()` has to be update. See #628 for details. (#627)
+* Add upper conda version bound as with conda >=23.1.0 the local repodata format has changed and `write_repodata()` has to be updated. See #628 for details. (#627)

--- a/news/627-restrict-conda-version
+++ b/news/627-restrict-conda-version
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add upper conda version bound as with conda >=23.1.0 the local repodata format has changed and write_repodata() has to be updated, see #628. (#627)

--- a/news/627-restrict-conda-version
+++ b/news/627-restrict-conda-version
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Add upper conda version bound as with conda >=23.1.0 the local repodata format has changed and write_repodata() has to be updated, see #628. (#627)
+* Add upper conda version bound as with conda >=23.1.0 the local repodata format has changed and `write_repodata()` has to be update. See #628 for details. (#627)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "console_scripts": ["constructor = constructor.main:main"],
     },
     install_requires=[
-        "conda >=4.6",
+        "conda >=4.6,<23.1.0",
         "ruamel_yaml",
         "pillow >=3.1 ; platform_system=='Windows' or platform_system=='Darwin'",
         # non-python dependency: "nsis >=3.01 ; platform_system=='Windows'",


### PR DESCRIPTION
attempt to workaround until there is a real fix:
```
  File "/usr/share/miniconda/envs/constructor/lib/python3.10/site-packages/constructor/conda_interface.py", line 143, in write_repodata
    url = used_repodata.pop('_url').rstrip("/")
KeyError: '_url'
```
see in https://github.com/conda/constructor/actions/runs/3998908201/jobs/6862143485

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
