### PR TITLE
Docs: Fix typo for the `/RemoveConfigFiles` CLI option in the Windows uninstaller.

### DIFF
--- a/docs/source/cli-options.md
+++ b/docs/source/cli-options.md
@@ -89,7 +89,7 @@ Windows uninstallers have the following CLI options:
 - `/RemoveCaches=[0|1]` (only if built with `uninstall_with_conda_exe`):
    Removes caches such package caches.
    For details, see the `constructor uninstall` subcommand of the `conda.exe` file.
-- `/RemoveConfigFiles=[none|users|system|all]` (only if built with `uninstall_with_conda_exe`):
+- `/RemoveConfigFiles=[none|user|system|all]` (only if built with `uninstall_with_conda_exe`):
   Removes configuration files such as `.condarc` files. `user` removes the files inside the
   current user's home directory and `system` removes all files outside of that directory.
   For details, see the `constructor uninstall` subcommand of the `conda.exe` file.

--- a/news/913-uninstaller-cli-option-typo
+++ b/news/913-uninstaller-cli-option-typo
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Fix typo `/RemoveConfigFiles` CLI option in the Windows uninstaller. (#913)
+
+### Other
+
+* <news item>

--- a/news/913-uninstaller-cli-option-typo
+++ b/news/913-uninstaller-cli-option-typo
@@ -12,7 +12,7 @@
 
 ### Docs
 
-* Fix typo `/RemoveConfigFiles` CLI option in the Windows uninstaller. (#913)
+* Fix typo for the `/RemoveConfigFiles` CLI option in the Windows uninstaller. (#913)
 
 ### Other
 


### PR DESCRIPTION
### Description

The documentation contains a typo for the `/RemoveConfigFiles` flag. It should be `user`, not `users`.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
