### PR TITLE
Add support for `virtual_specs` checks before installation

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -118,8 +118,12 @@ will be set equal to the value of `specs`.
 _required:_ no<br/>
 _type:_ list<br/>
 
-A list of virtual packages that must be satisfied at install time.Virtual
+A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+These specs are dry-run solved offline by the bundled `--conda-exe` binary.
+In PKG installers, `__osx` specs can be checked natively without the solver
+being involved as long as: the version constraint is single-component and only
+uses the operator `>=` or `<=`.
 
 ### `exclude`
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -122,8 +122,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as: the version constraint is single-component and only
-uses the operator `>=` or `<=`.
+being involved as long as only `>=`, `<=` or `,` are used.
 
 ### `exclude`
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -122,7 +122,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<=` or `,` are used.
+being involved as long as only `>=`, `<` or `,` are used.
 
 ### `exclude`
 

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -113,6 +113,14 @@ for example, if `python=3.6` is included, then conda will always seek versions
 of packages compatible with Python 3.6. If this is option is not provided, it
 will be set equal to the value of `specs`.
 
+### `virtual_specs`
+
+_required:_ no<br/>
+_type:_ list<br/>
+
+A list of virtual packages that must be satisfied at install time.Virtual
+packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+
 ### `exclude`
 
 _required:_ no<br/>

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -121,8 +121,9 @@ _type:_ list<br/>
 A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
-In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<` or `,` are used.
+In SH installers, `__glibc>=x.y` and `__osx>=x.y` specs can be checked with
+Bash only. In PKG installers, `__osx` specs can be checked natively without
+the solver being involved as long as only `>=`, `<` or `,` are used.
 
 ### `exclude`
 
@@ -821,7 +822,7 @@ _required:_ no<br/>
 _type:_ list<br/>
 
 Temporary files that could be referenced in the installation process (i.e. customized
- `welcome_file` and `conclusion_file` (see above)) . Should be a list of
+`welcome_file` and `conclusion_file` (see above)) . Should be a list of
 file paths, relative to the directory where `construct.yaml` is. In Windows, these
 files will be copied into a temporary folder, the NSIS `$PLUGINSDIR`, during
 install process (Windows only).

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -87,8 +87,9 @@ will be set equal to the value of `specs`.
 A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
-In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<` or `,` are used.
+In SH installers, `__glibc>=x.y` and `__osx>=x.y` specs can be checked with
+Bash only. In PKG installers, `__osx` specs can be checked natively without
+the solver being involved as long as only `>=`, `<` or `,` are used.
 '''),
 
     ('exclude',                False, list, '''
@@ -602,7 +603,7 @@ This setting can be passed as a list of:
 
     ('temp_extra_files', False, list, '''
 Temporary files that could be referenced in the installation process (i.e. customized
- `welcome_file` and `conclusion_file` (see above)) . Should be a list of
+`welcome_file` and `conclusion_file` (see above)) . Should be a list of
 file paths, relative to the directory where `construct.yaml` is. In Windows, these
 files will be copied into a temporary folder, the NSIS `$PLUGINSDIR`, during
 install process (Windows only).

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -84,8 +84,12 @@ will be set equal to the value of `specs`.
 '''),
 
     ('virtual_specs',          False, list, '''
-A list of virtual packages that must be satisfied at install time.Virtual
+A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+These specs are dry-run solved offline by the bundled `--conda-exe` binary.
+In PKG installers, `__osx` specs can be checked natively without the solver
+being involved as long as: the version constraint is single-component and only
+uses the operator `>=` or `<=`.
 '''),
 
     ('exclude',                False, list, '''

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -88,7 +88,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<=` or `,` are used.
+being involved as long as only `>=`, `<` or `,` are used.
 '''),
 
     ('exclude',                False, list, '''

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -83,6 +83,11 @@ of packages compatible with Python 3.6. If this is option is not provided, it
 will be set equal to the value of `specs`.
 '''),
 
+    ('virtual_specs',          False, list, '''
+A list of virtual packages that must be satisfied at install time.Virtual
+packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+'''),
+
     ('exclude',                False, list, '''
 A list of package names to be excluded after the `specs` have been resolved.
 For example, you can say that `readline` should be excluded, even though it

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -88,8 +88,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as: the version constraint is single-component and only
-uses the operator `>=` or `<=`.
+being involved as long as only `>=`, `<=` or `,` are used.
 '''),
 
     ('exclude',                False, list, '''

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -423,6 +423,13 @@ export TMP_BACKUP="${TMP:-}"
 export TMP="$PREFIX/install_tmp"
 mkdir -p "$TMP"
 
+# Check whether the virtual specs can be satisfied
+if [ "__VIRTUAL_SPECS__" != "" ]; then
+    CONDA_QUIET="$BATCH" \
+    CONDA_SOLVER="classic" \
+    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX" --offline __VIRTUAL_SPECS__
+fi
+
 # Create $PREFIX/.nonadmin if the installation didn't require superuser permissions
 if [ "$(id -u)" -ne 0 ]; then
     touch "$PREFIX/.nonadmin"

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -24,7 +24,11 @@ fi
 #if osx and min_osx_version
 min_osx_version="__MIN_OSX_VERSION__"
 system_osx_version=$(SYSTEM_VERSION_COMPAT=0 sw_vers -productVersion)
-if (( $(printf "%02d%02d%02d" ${system_osx_version//./ }) < $(printf "%02d%02d%02d" ${min_osx_version//./ }) )); then
+# shellcheck disable=SC2183 disable=SC2046
+int_min_osx_version="$(printf "%02d%02d%02d" $(echo "$min_osx_version" | sed 's/\./ /g'))" 
+# shellcheck disable=SC2183 disable=SC2046
+int_system_osx_version="$(printf "%02d%02d%02d" $(echo "$system_osx_version" | sed 's/\./ /g'))"
+if [  "$int_system_osx_version" -lt "$int_min_osx_version" ]; then
     echo "Installer requires macOS >=${min_osx_version}, but system has ${system_osx_version}."
     exit 1
 fi
@@ -33,7 +37,11 @@ fi
 min_glibc_version="__MIN_GLIBC_VERSION__"
 # ldd reports glibc in the last field of the first line
 system_glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
-if (( $(printf "%02d%02d%02d" ${system_glibc_version//./ }) < $(printf "%02d%02d%02d" ${min_glibc_version//./ }) )); then
+# shellcheck disable=SC2183 disable=SC2046
+int_min_glibc_version="$(printf "%02d%02d%02d" $(echo "$min_glibc_version" | sed 's/\./ /g'))"
+# shellcheck disable=SC2183 disable=SC2046
+int_system_glibc_version="$(printf "%02d%02d%02d" $(echo "$system_glibc_version" | sed 's/\./ /g'))"
+if [  "$int_system_glibc_version" -lt "$int_min_glibc_version" ]; then
     echo "Installer requires GLIBC >=${min_glibc_version}, but system has ${system_glibc_version}."
     exit 1
 fi

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -25,7 +25,7 @@ fi
 min_osx_version="__MIN_OSX_VERSION__"
 system_osx_version=$(SYSTEM_VERSION_COMPAT=0 sw_vers -productVersion)
 # shellcheck disable=SC2183 disable=SC2046
-int_min_osx_version="$(printf "%02d%02d%02d" $(echo "$min_osx_version" | sed 's/\./ /g'))" 
+int_min_osx_version="$(printf "%02d%02d%02d" $(echo "$min_osx_version" | sed 's/\./ /g'))"
 # shellcheck disable=SC2183 disable=SC2046
 int_system_osx_version="$(printf "%02d%02d%02d" $(echo "$system_osx_version" | sed 's/\./ /g'))"
 if [  "$int_system_osx_version" -lt "$int_min_osx_version" ]; then

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -38,7 +38,7 @@ min_glibc_version="__MIN_GLIBC_VERSION__"
 case "$(ldd --version 2>&1)" in
     *musl*)
         # musl ldd will report musl version; call ld.so directly
-        system_glibc_version=$($(ls -1 /lib64/ld-linux-*.so* | head -1) --version | awk 'NR==1{ sub(/\.$/, ""); print $NF}')
+        system_glibc_version=$($(ls -1 /lib*/ld-linux-*.so* | head -1) --version | awk 'NR==1{ sub(/\.$/, ""); print $NF}')
     ;;
     *)
         # ldd reports glibc in the last field of the first line

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -424,6 +424,7 @@ export TMP="$PREFIX/install_tmp"
 mkdir -p "$TMP"
 
 # Check whether the virtual specs can be satisfied
+# shellcheck disable=SC2050
 if [ "__VIRTUAL_SPECS__" != "" ]; then
     CONDA_QUIET="$BATCH" \
     CONDA_SOLVER="classic" \

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -424,6 +424,9 @@ export TMP="$PREFIX/install_tmp"
 mkdir -p "$TMP"
 
 # Check whether the virtual specs can be satisfied
+# We need to specify CONDA_SOLVER=classic for conda-standalone
+# to work around this bug in conda-libmamba-solver:
+# https://github.com/conda/conda-libmamba-solver/issues/480
 # shellcheck disable=SC2050
 if [ "__VIRTUAL_SPECS__" != "" ]; then
     CONDA_QUIET="$BATCH" \

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -38,7 +38,7 @@ min_glibc_version="__MIN_GLIBC_VERSION__"
 case "$(ldd --version 2>&1)" in
     *musl*)
         # musl ldd will report musl version; call ld.so directly
-        system_glibc_version=$($(ls -1 /lib*/ld-linux-*.so* | head -1) --version | awk 'NR==1{ sub(/\.$/, ""); print $NF}')
+        system_glibc_version=$($(find /lib/ /lib64/ -name 'ld-linux-*.so*' 2>/dev/null | head -1) --version | awk 'NR==1{ sub(/\.$/, ""); print $NF}')
     ;;
     *)
         # ldd reports glibc in the last field of the first line

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -21,6 +21,24 @@ if ! echo "$0" | grep '\.sh$' > /dev/null; then
     return 1
 fi
 
+#if osx and min_osx_version
+min_osx_version="__MIN_OSX_VERSION__"
+system_osx_version=$(SYSTEM_VERSION_COMPAT=0 sw_vers -productVersion)
+if (( $(printf "%02d%02d%02d" ${system_osx_version//./ }) < $(printf "%02d%02d%02d" ${min_osx_version//./ }) )); then
+    echo "Installer requires macOS >=${min_osx_version}, but system has ${system_osx_version}."
+    exit 1
+fi
+#endif
+#if linux and min_glibc_version
+min_glibc_version="__MIN_GLIBC_VERSION__"
+# ldd reports glibc in the last field of the first line
+system_glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
+if (( $(printf "%02d%02d%02d" ${system_glibc_version//./ }) < $(printf "%02d%02d%02d" ${min_glibc_version//./ }) )); then
+    echo "Installer requires GLIBC >=${min_glibc_version}, but system has ${system_glibc_version}."
+    exit 1
+fi
+#endif
+
 # Export variables to make installer metadata available to pre/post install scripts
 # NOTE: If more vars are added, make sure to update the examples/scripts tests too
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -35,8 +35,16 @@ fi
 #endif
 #if linux and min_glibc_version
 min_glibc_version="__MIN_GLIBC_VERSION__"
-# ldd reports glibc in the last field of the first line
-system_glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
+case "$(ldd --version 2>&1)" in
+    *musl*)
+        # musl ldd will report musl version; call ld.so directly
+        system_glibc_version=$($(ls -1 /lib64/ld-linux-*.so* | head -1) --version | awk 'NR==1{ sub(/\.$/, ""); print $NF}')
+    ;;
+    *)
+        # ldd reports glibc in the last field of the first line
+        system_glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
+    ;;
+esac
 # shellcheck disable=SC2183 disable=SC2046
 int_min_glibc_version="$(printf "%02d%02d%02d" $(echo "$min_glibc_version" | sed 's/\./ /g'))"
 # shellcheck disable=SC2183 disable=SC2046

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -115,7 +115,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     elif info.get("signing_certificate"):
         info["windows_signing_tool"] = "signtool"
 
-    for key in 'specs', 'packages':
+    for key in 'specs', 'packages', 'virtual_specs':
         if key not in info:
             continue
         if isinstance(info[key], str):
@@ -137,7 +137,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
                 new_extras.append({orig: dest})
         info[extra_type] = new_extras
 
-    for key in 'channels', 'specs', 'exclude', 'packages', 'menu_packages':
+    for key in 'channels', 'specs', 'exclude', 'packages', 'menu_packages', 'virtual_specs':
         if key in info:
             # ensure strings in those lists are stripped
             info[key] = [line.strip() for line in info[key]]

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -122,7 +122,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             info[key] = list(yield_lines(join(dir_path, info[key])))
         if key == "virtual_specs":
             for value in info[key]:
-                if not value.starswith("__"):
+                if not value.startswith("__"):
                     raise ValueError(
                         "'virtual_specs' can only include virtual package names like '__name', "
                         f"but you supplied: {value}."

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -120,6 +120,13 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             continue
         if isinstance(info[key], str):
             info[key] = list(yield_lines(join(dir_path, info[key])))
+        if key == "virtual_specs":
+            for value in info[key]:
+                if not value.starswith("__"):
+                    raise ValueError(
+                        "'virtual_specs' can only include virtual package names like '__name', "
+                        f"but you supplied: {value}."
+                    )
 
     # normalize paths to be copied; if they are relative, they must be to
     # construct.yaml's parent (dir_path)

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1132,6 +1132,18 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_PLAT", "${PLATFORM}").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_TYPE", "EXE").r0'
 
+    ${If} '__VIRTUAL_SPECS__' != ''
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "classic").r0'
+    SetDetailsPrint TextOnly
+    DetailPrint "Checking virtual specs..."
+    push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR" --offline __VIRTUAL_SPECS__'
+    push 'Virtual specs checks failed'
+    push 'WithLog'
+    call AbortRetryNSExecWait
+    SetDetailsPrint both
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "").r0'
+    ${EndIf}
+
     @PKG_COMMANDS@
 
     SetDetailsPrint TextOnly

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1132,12 +1132,12 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_PLAT", "${PLATFORM}").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_TYPE", "EXE").r0'
 
-    ${If} '__VIRTUAL_SPECS__' != ''
+    ${If} '@VIRTUAL_SPECS@' != ''
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "classic").r0'
     SetDetailsPrint TextOnly
     DetailPrint "Checking virtual specs..."
-    push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR" --offline __VIRTUAL_SPECS__'
-    push 'Failed to check virtual specs: __VIRTUAL_SPECS__'
+    push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR" --offline @VIRTUAL_SPECS@'
+    push 'Failed to check virtual specs: @VIRTUAL_SPECS@'
     push 'WithLog'
     call AbortRetryNSExecWait
     SetDetailsPrint both

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1133,6 +1133,9 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_TYPE", "EXE").r0'
 
     ${If} '@VIRTUAL_SPECS@' != ''
+    # We need to specify CONDA_SOLVER=classic for conda-standalone
+    # to work around this bug in conda-libmamba-solver:
+    # https://github.com/conda/conda-libmamba-solver/issues/480
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "classic").r0'
     SetDetailsPrint TextOnly
     DetailPrint "Checking virtual specs..."

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1137,7 +1137,7 @@ Section "Install"
     SetDetailsPrint TextOnly
     DetailPrint "Checking virtual specs..."
     push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR" --offline __VIRTUAL_SPECS__'
-    push 'Virtual specs checks failed'
+    push 'Failed to check virtual specs: __VIRTUAL_SPECS__'
     push 'WithLog'
     call AbortRetryNSExecWait
     SetDetailsPrint both

--- a/constructor/osx/prepare_installation.sh
+++ b/constructor/osx/prepare_installation.sh
@@ -31,6 +31,14 @@ chmod +x "$CONDA_EXEC"
 mkdir -p "$PREFIX/conda-meta"
 touch "$PREFIX/conda-meta/history"
 
+# Check whether the virtual specs can be satisfied
+# shellcheck disable=SC2050
+if [ "__VIRTUAL_SPECS__" != "" ]; then
+    CONDA_QUIET="$BATCH" \
+    CONDA_SOLVER="classic" \
+    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX" --offline __VIRTUAL_SPECS__
+fi
+
 # Create $PREFIX/.nonadmin if the installation didn't require superuser permissions
 if [ "$(id -u)" -ne 0 ]; then
     touch "$PREFIX/.nonadmin"

--- a/constructor/osx/prepare_installation.sh
+++ b/constructor/osx/prepare_installation.sh
@@ -32,6 +32,9 @@ mkdir -p "$PREFIX/conda-meta"
 touch "$PREFIX/conda-meta/history"
 
 # Check whether the virtual specs can be satisfied
+# We need to specify CONDA_SOLVER=classic for conda-standalone
+# to work around this bug in conda-libmamba-solver:
+# https://github.com/conda/conda-libmamba-solver/issues/480
 # shellcheck disable=SC2050
 if [ "__VIRTUAL_SPECS__" != "" ]; then
     CONDA_QUIET="$BATCH" \

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -197,11 +197,18 @@ def modify_xml(xml_path, info):
             continue
         if not spec.version:
             continue
-        operator = spec.version.operator_func.__name__
-        if operator == "ge":
-            osx_versions["min"] = str(spec.version.matcher_vo)
-        elif operator == "le":
-            osx_versions["max"] = str(spec.version.matcher_vo)
+        if "|" in spec.version.spec_str:
+            raise ValueError("Can't process `|`-joined versions. Only `,` is allowed.")
+        versions = spec.version.tup if "," in spec.version.spec_str else (spec.version,)
+        for version in versions:
+            operator = version.operator_func.__name__
+            if operator == "ge":
+                osx_versions["min"] = str(version.matcher_vo)
+            elif operator == "le":
+                osx_versions["max"] = str(version.matcher_vo)
+            else:
+                raise ValueError(
+                    f"Invalid version operator for {spec}. Only `<=` or `>=` are supported.")
 
     if osx_versions:
         allowed_os_versions = ET.Element("allowed-os-versions")

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -190,6 +190,7 @@ def modify_xml(xml_path, info):
         root.append(readme)
 
     # -- __osx virtual package checks -- #
+    # Reference: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html
     osx_versions = {}
     for spec in info.get("virtual_specs", ()):
         spec = MatchSpec(spec)
@@ -204,13 +205,16 @@ def modify_xml(xml_path, info):
             operator = version.operator_func.__name__
             if operator == "ge":
                 osx_versions["min"] = str(version.matcher_vo)
-            elif operator == "le":
-                osx_versions["max"] = str(version.matcher_vo)
+            elif operator == "lt":
+                osx_versions["before"] = str(version.matcher_vo)
             else:
                 raise ValueError(
-                    f"Invalid version operator for {spec}. Only `<=` or `>=` are supported.")
+                    f"Invalid version operator for {spec}. Only `<` or `>=` are supported."
+                )
 
     if osx_versions:
+        if "min" not in osx_versions:
+            raise ValueError("Specifying __osx requires a lower bound with `>=`")
         allowed_os_versions = ET.Element("allowed-os-versions")
         allowed_os_versions.append(ET.Element("os-version", osx_versions))
         volume_check = ET.Element("volume-check")

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -190,7 +190,7 @@ def modify_xml(xml_path, info):
         root.append(readme)
 
     # -- __osx virtual package checks -- #
-    # Reference: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html
+    # Reference: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html  # noqa
     osx_versions = {}
     for spec in info.get("virtual_specs", ()):
         spec = MatchSpec(spec)

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -192,7 +192,7 @@ def modify_xml(xml_path, info):
 
     # -- __osx virtual package checks -- #
     # Reference: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html  # noqa
-    osx_versions = parse_virtual_specs(info).get("__osx", {})
+    osx_versions = parse_virtual_specs(info).get("__osx")
     if osx_versions:
         if "min" not in osx_versions:
             raise ValueError("Specifying __osx requires a lower bound with `>=`")

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 import shutil
 import sys
 import xml.etree.ElementTree as ET
@@ -346,6 +347,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
         'SHORTCUTS': shortcuts_flags(info),
         'ENABLE_SHORTCUTS': str(info['_enable_shortcuts']).lower(),
         'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
+        'VIRTUAL_SPECS': shlex.join(info.get("virtual_specs", ())),
     }
     data = preprocess(data, ppd)
     custom_variables = info.get('script_env_variables', {})

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -206,7 +206,9 @@ def modify_xml(xml_path, info):
     if osx_versions:
         allowed_os_versions = ET.Element("allowed-os-versions")
         allowed_os_versions.append(ET.Element("os-version", osx_versions))
-        root.append(allowed_os_versions)
+        volume_check = ET.Element("volume-check")
+        volume_check.append(allowed_os_versions)
+        root.append(volume_check)
 
     # See below for an explanation of the consequences of this
     # customLocation value.

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -10,7 +10,7 @@ from plistlib import dump as plist_dump
 from tempfile import NamedTemporaryFile
 
 from . import preconda
-from .conda_interface import conda_context, MatchSpec
+from .conda_interface import MatchSpec, conda_context
 from .construct import ns_platform, parse
 from .imaging import write_images
 from .utils import (

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -192,7 +192,7 @@ def modify_xml(xml_path, info):
 
     # -- __osx virtual package checks -- #
     # Reference: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html  # noqa
-    osx_versions = parse_virtual_specs(info)["__osx"]
+    osx_versions = parse_virtual_specs(info).get("__osx", {})
     if osx_versions:
         if "min" not in osx_versions:
             raise ValueError("Specifying __osx requires a lower bound with `>=`")

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -99,12 +99,12 @@ def get_header(conda_exec, tarball, info):
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])
 
-    virtual_specs = parse_virtual_specs(info) 
+    virtual_specs = parse_virtual_specs(info)
     if min_osx_version := virtual_specs["__osx"].get("min"):
         replace['MIN_OSX_VERSION'] = ppd['min_osx_version'] = min_osx_version
     if min_glibc_version := virtual_specs["__glibc"].get("min"):
         replace['MIN_GLIBC_VERSION'] = ppd['min_glibc_version'] = min_glibc_version
-    
+
     data = read_header_template()
     data = preprocess(data, ppd)
     custom_variables = info.get('script_env_variables', {})

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -100,9 +100,9 @@ def get_header(conda_exec, tarball, info):
         replace['LICENSE'] = read_ascii_only(info['license_file'])
 
     virtual_specs = parse_virtual_specs(info)
-    if min_osx_version := virtual_specs["__osx"].get("min"):
+    if min_osx_version := virtual_specs.get("__osx", {}).get("min"):
         replace['MIN_OSX_VERSION'] = ppd['min_osx_version'] = min_osx_version
-    if min_glibc_version := virtual_specs["__glibc"].get("min"):
+    if min_glibc_version := virtual_specs.get("__glibc", {}).get("min"):
         replace['MIN_GLIBC_VERSION'] = ppd['min_glibc_version'] = min_glibc_version
 
     data = read_header_template()

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import shlex
 import shutil
 import stat
 import tarfile
@@ -92,6 +93,7 @@ def get_header(conda_exec, tarball, info):
         'SHORTCUTS': shortcuts_flags(info),
         'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
         'TOTAL_INSTALLATION_SIZE_KB': str(approx_size_kb(info, "total")),
+        'VIRTUAL_SPECS': shlex.join(info.get("virtual_specs", ()))
     }
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -24,6 +24,7 @@ from .utils import (
     fill_template,
     get_final_channels,
     hash_files,
+    parse_virtual_specs,
     preprocess,
     read_ascii_only,
     shortcuts_flags,
@@ -98,6 +99,12 @@ def get_header(conda_exec, tarball, info):
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])
 
+    virtual_specs = parse_virtual_specs(info) 
+    if min_osx_version := virtual_specs["__osx"].get("min"):
+        replace['MIN_OSX_VERSION'] = ppd['min_osx_version'] = min_osx_version
+    if min_glibc_version := virtual_specs["__glibc"].get("min"):
+        replace['MIN_GLIBC_VERSION'] = ppd['min_glibc_version'] = min_glibc_version
+    
     data = read_header_template()
     data = preprocess(data, ppd)
     custom_variables = info.get('script_env_variables', {})

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -100,10 +100,10 @@ def get_header(conda_exec, tarball, info):
         replace['LICENSE'] = read_ascii_only(info['license_file'])
 
     virtual_specs = parse_virtual_specs(info)
-    if min_osx_version := virtual_specs.get("__osx", {}).get("min"):
-        replace['MIN_OSX_VERSION'] = ppd['min_osx_version'] = min_osx_version
-    if min_glibc_version := virtual_specs.get("__glibc", {}).get("min"):
-        replace['MIN_GLIBC_VERSION'] = ppd['min_glibc_version'] = min_glibc_version
+    min_osx_version = virtual_specs.get("__osx", {}).get("min") or ""
+    replace['MIN_OSX_VERSION'] = ppd['min_osx_version'] = min_osx_version
+    min_glibc_version = virtual_specs.get("__glibc", {}).get("min") or ""
+    replace['MIN_GLIBC_VERSION'] = ppd['min_glibc_version'] = min_glibc_version
 
     data = read_header_template()
     data = preprocess(data, ppd)

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -287,7 +287,7 @@ def check_required_env_vars(env_vars):
 def parse_virtual_specs(info) -> dict:
     from .conda_interface import MatchSpec  # prevent circular import
 
-    specs = {"osx": {}, "glibc": {}}
+    specs = {"__osx": {}, "__glibc": {}}
     for spec in info.get("virtual_specs", ()):
         spec = MatchSpec(spec)
         if spec.name not in ("__osx", "__glibc"):

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -282,3 +282,30 @@ def check_required_env_vars(env_vars):
         raise RuntimeError(
             f"Missing required environment variables {', '.join(missing_vars)}."
         )
+
+
+def parse_virtual_specs(info) -> dict:
+    from .conda_interface import MatchSpec  # prevent circular import
+
+    specs = {"osx": {}, "glibc": {}}
+    for spec in info.get("virtual_specs", ()):
+        spec = MatchSpec(spec)
+        if spec.name not in ("__osx", "__glibc"):
+            continue
+        if not spec.version:
+            continue
+        if "|" in spec.version.spec_str:
+            raise ValueError("Can't process `|`-joined versions. Only `,` is allowed.")
+        versions = spec.version.tup if "," in spec.version.spec_str else (spec.version,)
+        for version in versions:
+            operator = version.operator_func.__name__
+            if operator == "ge":
+                specs[spec.name]["min"] = str(version.matcher_vo)
+            elif operator == "lt" and spec.name == "__osx":
+                specs[spec.name]["before"] = str(version.matcher_vo)
+            else:
+                raise ValueError(
+                    f"Invalid version operator for {spec}. "
+                    "__osx only supports `<` or `>=`; __glibc only supports `>=`."
+                )
+    return specs

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -274,7 +274,6 @@ def make_nsi(
         'PRE_UNINSTALL': '@pre_uninstall.bat',
         'INDEX_CACHE': '@cache',
         'REPODATA_RECORD': '@repodata_record.json',
-        'VIRTUAL_SPECS': " ".join([f'"{spec}"' for spec in info.get("virtual_specs", ())])
     }
 
     # These are NSIS predefines and must not be replaced
@@ -375,6 +374,8 @@ def make_nsi(
             else ''
         ),
         ('@TEMP_EXTRA_FILES@', '\n    '.join(insert_tempfiles_commands(temp_extra_files))),
+        ('@VIRTUAL_SPECS@', " ".join([f'"{spec}"' for spec in info.get("virtual_specs", ())])),
+
     ]:
         data = data.replace(key, value)
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -274,6 +274,7 @@ def make_nsi(
         'PRE_UNINSTALL': '@pre_uninstall.bat',
         'INDEX_CACHE': '@cache',
         'REPODATA_RECORD': '@repodata_record.json',
+        'VIRTUAL_SPECS': " ".join([f'"{spec}"' for spec in info.get("virtual_specs", ())])
     }
 
     # These are NSIS predefines and must not be replaced

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -118,8 +118,12 @@ will be set equal to the value of `specs`.
 _required:_ no<br/>
 _type:_ list<br/>
 
-A list of virtual packages that must be satisfied at install time.Virtual
+A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+These specs are dry-run solved offline by the bundled `--conda-exe` binary.
+In PKG installers, `__osx` specs can be checked natively without the solver
+being involved as long as: the version constraint is single-component and only
+uses the operator `>=` or `<=`.
 
 ### `exclude`
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -122,8 +122,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as: the version constraint is single-component and only
-uses the operator `>=` or `<=`.
+being involved as long as only `>=`, `<=` or `,` are used.
 
 ### `exclude`
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -122,7 +122,7 @@ A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
 In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<=` or `,` are used.
+being involved as long as only `>=`, `<` or `,` are used.
 
 ### `exclude`
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -113,6 +113,14 @@ for example, if `python=3.6` is included, then conda will always seek versions
 of packages compatible with Python 3.6. If this is option is not provided, it
 will be set equal to the value of `specs`.
 
+### `virtual_specs`
+
+_required:_ no<br/>
+_type:_ list<br/>
+
+A list of virtual packages that must be satisfied at install time.Virtual
+packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
+
 ### `exclude`
 
 _required:_ no<br/>

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -121,8 +121,9 @@ _type:_ list<br/>
 A list of virtual packages that must be satisfied at install time. Virtual
 packages must start with `__`. For example, `__osx>=11` or `__glibc>=2.24`.
 These specs are dry-run solved offline by the bundled `--conda-exe` binary.
-In PKG installers, `__osx` specs can be checked natively without the solver
-being involved as long as only `>=`, `<` or `,` are used.
+In SH installers, `__glibc>=x.y` and `__osx>=x.y` specs can be checked with
+Bash only. In PKG installers, `__osx` specs can be checked natively without
+the solver being involved as long as only `>=`, `<` or `,` are used.
 
 ### `exclude`
 
@@ -821,7 +822,7 @@ _required:_ no<br/>
 _type:_ list<br/>
 
 Temporary files that could be referenced in the installation process (i.e. customized
- `welcome_file` and `conclusion_file` (see above)) . Should be a list of
+`welcome_file` and `conclusion_file` (see above)) . Should be a list of
 file paths, relative to the directory where `construct.yaml` is. In Windows, these
 files will be copied into a temporary folder, the NSIS `$PLUGINSDIR`, during
 install process (Windows only).

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -11,9 +11,9 @@ specs:
   - ca-certificates
 
 virtual_specs:
-  - __osx>=5.1,<9    # [osx]
-  - __glibc>=20  # [linux]
-  - __win<0      # [win]
+  - __osx>=5.1,<9  # [osx]
+  - __glibc>=20    # [linux]
+  - __win<0        # [win]
 
 initialize_by_default: false
 register_python: false

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -11,7 +11,7 @@ specs:
   - ca-certificates
 
 virtual_specs:
-  - __osx<=9    # [osx]
+  - __osx>=5.1,<9    # [osx]
   - __glibc>=20  # [linux]
   - __win<0      # [win]
 

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -17,4 +17,6 @@ virtual_specs:
 
 initialize_by_default: false
 register_python: false
+check_path_spaces: false
+check_path_length: false
 installer_type: all

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -1,0 +1,20 @@
+name: virtual_specs
+
+version: 0.0.1
+
+keep_pkgs: True
+
+channels:
+  - conda-forge
+
+specs:
+  - ca-certificates
+
+virtual_specs:
+  - __osx>=20    # [osx]
+  - __glibc>=20  # [linux]
+  - __win<0      # [win]
+
+initialize_by_default: false
+register_python: false
+installer_type: all

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -11,7 +11,7 @@ specs:
   - ca-certificates
 
 virtual_specs:
-  - __osx>=20    # [osx]
+  - __osx<=9    # [osx]
   - __glibc>=20  # [linux]
   - __win<0      # [win]
 

--- a/examples/virtual_specs/construct.yaml
+++ b/examples/virtual_specs/construct.yaml
@@ -11,7 +11,7 @@ specs:
   - ca-certificates
 
 virtual_specs:
-  - __osx>=5.1,<9  # [osx]
+  - __osx>=30,<31  # [osx]
   - __glibc>=20    # [linux]
   - __win<0        # [win]
 

--- a/news/809-virtual-specs
+++ b/news/809-virtual-specs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* A new setting `virtual_specs` allows the installer to run some solver checks before the installation proceeds. Useful for checking whether certain virtual package versions can be satisfied. (#809)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -662,3 +662,11 @@ def test_cross_osx_building(tmp_path):
         extra_constructor_args=["--platform", "osx-arm64"],
         config_filename="constructor_input.yaml",
     )
+
+
+def test_virtual_specs(tmp_path, request):
+    input_path = _example_path("virtual_specs")
+    for installer, install_dir in create_installer(input_path, tmp_path):
+        with pytest.raises(subprocess.CalledProcessError):
+            # This example is configured to fail due to unsatisfiable virtual specs
+            _run_installer(input_path, installer, install_dir, request=request)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -704,9 +704,10 @@ def test_virtual_specs(tmp_path, request):
             # The GUI does provide a better message with the min version and so on
             # but on the CLI we fail with this one instead
             msg = "Cannot install on volume"
-        elif CONDA_EXE == "micromamba":
-            msg = "is missing on the system"
-        else:
-            msg = "PackagesNotFoundError"
+        else: 
+            # The shell installer has its own Bash code for __glibc and __osx
+            # Other virtual specs like __cuda are checked by conda-standalone/micromamba
+            # and will fail with solver errors like PackagesNotFound etc
+            msg = "Installer requires"
         assert process.returncode != 0
         assert msg in process.stdout + process.stderr

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -704,7 +704,7 @@ def test_virtual_specs(tmp_path, request):
             # The GUI does provide a better message with the min version and so on
             # but on the CLI we fail with this one instead
             msg = "Cannot install on volume"
-        else: 
+        else:
             # The shell installer has its own Bash code for __glibc and __osx
             # Other virtual specs like __cuda are checked by conda-standalone/micromamba
             # and will fail with solver errors like PackagesNotFound etc

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -700,7 +700,11 @@ def test_virtual_specs(tmp_path, request):
             with pytest.raises(AssertionError, match="Failed to check virtual specs"):
                 _check_installer_log(install_dir)
             continue
-        if CONDA_EXE == "micromamba":
+        elif installer.suffix == ".pkg":
+            # The GUI does provide a better message with the min version and so on
+            # but on the CLI we fail with this one instead
+            msg = "Cannot install on volume"
+        elif CONDA_EXE == "micromamba":
             msg = "is missing on the system"
         else:
             msg = "PackagesNotFoundError"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -667,6 +667,6 @@ def test_cross_osx_building(tmp_path):
 def test_virtual_specs(tmp_path, request):
     input_path = _example_path("virtual_specs")
     for installer, install_dir in create_installer(input_path, tmp_path):
-        with pytest.raises(subprocess.CalledProcessError):
+        # with pytest.raises(subprocess.CalledProcessError):
             # This example is configured to fail due to unsatisfiable virtual specs
-            _run_installer(input_path, installer, install_dir, request=request)
+        _run_installer(input_path, installer, install_dir, request=request)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -224,7 +224,7 @@ def _sentinel_file_checks(example_path, install_dir):
         if (example_path / script).exists() and not (install_dir / sentinel).exists():
             raise AssertionError(
                 f"Sentinel file for {script_prefix}_install not found! "
-                f"{install_dir} contents:\n" + "\n".join(sorted(install_dir.iterdir()))
+                f"{install_dir} contents:\n" + "\n".join(sorted(map(str, install_dir.iterdir())))
             )
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -257,8 +257,8 @@ def _run_installer(
         )
     elif installer.suffix == ".pkg":
         if request and ON_CI:
-            request.addfinalizer(lambda: shutil.rmtree(str(install_dir)))
-        process = _run_installer_pkg(
+            request.addfinalizer(lambda: shutil.rmtree(str(install_dir), ignore_errors=True))
+        process, _ = _run_installer_pkg(
             installer,
             install_dir,
             example_path=example_path,

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -57,6 +57,8 @@ def test_linux_template_processing():
         enable_shortcuts,
         check_path_spaces,
         arch,
+        min_glibc_version,
+        min_osx_version,
     ) in itertools.product(
         [False, True],
         [False, True],
@@ -72,6 +74,8 @@ def test_linux_template_processing():
         [False, True],
         [False, True],
         ["x86", "x86_64", " ppc64le", "s390x", "aarch64"],
+        [None, "2.17"],
+        [None, "10.13"],
     ):
         params = {
             "has_license": has_license,
@@ -93,12 +97,14 @@ def test_linux_template_processing():
             "initialize_by_default": initialize_by_default,
             "enable_shortcuts": enable_shortcuts,
             "check_path_spaces": check_path_spaces,
+            "min_glibc_version": min_glibc_version,
+            "min_osx_version": min_osx_version,
         }
         processed = preprocess(template, params)
         for template_string in ["#if", "#else", "#endif"]:
             if template_string in processed:
                 errors.append(
-                    f"Found '{template_string}' after " f"processing header.sh with '{params}'."
+                    f"Found '{template_string}' after processing header.sh with '{params}'."
                 )
 
     assert not errors
@@ -156,6 +162,8 @@ def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
 @pytest.mark.parametrize("arch", ["x86_64", "aarch64"])
 @pytest.mark.parametrize("check_path_spaces", [True])
 @pytest.mark.parametrize("enable_shortcuts", ["true"])
+@pytest.mark.parametrize("min_glibc_version", ["2.17"])
+@pytest.mark.parametrize("min_osx_version", ["10.13"])
 def test_template_shellcheck(
     osx,
     arch,
@@ -171,6 +179,8 @@ def test_template_shellcheck(
     direct_execute_post_install,
     check_path_spaces,
     enable_shortcuts,
+    min_glibc_version,
+    min_osx_version,
 ):
     template = read_header_template()
     processed = preprocess(
@@ -195,9 +205,12 @@ def test_template_shellcheck(
             "initialize_by_default": initialize_by_default,
             "check_path_spaces": check_path_spaces,
             "enable_shortcuts": enable_shortcuts,
+            "min_glibc_version": min_glibc_version,
+            "min_osx_version": min_osx_version,
         },
     )
 
     findings, returncode = run_shellcheck(processed)
+    print(*findings, sep="\n")
     assert findings == []
     assert returncode == 0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adds a new key `virtual_specs`.

This key allows installers to run some solver checks before the installation proceeds. Meant to be used with minimum required versions for virtual packages like `__osx` or `__glibc`. We need it because the solver only runs at installer build time, not on the target machine. 

We perform an offline dry-run just to check that the solver passes there. On PKG installers, we fast track the `__osx` checks so the native checks run as soon as possible. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
