### PR TITLE
Justme permissions

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1372,11 +1372,11 @@ Section "Install"
 
     # To address CVE-2022-26526.
     # Revoke the write permission on directory "$INSTDIR" for Users if this is
-    # being run with administrative privileges. Users are:
+    # an all-users installation. Users are:
     #   AU - authenticated users
     #   BU - built-in (local) users
     #   DU - domain users
-    ${If} ${UAC_IsAdmin}
+    ${If} $InstMode == ${ALL_USERS}
         ${Print} "Setting installation directory permissions..."
         AccessControl::DisableFileInheritance "$INSTDIR"
         AccessControl::RevokeOnFile "$INSTDIR" "(AU)" "GenericWrite"

--- a/news/873-justme-permission-bug
+++ b/news/873-justme-permission-bug
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Restrict Windows directory permission based on installation mode, not privilege level. (#872 via #873)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

The Windows installer restricts permissions for users if the installation was done with administrator privileges. It was reported in #872 that this can create a situation where a `JustMe` installation restricts write access to the installation directory when `UAC_IsAdmin` mistakenly thinks the user is an administrator.

Instead of checking for administrative privileges, check whether the installation is an `AllUsers` installation. Privileges should be elevated at this point anyway and reflects the intent of the user. A `JustMe` installation should not be able to write into a sensitive directory in the first place since it never requires admin privileges.

Closes #872.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?