### PR TITLE
Fix OS name in test matrix for AzureSignTool installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
           environment-file: dev/environment.yml
           python-version: ${{ matrix.python-version }}
       - name: Install AzureSignTool
-        if: matrix.os == 'windows'
+        if: startswith(matrix.os, 'windows')
         run: dotnet.exe tool install --global AzureSignTool
         shell: pwsh
       - name: Supply extra dependencies and install constructor

--- a/docs/source/howto.md
+++ b/docs/source/howto.md
@@ -87,6 +87,7 @@ For each tool, there are environment variables that may need to be set to config
 
 If neither `AZURE_SIGNTOOL_KEY_VAULT_ACCESSTOKEN` nor `AZURE_SIGNTOOL_KEY_VAULT_SECRET` are set, `constructor` will use a Managed Identity (`-kvm` CLI option).
 :::
+
 ### Signing and notarizing PKG installers
 
 In the case of macOS, users might get warnings for PKGs if the installers are not signed _and_ notarized. However, once these two requirements are fulfilled, the warnings disappear instantly.

--- a/news/771-add-azure-signtool-support
+++ b/news/771-add-azure-signtool-support
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add support for AzureSignTool to sign Windows installers. (#767 via #771)
+* Add support for AzureSignTool to sign Windows installers. (#767 via #771 and #790)
 
 ### Bug fixes
 

--- a/news/771-add-azure-signtool-support
+++ b/news/771-add-azure-signtool-support
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add support for AzureSignTool to sign Windows installers. (#767 via #771 and #790)
+* Add support for AzureSignTool to sign Windows installers. (#767 via #771 and #792)
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

The name of the `OS` parameter got changed in #777, but was not backported into #771 so that the AzureSignTool tests are not run when merged into `main`. This PR fixes this.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?