### PR TITLE
Fix constructor test skips and imports for MacOS

### DIFF
--- a/examples/customize_controls/construct.yaml
+++ b/examples/customize_controls/construct.yaml
@@ -11,3 +11,4 @@ specs:
 
 register_python: False
 initialize_conda: False
+initialize_by_default: false

--- a/examples/osxpkg/construct.yaml
+++ b/examples/osxpkg/construct.yaml
@@ -10,6 +10,7 @@ channels:
   - http://repo.anaconda.com/pkgs/main/
 
 attempt_hardlinks: True
+initialize_by_default: false
 
 specs:
   - python

--- a/examples/use_channel_remap/construct.yaml
+++ b/examples/use_channel_remap/construct.yaml
@@ -18,3 +18,4 @@ specs:
   - conda
 
 license_file: eula.txt
+initialize_by_default: false

--- a/news/709-test-import-fixes
+++ b/news/709-test-import-fixes
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix imports and skips for constructor tests
+* Fix imports and skips for constructor tests. (#709)
 
 ### Deprecations
 

--- a/news/709-test-import-fixes
+++ b/news/709-test-import-fixes
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix imports and skips for constructor tests
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -349,7 +349,7 @@ def test_example_noconda(tmp_path, request):
         _run_installer(input_path, installer, install_dir, request=request)
 
 
-@pytest.mark.skipif(sys.platform != "Darwin", reason="macOS only")
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
 def test_example_osxpkg(tmp_path, request):
     input_path = _example_path("osxpkg")
     for installer, install_dir in create_installer(input_path, tmp_path):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,7 +13,8 @@ import pytest
 from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 
-from constructor.osxpkg import calculate_install_dir
+if sys.platform == "darwin":
+    from constructor.osxpkg import calculate_install_dir
 
 try:
     import coverage  # noqa

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -10,6 +10,8 @@ import pytest
 
 if sys.platform == "darwin":
     from constructor.osxpkg import OSX_DIR
+else:
+    OSX_DIR = ""
 from constructor.shar import read_header_template
 from constructor.utils import preprocess
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,5 +1,6 @@
 import itertools
 import subprocess
+import sys
 import tempfile
 from functools import lru_cache
 from pathlib import Path

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -11,6 +11,7 @@ import pytest
 if sys.platform == "darwin":
     from constructor.osxpkg import OSX_DIR
 else:
+    # Tests with OSX_DIR are skipped, but a placeholder is needed for pytest
     OSX_DIR = ""
 from constructor.shar import read_header_template
 from constructor.utils import preprocess

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -7,7 +7,8 @@ from shutil import which
 
 import pytest
 
-from constructor.osxpkg import OSX_DIR
+if sys.platform == "darwin":
+    from constructor.osxpkg import OSX_DIR
 from constructor.shar import read_header_template
 from constructor.utils import preprocess
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -97,6 +97,7 @@ def test_linux_template_processing():
     assert not errors
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="Only on MacOS")
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])
 @pytest.mark.parametrize("check_path_spaces", [False, True])
 @pytest.mark.parametrize("script", sorted(Path(OSX_DIR).glob("*.sh")))
@@ -109,6 +110,7 @@ def test_osxpkg_scripts_template_processing(arch, check_path_spaces, script):
     assert "#endif" not in processed
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="Only on MacOS")
 @pytest.mark.skipif(available_command("shellcheck") is False, reason="requires shellcheck")
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])
 @pytest.mark.parametrize("check_path_spaces", [False, True])


### PR DESCRIPTION
### Description

Fix remaining import errors for the constructor tests for MacOS.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
