### PR TITLE
Windows installer shortcut wording

### DIFF
--- a/constructor/nsis/OptionsDialog.nsh
+++ b/constructor/nsis/OptionsDialog.nsh
@@ -77,7 +77,7 @@ Function mui_AnaCustomOptions_Show
     IntOp $5 0 + 0
 
     ${If} "${ENABLE_SHORTCUTS}" == "yes"
-        ${NSD_CreateCheckbox} 0 0u 100% 11u "Create start menu shortcuts (supported packages only)."
+        ${NSD_CreateCheckbox} 0 0u 100% 11u "Create shortcuts (supported packages only)."
         IntOp $5 $5 + 11
         Pop $mui_AnaCustomOptions.CreateShortcuts
         ${NSD_SetState} $mui_AnaCustomOptions.CreateShortcuts $Ana_CreateShortcuts_State

--- a/news/785-wording-win-shortcuts
+++ b/news/785-wording-win-shortcuts
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Change wording for shortcut creation on Windows


### PR DESCRIPTION
### Description

Since menuinst v2 can now create more than just Start Menu shortcuts, adjust the wording of the options dialog to be more general.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
