### PR TITLE
Use BytesIO wrapped font instead of passing path to avoid "Cannot open resource" error in Windows

### DIFF
--- a/constructor/imaging.py
+++ b/constructor/imaging.py
@@ -5,12 +5,15 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
 import sys
+from io import BytesIO
 from os.path import dirname, join
 from random import randint
 
 from PIL import Image, ImageDraw, ImageFont
 
 ttf_path = join(dirname(__file__), 'ttf', 'Vera.ttf')
+with open(ttf_path, "rb") as f:
+    ttf_bytes = f.read()
 white = 0xff, 0xff, 0xff
 # These are for Windows
 welcome_size = 164, 314
@@ -45,7 +48,7 @@ def add_text(im, xy, text, min_lines, line_height, font, color):
 
 
 def mk_welcome_image(info):
-    font = ImageFont.truetype(ttf_path, 20)
+    font = ImageFont.truetype(BytesIO(ttf_bytes), 20)
     im = new_background(welcome_size, info['_color'])
     text = '\n'.join([info['welcome_image_text'], info['version']])
     add_text(im, (20, 100), text, 2, 30, font, white)
@@ -53,7 +56,7 @@ def mk_welcome_image(info):
 
 
 def mk_welcome_image_osx(info):
-    font = ImageFont.truetype(ttf_path, 40)
+    font = ImageFont.truetype(BytesIO(ttf_bytes), 40)
     # Transparent background
     im = Image.new('RGBA', welcome_size_osx, color=(0, 0, 0, 0))
     text = '\n'.join([info['welcome_image_text'], info['version']])
@@ -62,7 +65,7 @@ def mk_welcome_image_osx(info):
 
 
 def mk_header_image(info):
-    font = ImageFont.truetype(ttf_path, 20)
+    font = ImageFont.truetype(BytesIO(ttf_bytes), 20)
     im = Image.new('RGB', header_size, color=white)
     text = info['header_image_text']
     color = info['_color']
@@ -71,7 +74,7 @@ def mk_header_image(info):
 
 
 def mk_icon_image(info):
-    font = ImageFont.truetype(ttf_path, 200)
+    font = ImageFont.truetype(BytesIO(ttf_bytes), 200)
     im = new_background(icon_size, info['_color'])
     d = ImageDraw.Draw(im)
     d.text((60, 20), info['name'][0], fill=white, font=font)

--- a/news/837-truetype
+++ b/news/837-truetype
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Prevent error on Windows where the text-based images cannot be generated because the TrueType font cannot be loaded. (#837)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

CI erroring out in Azure at https://github.com/conda-forge/constructor-feedstock/pull/78. Not sure why we didn't see this on GHA, but I can reproduce locally and this is the recommended fix in the [Pillow docstring](https://pillow.readthedocs.io/en/stable/reference/ImageFont.html#PIL.ImageFont.truetype).

This is the error:

```
Traceback (most recent call last):
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\const>
    sys.exit(main())
             ^^^^^^
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\constn
    main_build(dir_path, output_dir=out_dir, platform=args.platform,
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\constd
    create(info, verbose=verbose)
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\conste
    write_images(info, tmp_dir)
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\consts
    im = function(info)
         ^^^^^^^^^^^^^^
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\conste
    font = ImageFont.truetype(ttf_path, 20)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\conste
    return freetype(font)
           ^^^^^^^^^^^^^^
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\conste
    return FreeTypeFont(font, size, index, encoding, layout_engine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\username\Documents\GitHub\conda\devenv\Windows\envs\devenv-3.11\envs\const_
    self.font = core.getfont(
                ^^^^^^^^^^^^^
OSError: cannot open resource
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
