### PR TITLE
Ignore .condarc files during installation

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -468,10 +468,6 @@ export TMP_BACKUP="${TMP:-}"
 export TMP="$PREFIX/install_tmp"
 mkdir -p "$TMP"
 
-# Set this variable to prevent existing .condarc file from interfering with the installation
-# Requires conda-standalone 24.9.0 or newer
-export CONDA_RESTRICT_RC_SEARCH_PATH=1
-
 # Check whether the virtual specs can be satisfied
 # We need to specify CONDA_SOLVER=classic for conda-standalone
 # to work around this bug in conda-libmamba-solver:
@@ -484,7 +480,7 @@ if [ "__VIRTUAL_SPECS__" != "" ]; then
     CONDA_QUIET="$BATCH" \
     CONDA_SOLVER="classic" \
     CONDA_PKGS_DIRS="$(mktemp -d)" \
-    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX/envs/_virtual_specs_checks" --offline __VIRTUAL_SPECS__
+    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX/envs/_virtual_specs_checks" --offline __VIRTUAL_SPECS__ __NO_RCS_ARG__
 fi
 
 # Create $PREFIX/.nonadmin if the installation didn't require superuser permissions
@@ -562,7 +558,7 @@ CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS="__CHANNELS__" \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
 CONDA_QUIET="$BATCH" \
-"$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" $shortcuts || exit 1
+"$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" $shortcuts __NO_RCS_ARG__ || exit 1
 rm -f "$PREFIX/pkgs/env.txt"
 
 #The templating doesn't support nested if statements
@@ -607,7 +603,7 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
     CONDA_CHANNELS="$env_channels" \
     CONDA_PKGS_DIRS="$PREFIX/pkgs" \
     CONDA_QUIET="$BATCH" \
-    "$CONDA_EXEC" install --offline --file "${env_pkgs}env.txt" -yp "$PREFIX/envs/$env_name" $env_shortcuts || exit 1
+    "$CONDA_EXEC" install --offline --file "${env_pkgs}env.txt" -yp "$PREFIX/envs/$env_name" $env_shortcuts __NO_RCS_ARG__ || exit 1
     rm -f "${env_pkgs}env.txt"
 done
 #endif

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -468,6 +468,10 @@ export TMP_BACKUP="${TMP:-}"
 export TMP="$PREFIX/install_tmp"
 mkdir -p "$TMP"
 
+# Set this variable to prevent existing .condarc file from interfering with the installation
+# Requires conda-standalone 24.9.0 or newer
+export CONDA_RESTRICT_RC_SEARCH_PATH=1
+
 # Check whether the virtual specs can be satisfied
 # We need to specify CONDA_SOLVER=classic for conda-standalone
 # to work around this bug in conda-libmamba-solver:

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -201,9 +201,9 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
 
     # Add --no-rc option to CONDA_EXE command so that existing
     # .condarc files do not pollute the installation process.
-    if exe_name == "conda-standalone" and Version(exe_version) >= Version("24.9.0"):
+    if exe_type == StandaloneExe.CONDA and exe_version and exe_version >= Version("24.9.0"):
         info["_ignore_condarcs_arg"] = "--no-rc"
-    elif exe_name == "micromamba":
+    elif exe_type == StandaloneExe.MAMBA:
         info["_ignore_condarcs_arg"] = "--no-rc"
     else:
         info["_ignore_condarcs_arg"] = ""

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -197,6 +197,15 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             )
         )
 
+    # Add --no-rc option to CONDA_EXE command so that existing
+    # .condarc files do not pollute the installation process.
+    if exe_name == "conda-standalone" and Version(exe_version) >= Version("24.9.0"):
+        info["_ignore_condarcs_arg"] = "--no-rc"
+    elif exe_name == "micromamba":
+        info["_ignore_condarcs_arg"] = "--no-rc"
+    else:
+        info["_ignore_condarcs_arg"] = ""
+
     if 'pkg' in itypes:
         if (domains := info.get('pkg_domains')) is not None:
             domains = {key: str(val).lower() for key, val in domains.items()}

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1207,10 +1207,6 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("PATH", \
                  "$INSTDIR;$INSTDIR\Library\mingw-w64\bin;$INSTDIR\Library\usr\bin;$INSTDIR\Library\bin;$INSTDIR\Scripts;$INSTDIR\bin;$0;$0\system32;$0\system32\Wbem").r0'
 
-    # Set this variable to prevent existing .condarc file from interfering with the installation
-    # Requires conda-standalone 24.9.0 or newer
-    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_RESTRICT_RC_SEARCH_PATH", "1").r0'
-
     ${Print} "Unpacking payload..."
 
     # A conda-meta\history file is required for a valid conda prefix
@@ -1262,7 +1258,7 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "classic").r0'
     SetDetailsPrint TextOnly
     ${Print} "Checking virtual specs compatibility: @VIRTUAL_SPECS_DEBUG@"
-    push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR\envs\_virtual_specs_checks" --offline @VIRTUAL_SPECS@'
+    push '"$INSTDIR\_conda.exe" create --dry-run --prefix "$INSTDIR\envs\_virtual_specs_checks" --offline @VIRTUAL_SPECS@ @NO_RCS_ARG@'
     push 'Failed to check virtual specs: @VIRTUAL_SPECS_DEBUG@'
     push 'WithLog'
     call AbortRetryNSExecWait
@@ -1324,7 +1320,7 @@ Section "Install"
 
     ${If} $Ana_ClearPkgCache_State = ${BST_CHECKED}
         ${Print} "Clearing package cache..."
-        push '"$INSTDIR\_conda.exe" clean --all --force-pkgs-dirs --yes'
+        push '"$INSTDIR\_conda.exe" clean --all --force-pkgs-dirs --yes @NO_RCS_ARG@'
         push 'Failed to clear package cache'
         push 'WithLog'
         call AbortRetryNSExecWait

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1207,6 +1207,10 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("PATH", \
                  "$INSTDIR;$INSTDIR\Library\mingw-w64\bin;$INSTDIR\Library\usr\bin;$INSTDIR\Library\bin;$INSTDIR\Scripts;$INSTDIR\bin;$0;$0\system32;$0\system32\Wbem").r0'
 
+    # Set this variable to prevent existing .condarc file from interfering with the installation
+    # Requires conda-standalone 24.9.0 or newer
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_RESTRICT_RC_SEARCH_PATH", "1").r0'
+
     ${Print} "Unpacking payload..."
 
     # A conda-meta\history file is required for a valid conda prefix

--- a/constructor/osx/prepare_installation.sh
+++ b/constructor/osx/prepare_installation.sh
@@ -23,6 +23,9 @@ PREFIX=$(cd "$PREFIX"; pwd)
 export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
+# Set this variable to prevent existing .condarc file from interfering with the installation
+# Requires conda-standalone 24.9.0 or newer
+export CONDA_RESTRICT_RC_SEARCH_PATH=1
 # /COMMON UTILS
 
 chmod +x "$CONDA_EXEC"

--- a/constructor/osx/prepare_installation.sh
+++ b/constructor/osx/prepare_installation.sh
@@ -23,9 +23,6 @@ PREFIX=$(cd "$PREFIX"; pwd)
 export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
-# Set this variable to prevent existing .condarc file from interfering with the installation
-# Requires conda-standalone 24.9.0 or newer
-export CONDA_RESTRICT_RC_SEARCH_PATH=1
 # /COMMON UTILS
 
 chmod +x "$CONDA_EXEC"
@@ -45,7 +42,7 @@ if [ "__VIRTUAL_SPECS__" != "" ]; then
     notify 'Checking virtual specs compatibility: __VIRTUAL_SPECS__'
     CONDA_SOLVER="classic" \
     CONDA_PKGS_DIRS="$(mktemp -d)" \
-    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX/envs/_virtual_specs_checks" --offline __VIRTUAL_SPECS__
+    "$CONDA_EXEC" create --dry-run --prefix "$PREFIX/envs/_virtual_specs_checks" --offline __VIRTUAL_SPECS__ __NO_RCS_ARG__
 fi
 
 # Create $PREFIX/.nonadmin if the installation didn't require superuser permissions

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -26,6 +26,9 @@ export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
 # /COMMON UTILS
+# Set this variable to prevent existing .condarc file from interfering with the installation
+# Requires conda-standalone 24.9.0 or newer
+export CONDA_RESTRICT_RC_SEARCH_PATH=1
 
 # Check whether the user wants shortcuts or not
 # See check_shortcuts.sh script for details

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -26,9 +26,6 @@ export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
 # /COMMON UTILS
-# Set this variable to prevent existing .condarc file from interfering with the installation
-# Requires conda-standalone 24.9.0 or newer
-export CONDA_RESTRICT_RC_SEARCH_PATH=1
 
 # Check whether the user wants shortcuts or not
 # See check_shortcuts.sh script for details
@@ -51,7 +48,7 @@ CONDA_SAFETY_CHECKS=disabled \
 CONDA_EXTRA_SAFETY_CHECKS=no \
 CONDA_CHANNELS=__CHANNELS__ \
 CONDA_PKGS_DIRS="$PREFIX/pkgs" \
-"$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" $shortcuts; then
+"$CONDA_EXEC" install --offline --file "$PREFIX/pkgs/env.txt" -yp "$PREFIX" $shortcuts __NO_RCS_ARG__; then
     echo "ERROR: could not complete the conda install"
     exit 1
 fi
@@ -97,7 +94,7 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
     CONDA_EXTRA_SAFETY_CHECKS=no \
     CONDA_CHANNELS="$env_channels" \
     CONDA_PKGS_DIRS="$PREFIX/pkgs" \
-    "$CONDA_EXEC" install --offline --file "${env_pkgs}env.txt" -yp "$PREFIX/envs/$env_name" $env_shortcuts || exit 1
+    "$CONDA_EXEC" install --offline --file "${env_pkgs}env.txt" -yp "$PREFIX/envs/$env_name" $env_shortcuts __NO_RCS_ARG__ || exit 1
     # Move the prepackaged history file into place
     mv "${env_pkgs}/conda-meta/history" "$PREFIX/envs/$env_name/conda-meta/history"
     rm -f "${env_pkgs}env.txt"

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -24,9 +24,6 @@ export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
 # /COMMON UTILS
-# Set this variable to prevent existing .condarc file from interfering with the installation
-# Requires conda-standalone 24.9.0 or newer
-export CONDA_RESTRICT_RC_SEARCH_PATH=1
 
 # Expose these to user scripts as well
 export INSTALLER_NAME="__NAME__"

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -24,6 +24,9 @@ export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
 # /COMMON UTILS
+# Set this variable to prevent existing .condarc file from interfering with the installation
+# Requires conda-standalone 24.9.0 or newer
+export CONDA_RESTRICT_RC_SEARCH_PATH=1
 
 # Expose these to user scripts as well
 export INSTALLER_NAME="__NAME__"

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -345,6 +345,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
         'ENABLE_SHORTCUTS': str(info['_enable_shortcuts']).lower(),
         'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
         'VIRTUAL_SPECS': shlex.join(info.get("virtual_specs", ())),
+        'NO_RCS_ARG': info.get('_ignore_condarcs_arg', ''),
     }
     data = preprocess(data, ppd)
     custom_variables = info.get('script_env_variables', {})

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -94,7 +94,8 @@ def get_header(conda_exec, tarball, info):
         'SHORTCUTS': shortcuts_flags(info),
         'REGISTER_ENVS': str(info.get("register_envs", True)).lower(),
         'TOTAL_INSTALLATION_SIZE_KB': str(approx_size_kb(info, "total")),
-        'VIRTUAL_SPECS': shlex.join(info.get("virtual_specs", ()))
+        'VIRTUAL_SPECS': shlex.join(info.get("virtual_specs", ())),
+        'NO_RCS_ARG': info.get('_ignore_condarcs_arg', ''),
     }
     if has_license:
         replace['LICENSE'] = read_ascii_only(info['license_file'])

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -167,6 +167,7 @@ def setup_envs_commands(info, dir_path):
         channels=','.join(get_final_channels(info)),
         shortcuts=shortcuts_flags(info),
         register_envs=str(info.get("register_envs", True)).lower(),
+        no_rcs_arg=info.get("_ignore_condarcs_arg", ""),
     ).splitlines()
     # now we generate one more block per extra env, if present
     for env_name in info.get("_extra_envs_info", {}):

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -135,10 +135,10 @@ def setup_envs_commands(info, dir_path):
         # Run conda install
         ${{If}} $Ana_CreateShortcuts_State = ${{BST_CHECKED}}
             ${{Print}} "Installing packages for {name}, creating shortcuts if necessary..."
-            push '"$INSTDIR\_conda.exe" install --offline -yp "{prefix}" --file "{env_txt}" {shortcuts}'
+            push '"$INSTDIR\_conda.exe" install --offline -yp "{prefix}" --file "{env_txt}" {shortcuts} {no_rcs_arg}'
         ${{Else}}
             ${{Print}} "Installing packages for {name}..."
-            push '"$INSTDIR\_conda.exe" install --offline -yp "{prefix}" --file "{env_txt}" --no-shortcuts'
+            push '"$INSTDIR\_conda.exe" install --offline -yp "{prefix}" --file "{env_txt}" --no-shortcuts {no_rcs_arg}'
         ${{EndIf}}
         push 'Failed to link extracted packages to {prefix}!'
         push 'WithLog'
@@ -187,6 +187,7 @@ def setup_envs_commands(info, dir_path):
             channels=",".join(get_final_channels(channel_info)),
             shortcuts=shortcuts_flags(env_info, conda_exe=info.get("_conda_exe")),
             register_envs=str(info.get("register_envs", True)).lower(),
+            no_rcs_arg=info.get("_ignore_condarcs_arg", ""),
         ).splitlines()
 
     return [line.strip() for line in lines]
@@ -401,6 +402,7 @@ def make_nsi(
         # This is the same but without quotes so we can print it fine
         ('@VIRTUAL_SPECS_DEBUG@', " ".join([spec for spec in info.get("virtual_specs", ())])),
         ('@LICENSEFILENAME@', basename(info.get('license_file', 'placeholder_license.txt'))),
+        ('@NO_RCS_ARG@', info.get('_ignore_condarcs_arg', '')),
     ]:
         data = data.replace(key, value)
 

--- a/news/863-ignore-condarc-files
+++ b/news/863-ignore-condarc-files
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ignore pre-existing .condarc files to prevent these configuration files from interfering with the installation process. (#542 and #568 via #863)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -827,3 +827,25 @@ def test_virtual_specs_ok(tmp_path, request):
             check_subprocess=True,
             uninstall=True,
         )
+
+
+@pytest.mark.skipif(CONDA_EXE != "conda-standalone", reason="requires conda-standalone")
+@pytest.mark.xfail(
+    CONDA_EXE == "conda-standalone" and Version(CONDA_EXE_VERSION) < Version("24.9.0"),
+    reason="Global .condarc breaks installation",
+)
+def test_ignore_condarc_files(tmp_path, monkeypatch, request):
+    # Create a bogus .condarc file that would break an installation if read
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with open(tmp_path / ".condarc", "w") as crc:
+        crc.write("clobber: prevent")
+    input_path = _example_path("customize_controls")
+    for installer, install_dir in create_installer(input_path, tmp_path):
+        _run_installer(
+            input_path,
+            installer,
+            install_dir,
+            request=request,
+            check_subprocess=True,
+            uninstall=True,
+        )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -848,10 +848,10 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
             check_subprocess=True,
             uninstall=True,
         )
-        if CONDA_EXE == "micromamba":
-            if installer.suffix == ".sh":
-                # micromamba loads the rc files even for constructor subcommands.
-                # This cannot be turned off with --no-rc, which causes four errors
-                # in stderr. If there are more, other micromamba calls have read
-                # the bogus .condarc file.
-                assert proc.stderr.count("Bad conversion of configurable") == 4
+        if CONDA_EXE == "micromamba" and installer.suffix == ".sh":
+            # micromamba loads the rc files even for constructor subcommands.
+            # This cannot be turned off with --no-rc, which causes four errors
+            # in stderr. If there are more, other micromamba calls have read
+            # the bogus .condarc file.
+            # pkg installers unfortunately do not output any errors into the log.
+            assert proc.stderr.count("Bad conversion of configurable") == 4

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -845,7 +845,7 @@ def test_virtual_specs_ok(tmp_path, request):
 
 
 @pytest.mark.xfail(
-    CONDA_EXE == "conda-standalone" and Version(CONDA_EXE_VERSION) < Version("24.9.0"),
+    CONDA_EXE == StandaloneExe.CONDA and CONDA_EXE_VERSION < Version("24.9.0"),
     reason="Pre-existing .condarc breaks installation",
 )
 def test_ignore_condarc_files(tmp_path, monkeypatch, request):
@@ -855,7 +855,7 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
     # HOME or USERPROFILE breaks installer builds.
     # mamba does not search this directory, so use HOME as a fallback.
     # Since micromamba is not supported on Windows, this is not a problem.
-    if CONDA_EXE == "micromamba":
+    if CONDA_EXE == StandaloneExe.MAMBA:
         monkeypatch.setenv("HOME", str(tmp_path))
         condarc = tmp_path / ".condarc"
     else:
@@ -879,7 +879,7 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
             check_subprocess=True,
             uninstall=True,
         )
-        if CONDA_EXE == "micromamba" and installer.suffix == ".sh":
+        if CONDA_EXE == StandaloneExe.MAMBA and installer.suffix == ".sh":
             # micromamba loads the rc files even for constructor subcommands.
             # This cannot be turned off with --no-rc, which causes four errors
             # in stderr. If there are more, other micromamba calls have read


### PR DESCRIPTION
### Description

`conda-standalone` and `micromamba` load existing `.condarc` files during the installation process, which can have unintended consequences and even break the installation. These issues have been frequently reported (see #542, #568, and the issues reported therein). The behavior of the installer should be set by the installer itself and not by residual configuration files, especially since they are not cleaned up at all (see #642).

`micromamba` has a `--no-rc` option, which is also proposed to be added to `conda-standalone` (https://github.com/conda/conda-standalone/pull/99). This feature will add the `--no-rc` option with compatible standalone executables.

Closes #542 and #568.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
