### PR TITLE
Add step to file issues if tests fails after merging to main

### DIFF
--- a/.github/TEST_FAILURE_REPORT_TEMPLATE.md
+++ b/.github/TEST_FAILURE_REPORT_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "{{ env.TITLE }}"
+labels: [type::bug, type::testing]
+---
+
+The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
+
+Full run: https://github.com/conda/conda-libmamba-solver/actions/runs/{{ env.RUN_ID }}
+
+(This post will be updated if another test fails, as long as this issue remains open.)

--- a/.github/TEST_FAILURE_REPORT_TEMPLATE.md
+++ b/.github/TEST_FAILURE_REPORT_TEMPLATE.md
@@ -5,6 +5,6 @@ labels: [type::bug, type::testing]
 
 The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
 
-Full run: https://github.com/conda/conda-libmamba-solver/actions/runs/{{ env.RUN_ID }}
+Full run: https://github.com/conda/constructor/actions/runs/{{ env.RUN_ID }}
 
 (This post will be updated if another test fails, as long as this issue remains open.)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,16 @@ jobs:
         run: |
           python scripts/make_docs.py
           git diff --exit-code
+      - name: Report failures
+        if: always() && github.event_name == 'push'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONSTRUCTOR_ISSUES }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: "Constructor tests failed"
+        with:
+          filename: .github/TEST_FAILURE_REPORT_TEMPLATE.md
+          update_existing: true
       - name: Upload the example installers as artifacts
         if: github.event_name == 'pull_request' && matrix.python-version == '3.9'
         uses: actions/upload-artifact@v3

--- a/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
+++ b/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Automatically create issues when tests fail after pushing to main or creating tags (#776)

--- a/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
+++ b/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Automatically create issues when tests fail after pushing to main or creating tags (#776)
+* Automatically create issues when tests fail after pushing to main or creating tags. (#775 via #776)


### PR DESCRIPTION
### Description

Adding integration tests for AzureSignTool (#771) requires access to repository secrets. These are not available when submitting a PR from a fork. Tests must then be executed after merging to `main`. This risks that errors are not caught.

To increase visibility of these problems, create an issue when tests fail after being merged into `main`.

Closes #775.

Token has been added to the repo: https://github.com/conda/infrastructure/issues/920

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?