### PR TITLE
Prohibit parentheses in INSTDIR

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -929,7 +929,7 @@ Function OnDirectoryLeave
     Pop $R9
 
     # List of characters not allowed anywhere in $INSTDIR
-    Push "^%!=,"
+    Push "^%!=,()"
     Push $INSTDIR
     Call StrCSpn
     Pop $R0

--- a/news/699-prohibit-parentheses-instdir
+++ b/news/699-prohibit-parentheses-instdir
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Prohibit parentheses in $INSTDIR (#699)


### PR DESCRIPTION
### Description

`conda` has issues with parentheses in the environment path (https://github.com/conda/conda/issues/12587), so constructor shouldn't allow these characters in the installation path either until this is fixed.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?