### PR TITLE
Fix for the Redirect link for the edit source

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ html_context = {
     "github_user": "conda",
     "github_repo": "constructor",
     "github_version": "main",
-    "doc_path": "docs",
+    "doc_path": "docs/source",
 }
 
 # We don't have a locale set, so we can safely ignore that for the sitemaps.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -4,7 +4,7 @@ Constructor is a tool which allows constructing an installer
 for a collection of conda packages. It solves needed packages using user-provided
 specifications, and bundles those packages.  It can currently create 3 kinds of
 installers, which are best thought of as delivery vehicles for the bundled packages.
-There are shell installers (`.sh`), MacOS `.pkg` installers, and Windows .exe installers.
+There are shell installers (`.sh`), MacOS `.pkg` installers, and Windows `.exe` installers.
 Each of these will create an environment on the end user's system that contains the specs
 you provided, along with any necessary dependencies.  These installers are similar
 to the Anaconda and Miniconda installers, and indeed constructor is used to create
@@ -75,7 +75,7 @@ containing your desired `construct.yaml`. From there, run this command:
 $ constructor .
 ```
 
-Your installer will be created inside of the directory with
+Your installer will be created inside the directory with
 this naming scheme: `name-version-yourPlatform.{sh|exe|pkg}`.
 
 ## Some additional considerations

--- a/news/652-fix-edit-doc-link
+++ b/news/652-fix-edit-doc-link
@@ -12,8 +12,7 @@
 
 ### Docs
 
-* To fix the "Edit Source Link". https://github.com/conda/constructor/edit/main/docs/... to https://github.com/conda/constructor/edit/main/docs/source/...
-* minor doc fixes
+* Fix "Edit Source Link" references and other minor corrections. (#652)
 
 ### Other
 

--- a/news/652-fix-edit-doc-link
+++ b/news/652-fix-edit-doc-link
@@ -12,7 +12,7 @@
 
 ### Docs
 
-* To fix the Edit Source Link in the existing documentation, Previously we were referring to the https://github.com/conda/constructor/edit/main/docs/... expected: https://github.com/conda/constructor/edit/main/docs/source/...
+* To fix the "Edit Source Link". https://github.com/conda/constructor/edit/main/docs/... to https://github.com/conda/constructor/edit/main/docs/source/...
 * minor doc fixes
 
 ### Other

--- a/news/652-fix-edit-doc-link
+++ b/news/652-fix-edit-doc-link
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* To fix the Edit Source Link in the existing documentation, Previously we were referring to the https://github.com/conda/constructor/edit/main/docs/... expected: https://github.com/conda/constructor/edit/main/docs/source/...
+* minor doc fixes
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add/update necessary tests?
- [X] Add/update outdated documentation?


### Description

Hi, The Pull request for the following things:

1. To fix the Edit Source Link in the existing documentation, Previously we were referring to the `https://github.com/conda/constructor/edit/main/docs/...` expected: `https://github.com/conda/constructor/edit/main/docs/source/...`
2. emphasized `.exe` along with packages for macOS and Linux in the page: Getting Started 
<img width="643" alt="image" src="https://user-images.githubusercontent.com/57987728/221378543-81de9f78-49af-497d-a537-7f56d142f366.png">
3. Removed a Preposition "of" in Getting Started Page




<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
