### PR TITLE
Generate explicit lockfiles per environment

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -860,6 +860,8 @@ Allowed keys are:
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
+- `lockfile`: An `@EXPLICIT` lockfile for a given environment. Options:
+    - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
     - `include_text` (optional bool, default=`False`): Whether to dump the license text in the JSON.
       If false, only the path will be included.

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -104,7 +104,7 @@ def dump_lockfile(info, env="base"):
         f"# installer-name: {info['name']}"
         f"# installer-version: {info['version']}"
         f"# env-name: {env}"
-        f"# platform: {info['platform']}",
+        f"# platform: {info['_platform']}",
         f"# created-by: constructor {__version__}",
         "@EXPLICIT"
     ]

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from conda.base.constants import UNKNOWN_CHANNEL
 from conda.common.url import remove_auth, split_anaconda_token
+from conda.core.prefix_data import PrefixGraph
 
 from . import __version__
 
@@ -101,14 +102,14 @@ def dump_lockfile(info, env="base"):
     lines = [
         "# This file may be used to create an environment using:",
         "# $ conda create --name <env> --file <this file>",
-        f"# installer-name: {info['name']}"
-        f"# installer-version: {info['version']}"
-        f"# env-name: {env}"
+        f"# installer-name: {info['name']}",
+        f"# installer-version: {info['version']}",
+        f"# env-name: {env}",
         f"# platform: {info['_platform']}",
         f"# created-by: constructor {__version__}",
         "@EXPLICIT"
     ]
-    for record in records:
+    for record in PrefixGraph(records).graph:
         url = record.get("url")
         if not url or url.startswith(UNKNOWN_CHANNEL):
             print("# no URL for: {}".format(record["fn"]))

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -635,6 +635,8 @@ Allowed keys are:
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
+- `lockfile`: An `@EXPLICIT` lockfile for a given environment. Options:
+    - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
     - `include_text` (optional bool, default=`False`): Whether to dump the license text in the JSON.
       If false, only the path will be included.

--- a/constructor/fcp.py
+++ b/constructor/fcp.py
@@ -403,7 +403,7 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
         env_pc_recs, env_urls, env_dists, _ = _fetch_precs(
             env_precs, download_dir, transmute_file_type=transmute_file_type
         )
-        extra_envs_data[env_name] = {"_urls": env_urls, "_dists": env_dists}
+        extra_envs_data[env_name] = {"_urls": env_urls, "_dists": env_dists, "_records": env_precs}
         all_pc_recs += env_pc_recs
 
     duplicate_files = "warn" if ignore_duplicate_files else "error"
@@ -418,6 +418,7 @@ def _main(name, version, download_dir, platform, channel_urls=(), channels_remap
 
     return (
         all_pc_recs,
+        precs,
         _urls,
         dists,
         approx_tarballs_size,
@@ -466,8 +467,9 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
 
         (
             pkg_records,
-            _urls,
-            dists,
+            _base_env_records,
+            _base_env_urls,
+            _base_env_dists,
             approx_tarballs_size,
             approx_pkgs_size,
             has_conda,
@@ -495,10 +497,11 @@ def main(info, verbose=True, dry_run=False, conda_exe="conda.exe"):
         )
 
     info["_all_pkg_records"] = pkg_records  # full PackageRecord objects
-    info["_urls"] = _urls  # needed to mock the repodata cache
-    info["_dists"] = dists  # needed to tell conda what to install
+    info["_urls"] = _base_env_urls  # needed to mock the repodata cache
+    info["_dists"] = _base_env_dists  # needed to tell conda what to install
+    info["_records"] = _base_env_records  # needed to generate optional lockfile
     info["_approx_tarballs_size"] = approx_tarballs_size
     info["_approx_pkgs_size"] = approx_pkgs_size
     info["_has_conda"] = has_conda
-    # contains {env_name: [_dists, _urls]} for each extra environment
+    # contains {env_name: [_dists, _urls, _records]} for each extra environment
     info["_extra_envs_info"] = extra_envs_info

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -860,6 +860,8 @@ Allowed keys are:
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.
 - `pkgs_list`: The list of packages contained in a given environment. Options:
     - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
+- `lockfile`: An `@EXPLICIT` lockfile for a given environment. Options:
+    - `env` (optional, default=`base`): Name of an environment in `extra_envs` to export.
 - `licenses`: Generate a JSON file with the licensing details of all included packages. Options:
     - `include_text` (optional bool, default=`False`): Whether to dump the license text in the JSON.
       If false, only the path will be included.

--- a/examples/extra_envs/construct.yaml
+++ b/examples/extra_envs/construct.yaml
@@ -31,6 +31,9 @@ build_outputs:
   - pkgs_list
   - pkgs_list:
       env: py310
+  - lockfile
+  - lockfile:
+      env: py310
   - licenses:
       include_text: True
       text_errors: replace

--- a/news/898-lockfile
+++ b/news/898-lockfile
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add new `lockfile` output in `build_outputs`. This generates a `@EXPLICIT` lockfile for the requested environment. (#898)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I want this to be able to release lockfiles for a given installer, so local clients can create the same environment as shipped in the installer without downloading the whole thing again. Useful for application deployments that have a pretty minimal `base` environment, and then an application+version specific environment. A local upgrade would then just consist of creating a new environment with the given lockfile, and the user would obtain the _same_ thing as distributed in the new installer.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
