### PR TITLE
Render post-install pages for Windows when input is a string 

### DIFF
--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -365,9 +365,12 @@ def make_nsi(
         if variables['custom_conclusion']
         else ''
     )
-    variables['POST_INSTALL_PAGES'] = '\n'.join(
-        custom_nsi_insert_from_file(file) for file in info.get('post_install_pages', [])
-    )
+    if isinstance(info.get("post_install_pages"), str):
+        variables["POST_INSTALL_PAGES"] = custom_nsi_insert_from_file(info["post_install_pages"])
+    else:
+        variables['POST_INSTALL_PAGES'] = '\n'.join(
+            custom_nsi_insert_from_file(file) for file in info.get('post_install_pages', [])
+        )
     variables['TEMP_EXTRA_FILES'] = '\n    '.join(insert_tempfiles_commands(temp_extra_files))
     variables['VIRTUAL_SPECS'] = " ".join([f'"{spec}"' for spec in info.get("virtual_specs", ())])
     # This is the same but without quotes so we can print it fine

--- a/examples/exe_extra_pages/construct.yaml
+++ b/examples/exe_extra_pages/construct.yaml
@@ -5,6 +5,3 @@ channels:
   - http://repo.anaconda.com/pkgs/main/
 specs:
   - python
-post_install_pages:
-  - extra_page_1.nsi
-  - extra_page_2.nsi

--- a/examples/exe_extra_pages/construct.yaml
+++ b/examples/exe_extra_pages/construct.yaml
@@ -1,7 +1,19 @@
-name: extraPages
+{% if os.environ.get("POST_INSTALL_PAGES_LIST") %}
+{% set name = "extraPages" %}
+{% else %}
+{% set name = "extraPageSingle" %}
+{% endif %}
+name: {{ name }}
 version: X
 installer_type: all
 channels:
   - http://repo.anaconda.com/pkgs/main/
 specs:
   - python
+{% if os.environ.get("POST_INSTALL_PAGES_LIST") %}
+post_install_pages:
+  - extra_page_1.nsi
+  - extra_page_2.nsi
+{% else %}
+post_install_pages: extra_page_1.nsi
+{% endif %}

--- a/news/904-post-install-pages-win-fix
+++ b/news/904-post-install-pages-win-fix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Correctly parse post-install pages for Windows when input is a string. (#904)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -378,28 +378,12 @@ def test_example_customized_welcome_conclusion(tmp_path, request):
         _run_installer(input_path, installer, install_dir, request=request)
 
 
-@pytest.mark.parametrize(
-    "extra_pages",
-    (
-        pytest.param(["extra_page_1.nsi", "extra_page_2.nsi"], id="two pages"),
-        pytest.param("extra_page_1.nsi", id="single page"),
-    )
-)
+@pytest.mark.parametrize("extra_pages", ("str", "list"))
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_example_extra_pages_win(tmp_path, request, extra_pages):
-    recipe_path = _example_path("exe_extra_pages")
-    input_path = tmp_path / "input"
-    shutil.copytree(str(recipe_path), str(input_path))
-    construct_yaml = input_path / "construct.yaml"
-    content = construct_yaml.read_text()
-    if isinstance(extra_pages, str):
-        content += f"post_install_pages: {extra_pages}\n"
-        content = content.replace("extraPages", "extraPage")
-    else:
-        content += "post_install_pages:\n"
-        for page in extra_pages:
-            content += f"  - {page}\n"
-    construct_yaml.write_text(content)
+def test_example_extra_pages_win(tmp_path, request, extra_pages, monkeypatch):
+    if extra_pages == "list":
+        monkeypatch.setenv("POST_INSTALL_PAGES_LIST", "1")
+    input_path = _example_path("exe_extra_pages")
     for installer, install_dir in create_installer(input_path, tmp_path):
         _run_installer(input_path, installer, install_dir, request=request)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -379,7 +379,7 @@ def test_example_customized_welcome_conclusion(tmp_path, request):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "extra_pages",
     pytest.param(["extra_page_1.nsi", "extra_page_2.nsi"], id="two pages"),
     pytest.param("extra_page_1.nsi", id="single page"),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -379,8 +379,25 @@ def test_example_customized_welcome_conclusion(tmp_path, request):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_example_extra_pages_win(tmp_path, request):
-    input_path = _example_path("exe_extra_pages")
+@pytest.mark.parameterize(
+    "extra_pages",
+    pytest.param(["extra_page_1.nsi", "extra_page_2.nsi"], id="two pages"),
+    pytest.param("extra_page_1.nsi", id="single page"),
+)
+def test_example_extra_pages_win(tmp_path, request, extra_pages):
+    recipe_path = _example_path("exe_extra_pages")
+    input_path = tmp_path / "input"
+    shutil.copytree(str(recipe_path), str(input_path))
+    construct_yaml = input_path / "construct.yaml"
+    content = construct_yaml.read_text()
+    if isinstance(extra_pages, str):
+        content += f"post_install_pages: {extra_pages}\n"
+        content = content.replace("extraPages", "extraPage")
+    else:
+        content += "post_install_pages:\n"
+        for page in extra_pages:
+            content += f"  - {page}\n"
+    construct_yaml.write_text(content)
     for installer, install_dir in create_installer(input_path, tmp_path):
         _run_installer(input_path, installer, install_dir, request=request)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -378,12 +378,14 @@ def test_example_customized_welcome_conclusion(tmp_path, request):
         _run_installer(input_path, installer, install_dir, request=request)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 @pytest.mark.parametrize(
     "extra_pages",
-    pytest.param(["extra_page_1.nsi", "extra_page_2.nsi"], id="two pages"),
-    pytest.param("extra_page_1.nsi", id="single page"),
+    (
+        pytest.param(["extra_page_1.nsi", "extra_page_2.nsi"], id="two pages"),
+        pytest.param("extra_page_1.nsi", id="single page"),
+    )
 )
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 def test_example_extra_pages_win(tmp_path, request, extra_pages):
     recipe_path = _example_path("exe_extra_pages")
     input_path = tmp_path / "input"


### PR DESCRIPTION
### Description

Windows assumed that `post_install_pages` is a list, but can also be a string. This PR fixes this.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
