### PR TITLE
Implement `INSTALLER_UNATTENDED` for pkg installers

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -482,7 +482,7 @@ Path to a post-install script. Some notes:
 - For PKG installers, the shebang line is respected if present;
   otherwise, `bash` is used. The same variables mentioned for `sh`
   installers are available here. `${INSTALLER_TYPE}` is set to `PKG`.
-  `${INSTALLER_UNATTENDED}` is not supported and always set to `"?"`.
+  `${INSTALLER_UNATTENDED}` will be `"1"` for command line installs, `"0"` otherwise.
 - For Windows `.exe` installers, the script must be a `.bat` file.
   Installation path is available as `%PREFIX%`. Metadata about
   the installer can be found in the `%INSTALLER_NAME%`, `%INSTALLER_VER%`,

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -356,7 +356,7 @@ Path to a post-install script. Some notes:
 - For PKG installers, the shebang line is respected if present;
   otherwise, `bash` is used. The same variables mentioned for `sh`
   installers are available here. `${INSTALLER_TYPE}` is set to `PKG`.
-  `${INSTALLER_UNATTENDED}` is not supported and always set to `"?"`.
+  `${INSTALLER_UNATTENDED}` will be `"1"` for command line installs, `"0"` otherwise.
 - For Windows `.exe` installers, the script must be a `.bat` file.
   Installation path is available as `%PREFIX%`. Metadata about
   the installer can be found in the `%INSTALLER_NAME%`, `%INSTALLER_VER%`,

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -30,7 +30,7 @@ export INSTALLER_NAME="{{ installer_name }}"
 export INSTALLER_VER="{{ installer_version }}"
 export INSTALLER_PLAT="{{ installer_platform }}"
 export INSTALLER_TYPE="PKG"
-export INSTALLER_UNATTENDED="?"
+export INSTALLER_UNATTENDED="${COMMAND_LINE_INSTALL:-0}"
 export PRE_OR_POST="{{ pre_or_post }}"
 {{ script_env_variables }}
 

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -30,7 +30,14 @@ export INSTALLER_NAME="{{ installer_name }}"
 export INSTALLER_VER="{{ installer_version }}"
 export INSTALLER_PLAT="{{ installer_platform }}"
 export INSTALLER_TYPE="PKG"
+# The value for COMMAND_LINE_INSTALL is not documented,
+# but it is unset for interactive installations. To be
+# safe, set the variable for non-interactive installation
+# in a roundabout way.
 export INSTALLER_UNATTENDED="${COMMAND_LINE_INSTALL:-0}"
+if [[ "${INSTALLER_UNATTENDED}" != "0" ]]; then
+    INSTALLER_UNATTENDED="1"
+fi
 export PRE_OR_POST="{{ pre_or_post }}"
 {{ script_env_variables }}
 

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -482,7 +482,7 @@ Path to a post-install script. Some notes:
 - For PKG installers, the shebang line is respected if present;
   otherwise, `bash` is used. The same variables mentioned for `sh`
   installers are available here. `${INSTALLER_TYPE}` is set to `PKG`.
-  `${INSTALLER_UNATTENDED}` is not supported and always set to `"?"`.
+  `${INSTALLER_UNATTENDED}` will be `"1"` for command line installs, `"0"` otherwise.
 - For Windows `.exe` installers, the script must be a `.bat` file.
   Installation path is available as `%PREFIX%`. Metadata about
   the installer can be found in the `%INSTALLER_NAME%`, `%INSTALLER_VER%`,

--- a/examples/scripts/post_install.sh
+++ b/examples/scripts/post_install.sh
@@ -21,9 +21,7 @@ test "${CUSTOM_VARIABLE_1}" = 'FIR$T-CUSTOM_'\''STRING'\'' WITH SPACES AND @*! "
 # shellcheck disable=SC2016 # String interpolation disabling is deliberate
 test "${CUSTOM_VARIABLE_2}" = '$ECOND-CUSTOM_'\''STRING'\'' WITH SPACES AND @*! "CHARACTERS"'
 
-if [[ "${INSTALLER_TYPE}" == "SH" ]]; then
-    test "${INSTALLER_UNATTENDED}" = "1"
-fi
+test "${INSTALLER_UNATTENDED}" = "1"
 
 if [[ $(uname -s) == Linux ]]; then
     if [[ ${INSTALLER_PLAT} != linux-* ]]; then

--- a/news/915-installer-unattended-pkg
+++ b/news/915-installer-unattended-pkg
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `INSTALLER_UNATTENDED` environment variable for `pkg` installers. (#915)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Implement `INSTALLER_UNATTENDED` for `pkg` installers via the `COMMAND_LINE_INSTALL` environment variable. See the bottom of the [man page](https://www.unix.com/man-page/OSX/8/installer/) for the documentation of this variable.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
