### PR TITLE
default to `/opt` when `HOME` is not set (.sh installers)

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -457,10 +457,11 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix is
-`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
-for "All Users" installation, use the `default_prefix_all_users` key.
-If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix
+is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
+this is used only for "Just Me" installation; for "All Users" installation,
+use the `default_prefix_all_users` key. If not provided, the default prefix
+is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -329,10 +329,11 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 '''),
 
     ('default_prefix',         False, str, r'''
-Set default install prefix. On Linux, if not provided, the default prefix is
-`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
-for "All Users" installation, use the `default_prefix_all_users` key.
-If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix
+is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
+this is used only for "Just Me" installation; for "All Users" installation,
+use the `default_prefix_all_users` key. If not provided, the default prefix
+is `${USERPROFILE}\${NAME}`.
 '''),  # noqa
 
     ('default_prefix_domain_user', False, str, r'''

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -78,7 +78,7 @@ def get_header(conda_exec, tarball, info):
         'VERSION': info['version'],
         'PLAT': info['_platform'],
         'DEFAULT_PREFIX': info.get('default_prefix',
-                                   '$HOME/%s' % name.lower()),
+                                   '${HOME:-/opt}/%s' % name.lower()),
         'MD5': hash_files([conda_exec, tarball]),
         'FIRST_PAYLOAD_SIZE': str(getsize(conda_exec)),
         'SECOND_PAYLOAD_SIZE': str(getsize(tarball)),

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -457,10 +457,11 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix is
-`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
-for "All Users" installation, use the `default_prefix_all_users` key.
-If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix
+is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
+this is used only for "Just Me" installation; for "All Users" installation,
+use the `default_prefix_all_users` key. If not provided, the default prefix
+is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/news/678-default-home-not-set
+++ b/news/678-default-home-not-set
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* In `.sh` installers, use `/opt/NAME` as the default prefix when `$HOME` is not set. (#677 via #678)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/constructor/issues/677

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
