### PR TITLE
Added support for `extra_env_variables`

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -442,6 +442,18 @@ is compulsory and the option to disable it will not be offered.
 
 This option has no effect on `SH` installers.
 
+
+### `extra_env_variables`
+
+_required:_ no<br/>
+_type:_ list<br/>
+
+List of additional environment variables to be made available to the
+pre_install and post_install scripts, in the form of VAR=VALUE
+pairs. These environment variables are in addition to those in the
+`post_install` section above and take precedence in the case of name
+collisions.  Unix only.
+
 ### `pre_uninstall`
 
 _required:_ no<br/>

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -270,6 +270,13 @@ provided, it will default to `io.continuum`. (MacOS only)
 Application name in the Windows "Programs and Features" control panel.
 Defaults to `${NAME} ${VERSION} (Python ${PYVERSION} ${ARCH})`.
 '''),
+('extra_env_variables',           False, list, '''
+List of additional environment variables to be made available to the
+pre_install and post_install scripts, in the form of VAR=VALUE
+pairs. These environment variables are in addition to those in the
+`post_install` section above and take precedence in the case of name
+collisions.  Unix only.
+'''),
 
     ('pre_install',            False, str, '''
 Path to a pre-install script, run after the package cache has been set, but

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -23,6 +23,8 @@ fi
 
 # Export variables to make installer metadata available to pre/post install scripts
 # NOTE: If more vars are added, make sure to update the examples/scripts tests too
+
+_EXTRA_ENV_VARIABLES_=''  # Templated extra environment variable(s) 
 export INSTALLER_NAME='__NAME__'
 export INSTALLER_VER='__VERSION__'
 export INSTALLER_PLAT='__PLAT__'

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -92,8 +92,10 @@ def get_header(conda_exec, tarball, info):
 
     data = read_header_template()
     data = preprocess(data, ppd)
+    custom_variables = info.pop('extra_env_variables', [])
     data = fill_template(data, replace)
 
+    data = data.replace("_EXTRA_ENV_VARIABLES_=''", '\n'.join([f'export {var}' for var in custom_variables]))
     return data
 
 

--- a/examples/scripts/construct.yaml
+++ b/examples/scripts/construct.yaml
@@ -5,6 +5,11 @@ channels:
   - http://repo.anaconda.com/pkgs/main/
 specs:
   - python
+
+extra_env_variables:
+  - CUSTOM_VARIABLE_1=CUSTOM1
+  - CUSTOM_VARIABLE_2=CUSTOM2
+
 pre_install: pre_install.sh   # [unix]
 pre_install: pre_install.bat  # [win]
 pre_install_desc: "Adding this description makes the script selectable in the UI"

--- a/examples/scripts/post_install.sh
+++ b/examples/scripts/post_install.sh
@@ -9,10 +9,15 @@ echo "INSTALLER_NAME=${INSTALLER_NAME}"
 echo "INSTALLER_VER=${INSTALLER_VER}"
 echo "INSTALLER_PLAT=${INSTALLER_PLAT}"
 echo "INSTALLER_TYPE=${INSTALLER_TYPE}"
+echo "CUSTOM_VARIABLE_1=${CUSTOM_VARIABLE_1}"
+echo "CUSTOM_VARIABLE_2=${CUSTOM_VARIABLE_2}"
 echo "PREFIX=${PREFIX}"
 
 test "${INSTALLER_NAME}" = "Scripts"
 test "${INSTALLER_VER}" = "X"
+test "${CUSTOM_VARIABLE_1}" = "CUSTOM1"
+test "${CUSTOM_VARIABLE_2}" = "CUSTOM2"
+
 if [[ $(uname -s) == Linux ]]; then
     if [[ ${INSTALLER_PLAT} != linux-* ]]; then
         exit 1

--- a/examples/scripts/pre_install.sh
+++ b/examples/scripts/pre_install.sh
@@ -6,10 +6,15 @@ echo "INSTALLER_NAME=${INSTALLER_NAME}"
 echo "INSTALLER_VER=${INSTALLER_VER}"
 echo "INSTALLER_PLAT=${INSTALLER_PLAT}"
 echo "INSTALLER_TYPE=${INSTALLER_TYPE}"
+echo "CUSTOM_VARIABLE_1=${CUSTOM_VARIABLE_1}"
+echo "CUSTOM_VARIABLE_2=${CUSTOM_VARIABLE_2}"
 echo "PREFIX=${PREFIX}"
 
 test "${INSTALLER_NAME}" = "Scripts"
 test "${INSTALLER_VER}" = "X"
+test "${CUSTOM_VARIABLE_1}" = "CUSTOM1"
+test "${CUSTOM_VARIABLE_2}" = "CUSTOM2"
+
 if [[ $(uname -s) == Linux ]]; then
     if [[ ${INSTALLER_PLAT} != linux-* ]]; then
         exit 1


### PR DESCRIPTION
Adds support for an `extra_env_variables` key in the `construct.yaml` e.g.:

```yaml
extra_env_variables:
  - CUSTOM_VARIABLE_1=CUSTOM1
  - CUSTOM_VARIABLE_2=CUSTOM2
```

This makes these environment variables available to the `pre_install` and `post_install` scripts.

***Motivation***: This mechanism makes it much easier to template installers that use `pre_install` and `post_install` scripts, allowing those scripts to stay generic and unchanged while making the templated changes clear in the `construct.yaml` in an easy-to-read, declarative form.

Right now only Unix .sh installers are supported in this PR. I wanted to see whether to constructor maintainers are open to this addition before implementing support for other platforms.

The only open question I have right now is whether there is a use-case to allow custom overrides of the pre-defined variables (i.e. `$INSTALLER_NAME`, `$INSTALLER_VER`, `$INSTALLER_PLAT`). My instinct is that there is no good reason to allow this so this PR ensures that custom extra variable definitions cannot override these definitions.