### PR TITLE
also catch OSError when detecting conda_exe for cross-platform builds

### DIFF
--- a/constructor/main.py
+++ b/constructor/main.py
@@ -187,26 +187,27 @@ def main_build(dir_path, output_dir='.', platform=cc_platform,
             else:
                 env_config[config_key] = value
 
-    if exe_type is None or exe_version is None:
-        logger.warning(
-            "Could not identify conda-standalone / micromamba version. "
-            "Will assume it is compatible with shortcuts."
+    # Installers will provide shortcut options and features only if the user
+    # didn't opt-out by setting every `menu_packages` item to an empty list
+    info['_enable_shortcuts'] = bool(
+        info.get("menu_packages", True)
+        or any(
+            env.get("menu_packages", True)
+            for env in info.get("extra_envs", {}).values()
         )
-    elif sys.platform != "win32" and (
-        exe_type != StandaloneExe.CONDA or (exe_version and exe_version < Version("23.11.0"))
-    ):
-        logger.warning("conda-standalone 23.11.0 or above is required for shortcuts on Unix.")
-        info['_enable_shortcuts'] = "incompatible"
-    else:
-        # Installers will provide shortcut options and features only if the user
-        # didn't opt-out by setting every `menu_packages` item to an empty list
-        info['_enable_shortcuts'] = bool(
-            info.get("menu_packages", True)
-            or any(
-                env.get("menu_packages", True)
-                for env in info.get("extra_envs", {}).values()
+    )
+
+    if info['_enable_shortcuts']:
+        if exe_type is None or exe_version is None:
+            logger.warning(
+                "Could not identify conda-standalone / micromamba version. "
+                "Will assume it is compatible with shortcuts."
             )
-        )
+        elif sys.platform != "win32" and (
+            exe_type != StandaloneExe.CONDA or (exe_version and exe_version < Version("23.11.0"))
+        ):
+            logger.warning("conda-standalone 23.11.0 or above is required for shortcuts on Unix.")
+            info['_enable_shortcuts'] = "incompatible"
 
     # Add --no-rc option to CONDA_EXE command so that existing
     # .condarc files do not pollute the installation process.

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -71,7 +71,7 @@ def get_header(conda_exec, tarball, info):
     variables['initialize_conda'] = info.get('initialize_conda', True)
     variables['initialize_by_default'] = info.get('initialize_by_default', False)
     variables['has_conda'] = info['_has_conda']
-    variables['enable_shortcuts'] = str(info['_enable_shortcuts']).lower()
+    variables['enable_shortcuts'] = str(info.get('_enable_shortcuts', 'True')).lower()
     variables['check_path_spaces'] = info.get("check_path_spaces", True)
     install_lines = list(add_condarc(info))
     # Omit __osx and __glibc because those are tested with shell code direcly

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -71,7 +71,7 @@ def get_header(conda_exec, tarball, info):
     variables['initialize_conda'] = info.get('initialize_conda', True)
     variables['initialize_by_default'] = info.get('initialize_by_default', False)
     variables['has_conda'] = info['_has_conda']
-    variables['enable_shortcuts'] = str(info.get('_enable_shortcuts', 'True')).lower()
+    variables['enable_shortcuts'] = str(info['_enable_shortcuts']).lower()
     variables['check_path_spaces'] = info.get("check_path_spaces", True)
     install_lines = list(add_condarc(info))
     # Omit __osx and __glibc because those are tested with shell code direcly

--- a/constructor/utils.py
+++ b/constructor/utils.py
@@ -302,7 +302,7 @@ def identify_conda_exe(conda_exe: Union[str, Path] = None) -> Tuple[StandaloneEx
         output_help = check_output([conda_exe, "--help"], text=True)
         if "mamba" in output_help:
             return StandaloneExe.MAMBA, output_version
-    except CalledProcessError as exc:
+    except (CalledProcessError, OSError) as exc:
         logger.warning(f"Could not identify standalone binary {exc}.")
     return None, None
 


### PR DESCRIPTION
### Description

This PR handles some observations when `--platform` and `--conda-exe` are specified.

- before the `utils.py` patch:
```
OSError: [Errno 8] Exec format error: '~/build/standalone/linux-aarch64/standalone_conda/conda.exe'
```
- without the `main.py` tpach:
```
  File "~/build/lib/python3.12/site-packages/constructor/shar.py", line 74, in get_header
    variables['enable_shortcuts'] = str(info['_enable_shortcuts']).lower()
                                        ~~~~^^^^^^^^^^^^^^^^^^^^^
  File "~/build/lib/python3.12/site-packages/ruamel/yaml/comments.py", line 853, in __getitem__
    return ordereddict.__getitem__(self, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '_enable_shortcuts'
```

Presently, building with `constructor 3.11` on `python 3.12.1` on `linux-64`:



### Checklist - did you ...


- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
  - > are there tests of cross-platform building?
- [ ] Add / update outdated documentation?
  - > is there documentation about cross-platform building?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
