### PR TITLE
[docs] Fix links to signing examples

### DIFF
--- a/docs/source/howto.md
+++ b/docs/source/howto.md
@@ -49,8 +49,8 @@ Once signed, you can notarize your PKG with Apple's `notarytool`.
 
 ```{seealso}
 Example of a CI pipeline implementing:
-- [Signing on Windows](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L349)
-- [Signing](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L390) and [notarization](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L459) on macOS
+- [Signing on Windows](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L390)
+- [Signing](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L349) and [notarization](https://github.com/napari/packaging/blob/6f5fcfaf7b/.github/workflows/make_bundle_conda.yml#L459) on macOS
 ```
 
 ## Create shortcuts


### PR DESCRIPTION
Simple fix to correct links that were pointing to the wrong example. Looks like the two simply got switched.