### PR TITLE
Skip test_write_images on Linux

### DIFF
--- a/news/702-skip-imaging-test-linux
+++ b/news/702-skip-imaging-test-linux
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Skip imaging tests if not Windows or MacOS to avoid import errors (#702)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -10,7 +10,7 @@ if sys.platform == "win32" or sys.platform == "darwin":
 
 @pytest.mark.skipif(
     sys.platform != 'win32' and sys.platform != 'darwin',
-    reason='imaging not available on Linux'
+    reason='imaging only available on Windows and MacOS'
 )
 def test_write_images():
     tmp_dir = tempfile.mkdtemp()

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,9 +1,15 @@
+import pytest
 import shutil
+import sys
 import tempfile
 
 from constructor.imaging import write_images
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32" and sys.platform != "darwin",
+    reason="imaging not available on Linux"
+)
 def test_write_images():
     tmp_dir = tempfile.mkdtemp()
 

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -4,7 +4,8 @@ import tempfile
 
 import pytest
 
-from constructor.imaging import write_images
+if sys.platform == "win32" or sys.platform == "darwin":
+    from constructor.imaging import write_images
 
 
 @pytest.mark.skipif(

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -7,8 +7,8 @@ from constructor.imaging import write_images
 
 
 @pytest.mark.skipif(
-    sys.platform != "win32" and sys.platform != "darwin",
-    reason="imaging not available on Linux"
+    sys.platform != 'win32' and sys.platform != 'darwin',
+    reason='imaging not available on Linux'
 )
 def test_write_images():
     tmp_dir = tempfile.mkdtemp()

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,7 +1,8 @@
-import pytest
 import shutil
 import sys
 import tempfile
+
+import pytest
 
 from constructor.imaging import write_images
 


### PR DESCRIPTION
### Description

Writing images is only supported on Windows and MacOS, but pytest will currently run it on any system.

* Skip `test_write_images` if the platform is not Windows or MacOS

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?