### PR TITLE
Report example runs as integration test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,6 @@ jobs:
           conda create -p ../conda conda-build conda-verify
       - name: Build the package
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           PYTHONIOENCODING: utf-8
           # Uncomment to run within conda build
           # RUN_EXAMPLES: "1"
@@ -84,6 +83,7 @@ jobs:
             conda build conda.recipe --python=${{ matrix.pyver }}
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
       - name: Upload the packages as artifact
         if: github.event_name == 'push'
@@ -160,6 +160,7 @@ jobs:
           CONDA_SOLVER=libmamba CONDA_VERBOSITY=1 constructor examples/noconda/ --output-dir=examples_artifacts/
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request' && matrix.pyver == '3.9'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           source $CONDA/etc/profile.d/conda.sh
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
-            conda create -n constructor -c local --strict-channel-priority constructor codecov
+            conda create -n constructor -c local --strict-channel-priority constructor coverage
           conda activate constructor
           set -x
           installed_channel=$(conda list constructor --json | jq -r '.[].channel')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,8 +79,12 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate ../conda
           export CODECOV_COMMIT=$(git rev-parse --verify HEAD)
+          CODECOV_FOLDER=${PWD} \
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
             conda build conda.recipe --python=${{ matrix.pyver }}
+      - uses: codecov/codecov-action@v3
+        with:
+          flags: unit
       - name: Upload the packages as artifact
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v3
@@ -139,6 +143,7 @@ jobs:
           fi
       - name: Run examples and prepare artifacts
         run: |
+          rm -rf coverage.json
           source $CONDA/etc/profile.d/conda.sh
           conda activate constructor
           mkdir -p examples_artifacts/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           source $CONDA/etc/profile.d/conda.sh
           CONDA_BLD_PATH="${{ runner.temp }}/conda-bld" \
-            conda create -n constructor -c local --strict-channel-priority constructor
+            conda create -n constructor -c local --strict-channel-priority constructor codecov
           conda activate constructor
           set -x
           installed_channel=$(conda list constructor --json | jq -r '.[].channel')
@@ -145,6 +145,7 @@ jobs:
           python scripts/run_examples.py \
             --keep-artifacts=examples_artifacts/ \
             --conda-exe="${CONSTRUCTOR_CONDA_EXE}"
+          coverage json
       - name: Test with conda-libmamba-solver
         run: |
           source $CONDA/etc/profile.d/conda.sh
@@ -152,6 +153,9 @@ jobs:
           conda install -yq conda-libmamba-solver
           conda list
           CONDA_SOLVER=libmamba CONDA_VERBOSITY=1 constructor examples/noconda/ --output-dir=examples_artifacts/
+      - uses: codecov/codecov-action@v3
+        with:
+          flags: integration
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request' && matrix.pyver == '3.9'
         uses: actions/upload-artifact@v3

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,8 +15,7 @@ build:
   entry_points:
     - constructor = constructor.main:main
   script_env:
-    - CODECOV_TOKEN
-    - CODECOV_COMMIT
+    - CODECOV_FOLDER
     - RUN_EXAMPLES
 
 requirements:
@@ -46,13 +45,13 @@ test:
     - pillow >=3.1
     - pytest
     - pytest-cov
-    - codecov
   commands:
     - pip check
     - pytest -v --cov=constructor tests
     - coverage run --append -m constructor -V
-    - if [%CODECOV_TOKEN%] neq [] codecov --flags unit --commit %CODECOV_COMMIT% # [win]
-    - if [ -n "$CODECOV_TOKEN" ]; then codecov --flags unit --commit $CODECOV_COMMIT; fi # [unix]
+    - coverage json
+    - if [%CODECOV_FOLDER%] neq [] copy coverage.json "%CODECOV_FOLDER%" # [win]
+    - if [ -n "$CODECOV_FOLDER" ]; then cp coverage.json "$CODECOV_FOLDER"; fi # [unix]
     - coverage report
     - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py      # [win]
     - if [ -n "$RUN_EXAMPLES" ]; then python scripts/run_examples.py; fi  # [unix]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -51,8 +51,8 @@ test:
     - pip check
     - pytest -v --cov=constructor tests
     - coverage run --append -m constructor -V
-    - if [%CODECOV_TOKEN%] neq [] codecov --commit %CODECOV_COMMIT% # [win]
-    - if [ -n "$CODECOV_TOKEN" ]; then codecov --commit $CODECOV_COMMIT; fi # [unix]
+    - if [%CODECOV_TOKEN%] neq [] codecov --flags unit --commit %CODECOV_COMMIT% # [win]
+    - if [ -n "$CODECOV_TOKEN" ]; then codecov --flags unit --commit $CODECOV_COMMIT; fi # [unix]
     - coverage report
     - if [%RUN_EXAMPLES%] neq [] python scripts/run_examples.py      # [win]
     - if [ -n "$RUN_EXAMPLES" ]; then python scripts/run_examples.py; fi  # [unix]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -47,8 +47,8 @@ test:
     - pytest-cov
   commands:
     - pip check
-    - pytest -v --cov=constructor tests
-    - coverage run --append -m constructor -V
+    - pytest -v --cov-branch --cov=constructor tests
+    - coverage run --branch --append -m constructor -V
     - coverage json
     - if [%CODECOV_FOLDER%] neq [] copy coverage.json "%CODECOV_FOLDER%" # [win]
     - if [ -n "$CODECOV_FOLDER" ]; then cp coverage.json "$CODECOV_FOLDER"; fi # [unix]

--- a/news/639-int-coverage
+++ b/news/639-int-coverage
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Report example runs as integration coverage. (#639)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -15,7 +15,7 @@ from constructor.utils import rm_rf
 
 try:
     import coverage  # noqa
-    COV_CMD = ['coverage', 'run', '--append', '-m']
+    COV_CMD = ['coverage', 'run', '--branch', '--append', '-m']
 except ImportError:
     COV_CMD = []
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

run_examples.py automatically runs constructor with coverage if the coverage Python module is importable (so installing codecov -> coverage is enough). Also moving the codecov upload from inside the recipe to the action as there is much more  meta-data that gets reported that way (PR numbers etc).

This pushes the coverage from currently ~20% to >85%, see https://app.codecov.io/gh/conda/constructor/pull/639 and allows to either see what is not covered yet by tests or what is potentially dead code.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
