### PR TITLE
Fix ttf package data typo in pyproject.toml

### DIFF
--- a/news/839-tff-ttf-typo
+++ b/news/839-tff-ttf-typo
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix typo in pyproject.toml package data. (#839)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ constructor = [
     "header.sh",
     "nsis/*",
     "osx/*",
-    "tff/*",
+    "ttf/*",
 ]
 
 [tool.black]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,13 +29,18 @@ requirements:
     - nsis >=3.08      # [unix]
 
 test:
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
   imports:
     - constructor
   commands:
     - pip check
     - constructor --help
+    # Run unit tests
+    - pytest -v tests -k "not examples"
 
 about:
   home: https://conda.io


### PR DESCRIPTION
### Description

There is a typo in `pyproject.toml`: it says `tff` instead of `ttf`.

Also add unit tests to the recipe build - this would have caught the error early.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update outdated documentation?
