### PR TITLE
Update installation for windows .exe

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -518,7 +518,7 @@ Function CheckInstdirValidity
         IfFileExists $INSTDIR\$2 0 invalid_dir
         IntOp $1 $1 + 1
         goto loop_conda
-    endloop_conda: 
+    endloop_conda:
 
     # All checks have passed
     goto valid_dir
@@ -779,7 +779,7 @@ Function un.onInit
         IfFileExists $INSTDIR\$2 0 invalid_dir
         IntOp $1 $1 + 1
         goto loop_conda
-    endloop_conda: 
+    endloop_conda:
 
     # All checks have passed
     goto valid_dir
@@ -910,16 +910,16 @@ Function OnDirectoryLeave
 
         MessageBox MB_YESNO \
             "Directory '$INSTDIR' is not empty,$\n\
-             do you want to update the installation ?" \        
+             do you want to update the installation ?" \
             /SD IDYES \
             IDYES confirmed_yes IDNO confirmed_no
         confirmed_no:
-            MessageBox MB_OK|MB_ICONSTOP "Choose another directory." /SD IDOK 
+            MessageBox MB_OK|MB_ICONSTOP "Choose another directory." /SD IDOK
                 SetOverwrite "off"
-            Abort      
+            Abort
         confirmed_yes:
                 call CheckInstdirValidity
-                SetOverwrite "ifdiff" 
+                SetOverwrite "ifdiff"
     ${EndIf}
 
     ReadRegStr $LongPathsEnabled HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled"

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -510,7 +510,7 @@ Function CheckInstdirValidity
     endloop_critical:
 
     # Primitive check to see that $INSTDIR points to the right conda directory
-    StrCpy $0 "_conda.exe conda-meta\history Uninstall-${NAME}"
+    StrCpy $0 "_conda.exe conda-meta\history Uninstall-${NAME}.exe"
     StrCpy $1 1
     loop_conda:
         ${WordFind} $0 " " "E+$1" $2

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -475,6 +475,68 @@ Function InstModePage_Leave
     Pop $0
 FunctionEnd
 
+Function CheckInstdirValidity
+    Push $0
+    Push $1
+    Push $2
+    Push $3
+
+    # Resolve INSTDIR
+    GetFullPathName $0 $INSTDIR
+    # If the directory does not exist or cannot be resolved, $0 will be empty
+    StrCmp $0 "" invalid_dir
+    StrCpy $INSTDIR $0
+
+    # Never run the un/installer when $INSTDIR points at system-critical directories
+
+    StrLen $InstDirLen $INSTDIR
+    # INSTDIR is a full path and has no trailing backslash,
+    # so if its length is 2, it is pointed at a system root
+    StrCmp $InstdirLen 2 invalid_dir
+
+    # Never delete anything inside Windows
+    StrCpy $0 $INSTDIR 7 3
+    StrCmp $0 "Windows" invalid_dir
+
+    StrCpy $0 "ALLUSERSPROFILE APPDATA LOCALAPPDATA PROGRAMDATA PROGRAMFILES PROGRAMFILES(x86) PUBLIC SYSTEMDRIVE SYSTEMROOT USERPROFILE"
+    StrCpy $1 1
+    loop_critical:
+        ${WordFind} $0 " " "E+$1" $2
+        IfErrors endloop_critical
+        ReadEnvStr $3 $2
+        StrCmp $3 $INSTDIR invalid_dir
+        IntOp $1 $1 + 1
+        goto loop_critical
+    endloop_critical:
+
+    # Primitive check to see that $INSTDIR points to the right conda directory
+    StrCpy $0 "_conda.exe conda-meta\history Uninstall-${NAME}"
+    StrCpy $1 1
+    loop_conda:
+        ${WordFind} $0 " " "E+$1" $2
+        IfErrors endloop_conda
+        IfFileExists $INSTDIR\$2 0 invalid_dir
+        IntOp $1 $1 + 1
+        goto loop_conda
+    endloop_conda: 
+
+    # All checks have passed
+    goto valid_dir
+
+    invalid_dir:
+        MessageBox MB_OK|MB_ICONSTOP \
+            "Error: $INSTDIR is not a valid conda directory or another conda directory.$\n\
+             Please run the installer from a conda directory." \
+            /SD IDABORT
+        abort
+    valid_dir:
+
+    Pop $3
+    Pop $2
+    Pop $1
+    Pop $0
+FunctionEnd
+
 Function .onInit
     ${LogSet} on
     Push $0
@@ -717,7 +779,7 @@ Function un.onInit
         IfFileExists $INSTDIR\$2 0 invalid_dir
         IntOp $1 $1 + 1
         goto loop_conda
-    endloop_conda:
+    endloop_conda: 
 
     # All checks have passed
     goto valid_dir
@@ -845,6 +907,7 @@ Function OnDirectoryLeave
     ${LogSet} on
     ${If} ${IsNonEmptyDirectory} "$InstDir"
         DetailPrint "::error:: Directory '$INSTDIR' is not empty."
+
         MessageBox MB_YESNO \
             "Directory '$INSTDIR' is not empty,$\n\
              do you want to update the installation ?" \        
@@ -855,6 +918,7 @@ Function OnDirectoryLeave
                 SetOverwrite "off"
             Abort      
         confirmed_yes:
+                call CheckInstdirValidity
                 SetOverwrite "ifdiff" 
     ${EndIf}
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -510,7 +510,7 @@ Function CheckInstdirValidity
     endloop_critical:
 
     # Primitive check to see that $INSTDIR points to the right conda directory
-    StrCpy $0 "_conda.exe conda-meta\history Uninstall-${NAME}.exe"
+    StrCpy $0 "_conda.exe conda-meta\history"
     StrCpy $1 1
     loop_conda:
         ${WordFind} $0 " " "E+$1" $2

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -844,12 +844,17 @@ Pop $0
 Function OnDirectoryLeave
     ${LogSet} on
     ${If} ${IsNonEmptyDirectory} "$InstDir"
-        DetailPrint "::error:: Directory '$INSTDIR' is not empty, please choose a different location."
-        MessageBox MB_OK|MB_ICONEXCLAMATION \
+        DetailPrint "::error:: Directory '$INSTDIR' is not empty."
+        MessageBox MB_YESNO \
             "Directory '$INSTDIR' is not empty,$\n\
-             please choose a different location." \
-            /SD IDOK
-        Abort
+             do you want to upgrade the installation ?" \        
+            /SD IDYES \
+            IDYES confirmed_yes IDNO confirmed_no
+        confirmed_no:
+            MessageBox MB_OK|MB_ICONSTOP "Choose another directory." /SD IDOK 
+            Abort      
+        confirmed_yes:
+                SetOverwrite "ifdiff" 
     ${EndIf}
 
     ReadRegStr $LongPathsEnabled HKLM "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled"

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -847,11 +847,12 @@ Function OnDirectoryLeave
         DetailPrint "::error:: Directory '$INSTDIR' is not empty."
         MessageBox MB_YESNO \
             "Directory '$INSTDIR' is not empty,$\n\
-             do you want to upgrade the installation ?" \        
+             do you want to update the installation ?" \        
             /SD IDYES \
             IDYES confirmed_yes IDNO confirmed_no
         confirmed_no:
             MessageBox MB_OK|MB_ICONSTOP "Choose another directory." /SD IDOK 
+                SetOverwrite "off"
             Abort      
         confirmed_yes:
                 SetOverwrite "ifdiff" 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- No possibility to update an installation with windows .exe installer. It would be nice to have something which would look like the -u flag available for linux .sh installer #679. 
- I changed the MessageBox which would poped when a path already exists to a YESNO MessageBox. The message is now "The directory '$INSTDIR' is not empty, do you want to update the installation ?". 
  - If the user choose "yes", the installer update the $INSTDIR
  - If the user choose "no", them are send back to select the installation path.
- I added a function in main.nsi.tmpl which is called CheckInstdirValidity. It checks the validity of the selected directory during the installation. It avoids to install something in a windows critical directory or a non conda directory. 
- This function was made just by externalising some code from the function un.onInit. I had in mind to do so to be able to call it when necessary. However, for some reasons, I can not achieve to call CheckInstdirValidity within un.onInit. If anyone has some idea about how to do it, it would avoid code duplication.  

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?