### PR TITLE
header.sh: Ensure error mesage is emitted when $HOME is not writable

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -436,7 +436,7 @@ export FORCE
 # https://github.com/ContinuumIO/anaconda-issues/issues/11148
 # First try to fix it (this apparently didn't work; QA reported the issue again)
 # https://github.com/conda/conda/pull/9073
-mkdir -p ~/.conda > /dev/null 2>&1
+test -d ~/.conda || mkdir -p ~/.conda >/dev/null 2>/dev/null || test -d ~/.conda || mkdir ~/.conda
 
 printf "\nInstalling base environment...\n\n"
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -436,6 +436,8 @@ export FORCE
 # https://github.com/ContinuumIO/anaconda-issues/issues/11148
 # First try to fix it (this apparently didn't work; QA reported the issue again)
 # https://github.com/conda/conda/pull/9073
+# Avoid silent errors when $HOME is not writable
+# https://github.com/conda/constructor/pull/669
 test -d ~/.conda || mkdir -p ~/.conda >/dev/null 2>/dev/null || test -d ~/.conda || mkdir ~/.conda
 
 printf "\nInstalling base environment...\n\n"

--- a/news/669-mkdir-home
+++ b/news/669-mkdir-home
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure error mesage is emitted when `$HOME` is not writable in shell installers. (#669)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

I am not familar with this project's Issue/PR process.

I place this one line change in the public domain and do not require any attribution.

https://github.com/conda/conda/issues/12642
https://github.com/ContinuumIO/anaconda-issues/issues/13189


This patch does not address the other issue in the https://github.com/ContinuumIO/anaconda-issues/issues/13189 of the conda.mk file no restarting by re-running the installer.  As it is not clear if that is a conda issue or not.

### Checklist - did you ...

Not sure if the change is "significant".
It is a one-liner that has affected things for the past 3 years it seems.

Not sure a test is necessary, I can make one using docker it will takes many minutes to execute and download 100's Mb's in the process just to prove something.  Not sure it is really helpful considering the bug has existed for many years already.

I am not aware of any outdated document in respect of this change.


- [*] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [*] Add / update necessary tests?
- [*] Add / update outdated documentation?
