### PR TITLE
Disk space checks should come earlier and use MB in the message

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -21,6 +21,16 @@ if ! echo "$0" | grep '\.sh$' > /dev/null; then
     return 1
 fi
 
+total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
+free_disk_space_bytes="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
+free_disk_space_kb="$((free_disk_space_bytes / 1024))"
+free_disk_space_kb_with_buffer="$((free_disk_space_kb - 50 * 1024))"  # add 50MB of buffer
+if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
+    printf "ERROR: Not enough free disk space. Only %s MB are available, but %s MB are required (leaving a 50 MB buffer).\\n" \
+        "$((free_disk_space_kb / 1024))" "$((total_installation_size_kb / 1024))" >&2
+    exit 1
+fi
+
 #if osx and min_osx_version
 min_osx_version="__MIN_OSX_VERSION__"
 system_osx_version=$(SYSTEM_VERSION_COMPAT=0 sw_vers -productVersion)
@@ -391,15 +401,6 @@ fi
 
 if ! mkdir -p "$PREFIX"; then
     printf "ERROR: Could not create directory: '%s'\\n" "$PREFIX" >&2
-    exit 1
-fi
-
-total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
-free_disk_space_bytes="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
-free_disk_space_kb="$((free_disk_space_bytes / 1024))"
-free_disk_space_kb_with_buffer="$((free_disk_space_bytes - 100 * 1024))"  # add 100MB of buffer
-if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
-    printf "ERROR: Not enough free disk space: %s < %s\\n" "$free_disk_space_kb_with_buffer" "$total_installation_size_kb" >&2
     exit 1
 fi
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -390,16 +390,18 @@ elif [ "$FORCE" = "1" ] && [ -e "$PREFIX" ]; then
 fi
 
 total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
+total_installation_size_mb="$(( total_installation_size_kb / 1024 ))"
+if ! mkdir -p "$PREFIX"; then
+    printf "ERROR: Could not create directory: '%s'.\\n" "$PREFIX" >&2
+    printf "Check permissions and available disk space (%s MB needed).\\n" "$total_installation_size_mb" >&2
+    exit 1
+fi
+
 free_disk_space_kb="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
 free_disk_space_kb_with_buffer="$((free_disk_space_kb - 50 * 1024))"  # add 50MB of buffer
 if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
     printf "ERROR: Not enough free disk space. Only %s MB are available, but %s MB are required (leaving a 50 MB buffer).\\n" \
-        "$((free_disk_space_kb_with_buffer / 1024))" "$((total_installation_size_kb / 1024))" >&2
-    exit 1
-fi
-
-if ! mkdir -p "$PREFIX"; then
-    printf "ERROR: Could not create directory: '%s'\\n" "$PREFIX" >&2
+        "$((free_disk_space_kb_with_buffer / 1024))" "$total_installation_size_mb" >&2
     exit 1
 fi
 

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -21,16 +21,6 @@ if ! echo "$0" | grep '\.sh$' > /dev/null; then
     return 1
 fi
 
-total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
-free_disk_space_bytes="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
-free_disk_space_kb="$((free_disk_space_bytes / 1024))"
-free_disk_space_kb_with_buffer="$((free_disk_space_kb - 50 * 1024))"  # add 50MB of buffer
-if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
-    printf "ERROR: Not enough free disk space. Only %s MB are available, but %s MB are required (leaving a 50 MB buffer).\\n" \
-        "$((free_disk_space_kb / 1024))" "$((total_installation_size_kb / 1024))" >&2
-    exit 1
-fi
-
 #if osx and min_osx_version
 min_osx_version="__MIN_OSX_VERSION__"
 system_osx_version=$(SYSTEM_VERSION_COMPAT=0 sw_vers -productVersion)
@@ -397,6 +387,16 @@ if [ "$FORCE" = "0" ] && [ -e "$PREFIX" ]; then
     exit 1
 elif [ "$FORCE" = "1" ] && [ -e "$PREFIX" ]; then
     REINSTALL=1
+fi
+
+total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
+free_disk_space_bytes="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
+free_disk_space_kb="$((free_disk_space_bytes / 1024))"
+free_disk_space_kb_with_buffer="$((free_disk_space_kb - 50 * 1024))"  # add 50MB of buffer
+if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
+    printf "ERROR: Not enough free disk space. Only %s MB are available, but %s MB are required (leaving a 50 MB buffer).\\n" \
+        "$((free_disk_space_kb / 1024))" "$((total_installation_size_kb / 1024))" >&2
+    exit 1
 fi
 
 if ! mkdir -p "$PREFIX"; then

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -390,12 +390,11 @@ elif [ "$FORCE" = "1" ] && [ -e "$PREFIX" ]; then
 fi
 
 total_installation_size_kb="__TOTAL_INSTALLATION_SIZE_KB__"
-free_disk_space_bytes="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
-free_disk_space_kb="$((free_disk_space_bytes / 1024))"
+free_disk_space_kb="$(df -Pk "$PREFIX" | tail -n 1 | awk '{print $4}')"
 free_disk_space_kb_with_buffer="$((free_disk_space_kb - 50 * 1024))"  # add 50MB of buffer
 if [ "$free_disk_space_kb_with_buffer" -lt "$total_installation_size_kb" ]; then
     printf "ERROR: Not enough free disk space. Only %s MB are available, but %s MB are required (leaving a 50 MB buffer).\\n" \
-        "$((free_disk_space_kb / 1024))" "$((total_installation_size_kb / 1024))" >&2
+        "$((free_disk_space_kb_with_buffer / 1024))" "$((total_installation_size_kb / 1024))" >&2
     exit 1
 fi
 

--- a/news/889-disk
+++ b/news/889-disk
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Perform disk space checks earlier and report errors in MB (`.sh` installers only). (#778 via 889)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Close #774

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
