### PR TITLE
Use separate job to create issues on test failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,8 +145,21 @@ jobs:
         run: |
           python scripts/make_docs.py
           git diff --exit-code
+      - name: Upload the example installers as artifacts
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.9'
+        uses: actions/upload-artifact@v3
+        with:
+          name: installers-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          path: "${{ runner.temp }}/examples_artifacts"
+          retention-days: 7
+
+  report:
+    name: Report failures
+    needs: [tests]
+    if: always() && github.event_name == 'push' && needs.tests.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
       - name: Report failures
-        if: always() && github.event_name == 'push'
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CONSTRUCTOR_ISSUES }}
@@ -155,13 +168,6 @@ jobs:
         with:
           filename: .github/TEST_FAILURE_REPORT_TEMPLATE.md
           update_existing: true
-      - name: Upload the example installers as artifacts
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.9'
-        uses: actions/upload-artifact@v3
-        with:
-          name: installers-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-          path: "${{ runner.temp }}/examples_artifacts"
-          retention-days: 7
 
   build:
     name: Canary Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,8 @@ jobs:
     if: always() && github.event_name == 'push' && github.ref_name == 'main' && needs.tests.result == 'failure'
     runs-on: ubuntu-latest
     steps:
+      - name: Retrieve the source code
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Report failures
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
   report:
     name: Report failures
     needs: [tests]
-    if: always() && github.event_name == 'push' && needs.tests.result == 'failure'
+    if: always() && github.event_name == 'push' && github.ref_name == 'main' && needs.tests.result == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Report failures

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,7 @@ repos:
     hooks:
       - id: shellcheck
         exclude: ^(constructor/header.sh|constructor/osx/.*sh)
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.2
+    hooks:
+      - id: check-github-workflows

--- a/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
+++ b/news/776-automatically-create-issue-on-test-failure-after-merging-to-main
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Automatically create issues when tests fail after pushing to main or creating tags. (#775 via #776)
+* Automatically create issues when tests fail after pushing to main or creating tags. (#775 via #776 and #778)


### PR DESCRIPTION
### Description

Submitting issues on test failures in the test job can result in duplicate issues since the tests run in parallel. This introduces a race condition.

Instead, use a separate job that gets called when all tests have concluded.

Also, add a pre-commit hook to check GitHub workflows, which has been missing so far.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?