### PR TITLE
Warn when `conda_exe` cannot be identified

### DIFF
--- a/constructor/main.py
+++ b/constructor/main.py
@@ -146,13 +146,13 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
                 env_config[config_key] = [val.strip() for val in value]
             if config_key == "environment_file":
                 env_config[config_key] = abspath(join(dir_path, value))
-    
+
     try:
         exe_name, exe_version = identify_conda_exe(info.get("_conda_exe"))
     except OSError as exc:
         logger.warning(
             "Could not identify conda-standalone / micromamba version (%s). "
-            "Will assume it is compatible with shortcuts.", 
+            "Will assume it is compatible with shortcuts.",
             exc,
          )
         exe_name, exe_version = None, None

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -151,7 +151,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
         exe_name, exe_version = identify_conda_exe(info.get("_conda_exe"))
     except OSError as exc:
         logger.warning(
-            "Could not identify conda-standalone version (%s). "
+            "Could not identify conda-standalone / micromamba version (%s). "
             "Will assume it is compatible with shortcuts.", 
             exc,
          )

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -146,9 +146,17 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
                 env_config[config_key] = [val.strip() for val in value]
             if config_key == "environment_file":
                 env_config[config_key] = abspath(join(dir_path, value))
-
-    exe_name, exe_version = identify_conda_exe(info.get("_conda_exe"))
-    if sys.platform != "win32" and (
+    
+    try:
+        exe_name, exe_version = identify_conda_exe(info.get("_conda_exe"))
+    except OSError as exc:
+        logger.warning(
+            "Could not identify conda-standalone version (%s). "
+            "Will assume it is compatible with shortcuts.", 
+            exc,
+         )
+        exe_name, exe_version = None, None
+    if sys.platform != "win32" and exe_name is not None and (
         exe_name == "micromamba" or Version(exe_version) < Version("23.11.0")
     ):
         logger.warning("conda-standalone 23.11.0 or above is required for shortcuts on Unix.")

--- a/news/474-menuinst-v2
+++ b/news/474-menuinst-v2
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add support for `menuinst` v2, which extends shortcut (menu items) creation from Windows to Linux and macOS. See [`menuinst` documentation](https://conda.github.io/menuinst/) for more information. Note that this feature requires `conda-standalone 23.11.0` or later. `micromamba` doesn't support v2-style menu items yet. (#474)
+* Add support for `menuinst` v2, which extends shortcut (menu items) creation from Windows to Linux and macOS. See [`menuinst` documentation](https://conda.github.io/menuinst/) for more information. Note that this feature requires `conda-standalone 23.11.0` or later. `micromamba` doesn't support v2-style menu items yet. (#474, #743)
 
 ### Bug fixes
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -249,6 +249,7 @@ def create_installer(
     debug=CONSTRUCTOR_DEBUG,
     with_spaces=False,
     timeout=420,
+    extra_constructor_args: Iterable[str] = None,
     **env_vars,
 ) -> Tuple[Path, Path]:
     if sys.platform.startswith("win") and conda_exe and _is_micromamba(conda_exe):
@@ -268,6 +269,8 @@ def create_installer(
         cmd.extend(["--conda-exe", conda_exe])
     if debug:
         cmd.append("--debug")
+    if extra_constructor_args:
+        cmd.extend(extra_constructor_args)
 
     _execute(cmd, timeout=timeout, **env_vars)
 
@@ -519,3 +522,9 @@ def test_register_envs(tmp_path, request):
         _run_installer(input_path, installer, install_dir, request=request)
         environments_txt = Path("~/.conda/environments.txt").expanduser().read_text()
         assert str(install_dir) not in environments_txt
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
+def test_cross_osx_building(tmp_path):
+    input_path = _example_path("noconda")
+    create_installer(input_path, tmp_path, extra_constructor_args=["--platform", "osx-arm64"])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -527,4 +527,24 @@ def test_register_envs(tmp_path, request):
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
 def test_cross_osx_building(tmp_path):
     input_path = _example_path("noconda")
-    create_installer(input_path, tmp_path, extra_constructor_args=["--platform", "osx-arm64"])
+    tmp_env = tmp_path / "env"
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-mconda",
+            "create",
+            "-p",
+            tmp_env,
+            "-y",
+            "micromamba",
+            "--platform",
+            "osx-arm64",
+        ],
+    )
+    micromamba_arm64 = tmp_env / "bin" / "micromamba"
+    create_installer(
+        input_path,
+        tmp_path,
+        conda_exe=micromamba_arm64,
+        extra_constructor_args=["--platform", "osx-arm64"],
+    )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

#474 introduced a regression when cross-building installers (as seen in https://github.com/napari/packaging/pull/103). We are now trying to guess the type and version of the passed conda-standalone executable (which can be mamba), but we can't do so if the target platform is not the same as host (can't execute!). Instead of crashing with a traceback, we'll catch that exception and warn the user that "things might not work" but proceed anyway.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
