### PR TITLE
Add option to output file with installer hashes

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -825,6 +825,9 @@ _type:_ list<br/>
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
+- `hash`: The hash of the installer files.
+    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+       https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -826,7 +826,7 @@ Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
 - `hash`: The hash of the installer files.
-    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+    - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -34,7 +34,7 @@ def process_build_outputs(info):
                 f"Available keys: {tuple(OUTPUT_HANDLERS.keys())}"
             )
         outpath = handler(info, **config)
-        logger.info("build_outputs: '%s' created '%s'.", name, os.path.abspath(outpath))
+        logger.info("build_outputs: '%s' created '%s'.", name, outpath)
 
 
 def dump_hash(info, algorithm=""):
@@ -45,25 +45,23 @@ def dump_hash(info, algorithm=""):
         installers = [Path(info["_outpath"])]
     else:
         installers = [Path(outpath) for outpath in info["_outpath"]]
-    outpath = os.path.join(info["_output_dir"], f"hash.{algorithm}")
-    hashes = []
+    outpaths = []
     for installer in installers:
         filehash = hashlib.new(algorithm)
         with open(installer, "rb") as f:
             while buffer := f.read(BUFFER_SIZE):
                 filehash.update(buffer)
-        hashes.append((filehash.hexdigest(), installer.name))
-    with open(outpath, "w") as f:
-        for hashval, filename in hashes:
-            f.write(f"{hashval}  {filename}\n")
-    return outpath
+        outpath = Path(f"{installer}.{algorithm}")
+        outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n")
+        outpaths.append(str(outpath.absolute()))
+    return ", ".join(outpaths)
 
 
 def dump_info(info):
     outpath = os.path.join(info["_output_dir"], "info.json")
     with open(outpath, "w") as f:
         json.dump(info, f, indent=2, default=repr)
-    return outpath
+    return os.path.abspath(outpath)
 
 
 def dump_packages_list(info, env="base"):
@@ -78,7 +76,7 @@ def dump_packages_list(info, env="base"):
     with open(outpath, 'w') as fo:
         fo.write(f"# {info['name']} {info['version']}, env={env}\n")
         fo.write("\n".join(dists))
-    return outpath
+    return os.path.abspath(outpath)
 
 
 def dump_licenses(info, include_text=False, text_errors=None):
@@ -128,7 +126,7 @@ def dump_licenses(info, include_text=False, text_errors=None):
     outpath = os.path.join(info["_output_dir"], "licenses.json")
     with open(outpath, "w") as f:
         json.dump(licenses, f, indent=2, default=repr)
-    return outpath
+    return os.path.abspath(outpath)
 
 
 OUTPUT_HANDLERS = {

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -58,7 +58,7 @@ def dump_hash(info, algorithm=""):
 
 def dump_info(info):
     outpath = Path(info["_output_dir"], "info.json")
-    outpath.write_text(json.dumps(info, indent=2, default=repr))
+    outpath.write_text(json.dumps(info, indent=2, default=repr) + "\n")
     return outpath.absolute()
 
 
@@ -121,7 +121,7 @@ def dump_licenses(info, include_text=False, text_errors=None):
                 license_files.append(license_file)
 
     outpath = Path(info["_output_dir"], "licenses.json")
-    outpath.write_text(json.dumps(licenses, indent=2, default=repr))
+    outpath.write_text(json.dumps(licenses, indent=2, default=repr) + "\n")
     return outpath.absolute()
 
 

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -37,7 +37,8 @@ def process_build_outputs(info):
         logger.info("build_outputs: '%s' created '%s'.", name, outpath)
 
 
-def dump_hash(info, algorithm=[]):
+def dump_hash(info, algorithm=None):
+    algorithm = algorithm or []
     if isinstance(algorithm, str):
         algorithm = [algorithm]
     algorithms = set(algorithm)

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -58,7 +58,7 @@ def dump_hash(info, algorithm=""):
 
 def dump_info(info):
     outpath = Path(info["_output_dir"], "info.json")
-    outpath.write_text(json.dumps(info, indent=2, default=repr) + "\n")
+    outpath.write_text(json.dumps(info, indent=2, default=repr))
     return outpath.absolute()
 
 
@@ -121,7 +121,7 @@ def dump_licenses(info, include_text=False, text_errors=None):
                 license_files.append(license_file)
 
     outpath = Path(info["_output_dir"], "licenses.json")
-    outpath.write_text(json.dumps(licenses, indent=2, default=repr) + "\n")
+    outpath.write_text(json.dumps(licenses, indent=2, default=repr))
     return outpath.absolute()
 
 

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -6,7 +6,6 @@ Update documentation in `construct.py` if any changes are made.
 import hashlib
 import json
 import logging
-import os
 from collections import defaultdict
 from pathlib import Path
 
@@ -58,10 +57,9 @@ def dump_hash(info, algorithm=""):
 
 
 def dump_info(info):
-    outpath = os.path.join(info["_output_dir"], "info.json")
-    with open(outpath, "w") as f:
-        json.dump(info, f, indent=2, default=repr)
-    return os.path.abspath(outpath)
+    outpath = Path(info["_output_dir"], "info.json")
+    outpath.write_text(json.dumps(info, indent=2, default=repr) + "\n")
+    return outpath.absolute()
 
 
 def dump_packages_list(info, env="base"):
@@ -72,11 +70,10 @@ def dump_packages_list(info, env="base"):
     else:
         raise ValueError(f"env='{env}' is not a valid env name.")
 
-    outpath = os.path.join(info["_output_dir"], f'pkg-list.{env}.txt')
-    with open(outpath, 'w') as fo:
-        fo.write(f"# {info['name']} {info['version']}, env={env}\n")
-        fo.write("\n".join(dists))
-    return os.path.abspath(outpath)
+    outpath = Path(info["_output_dir"], f'pkg-list.{env}.txt')
+    outpath.write_text(f"# {info['name']} {info['version']}, env={env}\n")
+    outpath.write_text("\n".join(dists))
+    return outpath.absolute()
 
 
 def dump_licenses(info, include_text=False, text_errors=None):
@@ -109,24 +106,23 @@ def dump_licenses(info, include_text=False, text_errors=None):
     licenses = defaultdict(dict)
     for pkg_record in info["_all_pkg_records"]:
         extracted_package_dir = pkg_record.extracted_package_dir
-        licenses_dir = os.path.join(extracted_package_dir, "info", "licenses")
+        licenses_dir = Path(extracted_package_dir, "info", "licenses")
         licenses[pkg_record.dist_str()]["type"] = pkg_record.license
         licenses[pkg_record.dist_str()]["files"] = license_files = []
-        if not os.path.isdir(licenses_dir):
+        if not licenses_dir.is_dir():
             continue
 
-        for directory, _, files in os.walk(licenses_dir):
+        for directory, _, files in licenses_dir.walk():
             for filepath in files:
-                license_path = os.path.join(directory, filepath)
+                license_path = directory / filepath
                 license_file = {"path": license_path, "text": None}
                 if include_text:
-                    license_file["text"] = Path(license_path).read_text(errors=text_errors)
+                    license_file["text"] = license_path.read_text(errors=text_errors)
                 license_files.append(license_file)
 
-    outpath = os.path.join(info["_output_dir"], "licenses.json")
-    with open(outpath, "w") as f:
-        json.dump(licenses, f, indent=2, default=repr)
-    return os.path.abspath(outpath)
+    outpath = Path(info["_output_dir"], "licenses.json")
+    outpath.write_text(json.dumps(licenses, indent=2, default=repr) + "\n")
+    return outpath.absolute()
 
 
 OUTPUT_HANDLERS = {

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -606,6 +606,9 @@ Supports the same values as `extra_files`.
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
+- `hash`: The hash of the installer files.
+    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+       https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -607,7 +607,7 @@ Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
 - `hash`: The hash of the installer files.
-    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+    - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -229,6 +229,7 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
     # '_dists': List[Dist]
     # '_urls': List[Tuple[url, md5]]
 
+    info_dicts = []
     for itype in itypes:
         if itype == 'sh':
             from .shar import create as shar_create
@@ -242,7 +243,18 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
         info['installer_type'] = itype
         info['_outpath'] = abspath(join(output_dir, get_output_filename(info)))
         create(info, verbose=verbose)
+        if len(itypes) > 1:
+            info_dicts.append(info.copy())
         logger.info("Successfully created '%(_outpath)s'.", info)
+
+    # Merge info files for each installer type
+    if len(itypes) > 1:
+        keys = set()
+        for info_dict in info_dicts:
+            keys.update(info_dict.keys())
+        for key in keys:
+            if any(info_dict.get(key) != info.get(key) for info_dict in info_dicts):
+                info[key] = [info_dict.get(key, "") for info_dict in info_dicts]
 
     process_build_outputs(info)
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -825,6 +825,9 @@ _type:_ list<br/>
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
+- `hash`: The hash of the installer files.
+    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+       https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -826,7 +826,7 @@ Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
 - `hash`: The hash of the installer files.
-    - `algorithm`: The hash algorithm. Must be among `hashlib`'s available algorithms:
+    - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:

--- a/news/816-output-installer-hashes
+++ b/news/816-output-installer-hashes
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add option to output hashes of installer files. (#816)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,8 +20,10 @@ def test_hash_dump(tmp_path):
         "_output_dir": str(tmp_path),
     }
     outpath = dump_hash(info, algorithm="sha256")
-    assert outpath == str(f"{testfile}.sha256")
+    assert outpath == str(tmp_path / "hash.sha256")
     filecontent = Path(outpath).read_text()
-    filehash, filename = filecontent.split()
-    assert filehash.strip() == expected
-    assert filename.strip() == testfile.name
+    lines = filecontent.split("\n")
+    for i in range(len(lines) - 1):
+        filehash, filename = lines[i].split()
+        assert filehash.strip() == expected[i]
+        assert filename.strip() == Path(info["_outpath"][i]).name

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -5,12 +5,12 @@ from constructor.build_outputs import dump_hash
 
 def test_hash_dump(tmp_path):
     testfile = tmp_path / "test.txt"
-    testfile.write_text("test string\n")
+    testfile.write_text("test string")
     testfile = tmp_path / "test2.txt"
-    testfile.write_text("another test\n")
+    testfile.write_text("another test")
     expected = (
-        "37d2046a395cbfcb2712ff5c96a727b1966876080047c56717009dbbc235f566",
-        "60fa80b948a0acc557a6ba7523f4040a7b452736723df20f118d0aacb5c1901b",
+        "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
+        "64320dd12e5c2caeac673b91454dac750c08ba333639d129671c2f58cb5d0ad1",
     )
     info = {
         "_outpath": [

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from constructor.build_outputs import dump_hash
+
+
+def test_hash_dump(tmp_path):
+    testfile = tmp_path / "test.txt"
+    testfile.write_text("test string\n")
+    testfile = tmp_path / "test2.txt"
+    testfile.write_text("another test\n")
+    expected = (
+        "37d2046a395cbfcb2712ff5c96a727b1966876080047c56717009dbbc235f566",
+        "60fa80b948a0acc557a6ba7523f4040a7b452736723df20f118d0aacb5c1901b",
+    )
+    info = {
+        "_outpath": [
+            str(tmp_path / "test.txt"),
+            str(tmp_path / "test2.txt"),
+        ],
+    }
+    outpath = dump_hash(info, algorithm="sha256")
+    assert outpath == str(f"{testfile}.sha256")
+    filecontent = Path(outpath).read_text()
+    filehash, filename = filecontent.split()
+    assert filehash.strip() == expected
+    assert filename.strip() == testfile.name

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from constructor.build_outputs import dump_hash
 
 
@@ -8,20 +10,29 @@ def test_hash_dump(tmp_path):
     testfile.write_text("test string")
     testfile = tmp_path / "test2.txt"
     testfile.write_text("another test")
-    expected = (
-        "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
-        "64320dd12e5c2caeac673b91454dac750c08ba333639d129671c2f58cb5d0ad1",
-    )
+    expected = {
+        "sha256": (
+            "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
+            "64320dd12e5c2caeac673b91454dac750c08ba333639d129671c2f58cb5d0ad1",
+        ),
+        "md5": (
+            "6f8db599de986fab7a21625b7916589c",
+            "5e8862cd73694287ff341e75c95e3c6a",
+        ),
+    }
     info = {
         "_outpath": [
             str(tmp_path / "test.txt"),
             str(tmp_path / "test2.txt"),
         ]
     }
-    dump_hash(info, algorithm="sha256")
+    with pytest.raises(ValueError):
+        dump_hash(info, algorithm="bad_algorithm")
+    dump_hash(info, algorithm=["sha256", "md5"])
     for f, file in enumerate(info["_outpath"]):
-        hashfile = Path(f"{file}.sha256")
-        assert hashfile.exists()
-        filehash, filename = hashfile.read_text().strip().split()
-        assert filehash == expected[f]
-        assert filename == Path(file).name
+        for algorithm in expected:
+            hashfile = Path(f"{file}.{algorithm}")
+            assert hashfile.exists()
+            filehash, filename = hashfile.read_text().strip().split()
+            assert filehash == expected[algorithm][f]
+            assert filename == Path(file).name

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -16,14 +16,12 @@ def test_hash_dump(tmp_path):
         "_outpath": [
             str(tmp_path / "test.txt"),
             str(tmp_path / "test2.txt"),
-        ],
-        "_output_dir": str(tmp_path),
+        ]
     }
-    outpath = dump_hash(info, algorithm="sha256")
-    assert outpath == str(tmp_path / "hash.sha256")
-    filecontent = Path(outpath).read_text()
-    lines = filecontent.split("\n")
-    for i in range(len(lines) - 1):
-        filehash, filename = lines[i].split()
-        assert filehash.strip() == expected[i]
-        assert filename.strip() == Path(info["_outpath"][i]).name
+    dump_hash(info, algorithm="sha256")
+    for f, file in enumerate(info["_outpath"]):
+        hashfile = Path(f"{file}.sha256")
+        assert hashfile.exists()
+        filehash, filename = hashfile.read_text().strip().split()
+        assert filehash == expected[f]
+        assert filename == Path(file).name

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -17,6 +17,7 @@ def test_hash_dump(tmp_path):
             str(tmp_path / "test.txt"),
             str(tmp_path / "test2.txt"),
         ],
+        "_output_dir": str(tmp_path),
     }
     outpath = dump_hash(info, algorithm="sha256")
     assert outpath == str(f"{testfile}.sha256")


### PR DESCRIPTION
### Description

Add option to output hashes of installer file. The file format is written in a way that it can be verified with `shasum -c` and similar UNIX tools.

In order to work with `installer_type: all` (see issue #814), I merged the info objects before creating outputs. I'm not sure if that closes the issue, but it's a temporary workaround.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?