### PR TITLE
Add option for the new `register_envs`

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -163,12 +163,13 @@ reproduced.
 _required:_ no<br/>
 _type:_ string<br/>
 
-Path to an environment file to construct from. If this option is present, the
-`specs` argument will be ignored. Instead, constructor will call conda to
-create a temporary environment, constructor will build and installer from
-that, and the temporary environment will be removed. This ensures that
-constructor is using the precise local conda configuration to discover
-and install the packages. The created environment MUST include `python`.
+Path to an environment file (TXT or YAML) to construct from. If this option
+is present, the `specs` argument will be ignored. Instead, constructor will
+call conda to create a temporary environment, constructor will build and
+installer from that, and the temporary environment will be removed.
+This ensures that constructor is using the precise local conda configuration
+to discover and install the packages. The created environment MUST include
+`python`.
 
 Read notes about the solver in the `specs` field.
 
@@ -228,6 +229,14 @@ Notes:
   extra environments will have it either. Unlike the global option, an error will not be
   thrown if the excluded package is not found in the packages required by the extra environment.
   To override the global `exclude` value, use an empty list `[]`.
+
+### `register_envs`
+
+_required:_ no<br/>
+_type:_ boolean<br/>
+
+Whether to register the environments created by the installer (both `base` and `extra_envs`)
+in `~/.conda/environments.txt`. Only compatible with conda-standalone >=23.9. Defaults to `True`.
 
 ### `installer_filename`
 
@@ -457,10 +466,11 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix is
-`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
-for "All Users" installation, use the `default_prefix_all_users` key.
-If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix
+is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
+this is used only for "Just Me" installation; for "All Users" installation,
+use the `default_prefix_all_users` key. If not provided, the default prefix
+is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -163,13 +163,12 @@ reproduced.
 _required:_ no<br/>
 _type:_ string<br/>
 
-Path to an environment file (TXT or YAML) to construct from. If this option
-is present, the `specs` argument will be ignored. Instead, constructor will
-call conda to create a temporary environment, constructor will build and
-installer from that, and the temporary environment will be removed.
-This ensures that constructor is using the precise local conda configuration
-to discover and install the packages. The created environment MUST include
-`python`.
+Path to an environment file to construct from. If this option is present, the
+`specs` argument will be ignored. Instead, constructor will call conda to
+create a temporary environment, constructor will build and installer from
+that, and the temporary environment will be removed. This ensures that
+constructor is using the precise local conda configuration to discover
+and install the packages. The created environment MUST include `python`.
 
 Read notes about the solver in the `specs` field.
 
@@ -458,11 +457,10 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix
-is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
-this is used only for "Just Me" installation; for "All Users" installation,
-use the `default_prefix_all_users` key. If not provided, the default prefix
-is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix is
+`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
+for "All Users" installation, use the `default_prefix_all_users` key.
+If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -163,6 +163,11 @@ Notes:
   To override the global `exclude` value, use an empty list `[]`.
 '''),
 
+    ('register_envs', True, bool, '''
+Whether to register the environments created by the installer (both `base` and `extra_envs`)
+in `~/.conda/environments.txt`. Only compatible with conda-standalone >=23.9.
+'''),
+
     ('installer_filename',     False, str, '''
 The filename of the installer being created. If not supplied, a reasonable
 default will determined by the `name`, `version`, platform, and installer type.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -163,9 +163,9 @@ Notes:
   To override the global `exclude` value, use an empty list `[]`.
 '''),
 
-    ('register_envs', True, bool, '''
+    ('register_envs', False, bool, '''
 Whether to register the environments created by the installer (both `base` and `extra_envs`)
-in `~/.conda/environments.txt`. Only compatible with conda-standalone >=23.9.
+in `~/.conda/environments.txt`. Only compatible with conda-standalone >=23.9. Defaults to `True`.
 '''),
 
     ('installer_filename',     False, str, '''

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -443,6 +443,7 @@ test -d ~/.conda || mkdir -p ~/.conda >/dev/null 2>/dev/null || test -d ~/.conda
 
 printf "\nInstalling base environment...\n\n"
 
+CONDA_REGISTER_ENVS="__REGISTER_ENVS__" \
 CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS="__CHANNELS__" \
@@ -468,6 +469,7 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
     fi
 
     # TODO: custom shortcuts per env?
+    CONDA_REGISTER_ENVS="__REGISTER_ENVS__" \
     CONDA_SAFETY_CHECKS=disabled \
     CONDA_EXTRA_SAFETY_CHECKS=no \
     CONDA_CHANNELS="$env_channels" \

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -29,7 +29,8 @@ CONDA_EXEC="$PREFIX/conda.exe"
 
 # Perform the conda install
 notify "Installing packages. This might take a few minutes."
-if ! CONDA_SAFETY_CHECKS=disabled \
+if ! CONDA_REGISTER_ENVS="__REGISTER_ENVS__" \
+CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=__CHANNELS__ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
@@ -64,6 +65,7 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
     fi
     # TODO: custom channels per env?
     # TODO: custom shortcuts per env?
+    CONDA_REGISTER_ENVS="__REGISTER_ENVS__" \
     CONDA_SAFETY_CHECKS=disabled \
     CONDA_EXTRA_SAFETY_CHECKS=no \
     CONDA_CHANNELS="$env_channels" \

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -296,6 +296,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
         'PROGRESS_NOTIFICATIONS': str(info.get('progress_notifications', False)),
         'PRE_OR_POST': user_script_type or '__PRE_OR_POST__',
         'CONSTRUCTOR_VERSION': info['CONSTRUCTOR_VERSION'],
+        'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
     }
     data = preprocess(data, ppd)
     data = fill_template(data, replace)

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -86,6 +86,7 @@ def get_header(conda_exec, tarball, info):
         'CHANNELS': ','.join(get_final_channels(info)),
         'CONCLUSION_TEXT': info.get("conclusion_text", "installation finished."),
         'pycache': '__pycache__',
+        'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
     }
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -115,6 +115,8 @@ def setup_envs_commands(info, dir_path):
         File "{history_abspath}"
         # Set channels
         System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_CHANNELS", "{channels}").r0'
+        # Set register_envs
+        System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_REGISTER_ENVS", "{register_envs}").r0'
         # Run conda
         SetDetailsPrint TextOnly
         nsExec::ExecToLog '"$INSTDIR\_conda.exe" install --offline -yp "{prefix}" --file "{env_txt}" {shortcuts}'
@@ -143,7 +145,8 @@ def setup_envs_commands(info, dir_path):
         conda_meta=r"$INSTDIR\conda-meta",
         history_abspath=join(dir_path, "conda-meta", "history"),
         channels=','.join(get_final_channels(info)),
-        shortcuts="--no-shortcuts"
+        shortcuts="--no-shortcuts",
+        register_envs=str(info.get("register_envs", True)).lower(),
     ).splitlines()
     # now we generate one more block per extra env, if present
     for env_name in info.get("_extra_envs_info", {}):
@@ -163,6 +166,7 @@ def setup_envs_commands(info, dir_path):
             history_abspath=join(dir_path, "envs", env_name, "conda-meta", "history"),
             channels=",".join(get_final_channels(channel_info)),
             shortcuts="",
+            register_envs=str(info.get("register_envs", True)).lower(),
         ).splitlines()
 
     return [line.strip() for line in lines]

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -163,12 +163,13 @@ reproduced.
 _required:_ no<br/>
 _type:_ string<br/>
 
-Path to an environment file to construct from. If this option is present, the
-`specs` argument will be ignored. Instead, constructor will call conda to
-create a temporary environment, constructor will build and installer from
-that, and the temporary environment will be removed. This ensures that
-constructor is using the precise local conda configuration to discover
-and install the packages. The created environment MUST include `python`.
+Path to an environment file (TXT or YAML) to construct from. If this option
+is present, the `specs` argument will be ignored. Instead, constructor will
+call conda to create a temporary environment, constructor will build and
+installer from that, and the temporary environment will be removed.
+This ensures that constructor is using the precise local conda configuration
+to discover and install the packages. The created environment MUST include
+`python`.
 
 Read notes about the solver in the `specs` field.
 
@@ -228,6 +229,14 @@ Notes:
   extra environments will have it either. Unlike the global option, an error will not be
   thrown if the excluded package is not found in the packages required by the extra environment.
   To override the global `exclude` value, use an empty list `[]`.
+
+### `register_envs`
+
+_required:_ no<br/>
+_type:_ boolean<br/>
+
+Whether to register the environments created by the installer (both `base` and `extra_envs`)
+in `~/.conda/environments.txt`. Only compatible with conda-standalone >=23.9. Defaults to `True`.
 
 ### `installer_filename`
 
@@ -457,10 +466,11 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix is
-`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
-for "All Users" installation, use the `default_prefix_all_users` key.
-If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix
+is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
+this is used only for "Just Me" installation; for "All Users" installation,
+use the `default_prefix_all_users` key. If not provided, the default prefix
+is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -163,13 +163,12 @@ reproduced.
 _required:_ no<br/>
 _type:_ string<br/>
 
-Path to an environment file (TXT or YAML) to construct from. If this option
-is present, the `specs` argument will be ignored. Instead, constructor will
-call conda to create a temporary environment, constructor will build and
-installer from that, and the temporary environment will be removed.
-This ensures that constructor is using the precise local conda configuration
-to discover and install the packages. The created environment MUST include
-`python`.
+Path to an environment file to construct from. If this option is present, the
+`specs` argument will be ignored. Instead, constructor will call conda to
+create a temporary environment, constructor will build and installer from
+that, and the temporary environment will be removed. This ensures that
+constructor is using the precise local conda configuration to discover
+and install the packages. The created environment MUST include `python`.
 
 Read notes about the solver in the `specs` field.
 
@@ -458,11 +457,10 @@ Metadata about the installer can be found in the `%INSTALLER_NAME%`,
 _required:_ no<br/>
 _type:_ string<br/>
 
-Set default install prefix. On Linux, if not provided, the default prefix
-is `${HOME}/${NAME}` (or, if `HOME` is not set, `/opt/${NAME}`). On Windows,
-this is used only for "Just Me" installation; for "All Users" installation,
-use the `default_prefix_all_users` key. If not provided, the default prefix
-is `${USERPROFILE}\${NAME}`.
+Set default install prefix. On Linux, if not provided, the default prefix is
+`${HOME}/${NAME}`. On windows, this is used only for "Just Me" installation;
+for "All Users" installation, use the `default_prefix_all_users` key.
+If not provided, the default prefix is `${USERPROFILE}\${NAME}`.
 
 ### `default_prefix_domain_user`
 

--- a/examples/register_envs/construct.yaml
+++ b/examples/register_envs/construct.yaml
@@ -1,0 +1,8 @@
+name: RegisterEnvs
+version: X
+installer_type: all
+channels:
+  - http://repo.anaconda.com/pkgs/main/
+specs:
+  - python
+register_envs: false

--- a/news/716-register-envs
+++ b/news/716-register-envs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add support for the `register_envs` option. (#705 via #716)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -444,3 +444,11 @@ def test_example_from_explicit(tmp_path, request):
             text=True,
         )
         assert out == (input_path / "explicit_linux-64.txt").read_text()
+
+
+def test_register_envs(tmp_path, request):
+    input_path = _example_path("register_envs")
+    for installer, install_dir in create_installer(input_path, tmp_path):
+        _run_installer(input_path, installer, install_dir, request=request)
+        environments_txt = Path("~/.conda/environments.txt").expanduser().read_text()
+        assert str(install_dir) not in environments_txt


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

conda 23.9 will ship a new `register_envs` option (see https://github.com/conda/conda/pull/12924). This PR exposes that to `constructor`. This is not yet released (we need it in conda-standalone too), and micromamba doesn't have it (yet? see https://github.com/mamba-org/mamba/issues/2783). Adding this now so I don't forget :D 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
