### PR TITLE
Expand Jinja templating

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -71,7 +71,9 @@ fi
 # Export variables to make installer metadata available to pre/post install scripts
 # NOTE: If more vars are added, make sure to update the examples/scripts tests too
 
-{{ script_env_variables }}
+{%- for key, val in script_env_variables|items %}
+export {{ key }}='{{ val }}'
+{%- endfor %}
 export INSTALLER_NAME='{{ installer_name }}'
 export INSTALLER_VER='{{ installer_version }}'
 export INSTALLER_PLAT='{{ installer_platform }}'
@@ -529,6 +531,7 @@ shortcuts="--no-shortcuts"
 shortcuts=""
 {%- endif %}
 
+{%- set channels = final_channels|join(",") %}
 # shellcheck disable=SC2086
 CONDA_ROOT_PREFIX="$PREFIX" \
 CONDA_REGISTER_ENVS="{{ register_envs }}" \
@@ -582,7 +585,9 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
 done
 {%- endif %}
 
-{{ install_commands }}
+{%- for condarc in write_condarc %}
+{{ condarc }}
+{%- endfor %}
 
 POSTCONDA="$PREFIX/postconda.tar.bz2"
 CONDA_QUIET="$BATCH" \

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1289,8 +1289,8 @@ Section "Install"
     File /r {{ repodata_record }}
 
 
-{%- for key, val in SCRIPT_ENV_VARIABLES | items %}
-    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("{{ key }}", {{ val }}).r0'
+{%- for key, escaped_val in SCRIPT_ENV_VARIABLES | items %}
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("{{ key }}", {{ escaped_val }}).r0'
 {%- endfor %}
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -77,10 +77,10 @@ var /global StdOutHandleSet
 !define ARCH {{ arch }}
 !define PLATFORM {{ installer_platform }}
 !define CONSTRUCTOR_VERSION {{ constructor_version }}
-!define PY_VER {{ py_ver }}
-!define PYVERSION_JUSTDIGITS {{ pyversion_justdigits }}
-!define PYVERSION {{ pyversion }}
-!define PYVERSION_MAJOR {{ pyversion_major }}
+!define PY_VER {{ pyver_components[:2] | join(".") }}
+!define PYVERSION_JUSTDIGITS {{ pyver_components | join("") }}
+!define PYVERSION {{ pyver_components | join(".") }}
+!define PYVERSION_MAJOR {{ pyver_components[0] }}
 !define DEFAULT_PREFIX {{ default_prefix }}
 !define DEFAULT_PREFIX_DOMAIN_USER {{ default_prefix_domain_user }}
 !define DEFAULT_PREFIX_ALL_USERS {{ default_prefix_all_users }}
@@ -190,10 +190,9 @@ Page Custom InstModePage_Create InstModePage_Leave
 # Custom options now differ depending on installation mode.
 Page Custom mui_AnaCustomOptions_Show
 !insertmacro MUI_PAGE_INSTFILES
-
-{%- if post_install_pages %}
-{{ POST_INSTALL_PAGES }}
-{%- endif %}
+{%- for page in POST_INSTALL_PAGES %}
+{{ page }}
+{%- endfor %}
 
 {%- if with_conclusion_text %}
 !define MUI_FINISHPAGE_TITLE {{ conclusion_title }}
@@ -557,7 +556,12 @@ Function .onInit
     Push $R2
 
     InitPluginsDir
-    {{ TEMP_EXTRA_FILES }}
+{%- if TEMP_EXTRA_FILES|length != 0 %}
+    SetOutPath $PLUGINSDIR
+{%- for file in TEMP_EXTRA_FILES %}
+    File {{ file }}
+{%- endfor %}
+{%- endif %}
     !insertmacro ParseCommandLineArgs
 
     # Select the correct registry to look at, depending
@@ -1260,8 +1264,12 @@ Section "Install"
     File {{ conda_exe }}
     File {{ pre_uninstall }}
 
-    # Copy extra files (code generated on winexe.py)
-    {{ EXTRA_FILES }}
+{%- for path, files in extra_files | items %}
+    SetOutPath {{ path }}
+{%- for file in files %}
+    File {{ file }}
+{%- endfor %}
+{%- endfor %}
 
     ${If} $InstMode = ${JUST_ME}
         SetOutPath "$INSTDIR"
@@ -1279,7 +1287,10 @@ Section "Install"
     File /nonfatal /r {{ index_cache }}
     File /r {{ repodata_record }}
 
-    {{ SCRIPT_ENV_VARIABLES }}
+
+{%- for key, val in SCRIPT_ENV_VARIABLES | items %}
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("{{ key }}", {{ val }}).r0'
+{%- endfor %}
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SAFETY_CHECKS", "disabled").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_ROOT_PREFIX", "$INSTDIR")".r0'
@@ -1314,7 +1325,9 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SOLVER", "").r0'
     ${EndIf}
 
-    {{ PKG_COMMANDS }}
+{%- for dist in DISTS %}
+    File {{ dist }}
+{%- endfor %}
 
     SetDetailsPrint TextOnly
     ${Print} "Setting up the package cache..."
@@ -1344,9 +1357,53 @@ Section "Install"
         call AbortRetryNSExecWait
     NoPreInstall:
 
-    {{ SETUP_ENVS }}
+{%- for env in SETUP_ENVS %}
+    {%- set channels = env.final_channels|join(",") %}
+    # Set up {{ env.name }} env
+    SetDetailsPrint both
+    ${Print} "Setting up the {{ env.name }} environment..."
+    SetDetailsPrint listonly
 
-    {{ WRITE_CONDARC }}
+    # List of packages to install
+    SetOutPath "{{ env.env_txt_dir }}"
+    File "{{ env.env_txt_abspath }}"
+
+    # A conda-meta\history file is required for a valid conda prefix
+    SetOutPath "{{ env.conda_meta }}"
+    File "{{ env.history_abspath }}"
+
+    # Set channels
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_CHANNELS", "{{ channels }}").r0'
+    # Set register_envs
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_REGISTER_ENVS", "{{ env.register_envs }}").r0'
+
+    # Run conda install
+    ${If} $Ana_CreateShortcuts_State = ${BST_CHECKED}
+        ${Print} "Installing packages for {{ env.name }}, creating shortcuts if necessary..."
+        push '"$INSTDIR\_conda.exe" install --offline -yp "{{ env.prefix }}" --file "{{ env.env_txt }}" {{ env.shortcuts }} {{ env.no_rcs_arg }}'
+    ${Else}
+        ${Print} "Installing packages for {{ env.name }}..."
+        push '"$INSTDIR\_conda.exe" install --offline -yp "{{ env.prefix }}" --file "{{ env.env_txt }}" --no-shortcuts {{ env.no_rcs_arg }}'
+    ${EndIf}
+    push 'Failed to link extracted packages to {{ env.prefix }}!'
+    push 'WithLog'
+    SetDetailsPrint listonly
+    call AbortRetryNSExecWait
+    SetDetailsPrint both
+
+    # Cleanup {{ env.name }} env.txt
+    SetOutPath "$INSTDIR"
+    Delete "{{ env.env_txt }}"
+
+    # Restore shipped conda-meta\history for remapped
+    # channels and retain only the first transaction
+    SetOutPath "{{ env.conda_meta }}"
+    File "{{ env.history_abspath }}"
+{%- endfor %}
+
+{%- for condarc in WRITE_CONDARC %}
+    {{ condarc }}
+{%- endfor %}
 
     AddSize {{ SIZE }}
 
@@ -1507,7 +1564,68 @@ Section "Uninstall"
         System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_UNATTENDED", "0").r0'
     ${EndIf}
 
-    {{ UNINSTALL_COMMANDS }}
+{%- if uninstall_with_conda_exe %}
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "pre_uninstall"
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
+
+    # Parse arguments
+    StrCpy $R0 ""
+
+    ${If} $UninstRemoveConfigFiles_User_State == ${BST_CHECKED}
+    ${If} $UninstRemoveConfigFiles_System_State == ${BST_CHECKED}
+        StrCpy $R0 "$R0 --remove-config-files=all"
+    ${Else}
+        StrCpy $R0 "$R0 --remove-config-files=user"
+    ${EndIf}
+    ${ElseIf} $UninstRemoveConfigFiles_System_State == ${BST_CHECKED}
+        StrCpy $R0 "$R0 --remove-config-files=system"
+    ${EndIf}
+
+    ${If} $UninstRemoveUserData_State == ${BST_CHECKED}
+    StrCpy $R0 "$R0 --remove-user-data"
+    ${EndIf}
+
+    ${If} $UninstRemoveCaches_State == ${BST_CHECKED}
+    StrCpy $R0 "$R0 --remove-caches"
+    ${EndIf}
+
+    ${Print} "Removing files and folders..."
+    push '"$INSTDIR\_conda.exe" constructor uninstall $R0 --prefix "$INSTDIR"'
+    push 'Failed to remove files and folders. Please see the log for more information.'
+    push 'WithLog'
+    SetDetailsPrint listonly
+    call un.AbortRetryNSExecWait
+    SetDetailsPrint both
+
+    # The uninstallation may leave the install.log, the uninstaller,
+    # and .conda_trash files behind, so remove those manually.
+    ${If} ${FileExists} "$INSTDIR"
+    RMDir /r /REBOOTOK "$INSTDIR"
+    ${EndIf}
+{%- else %}
+{%- for env in SETUP_ENVS | reverse %}
+    {%- set subdir = ("\envs\%(name)s" | format(name=env.name)) if env.name != "base" else "" %}
+    SetDetailsPrint both
+    ${Print} "Deleting ${NAME} menus in {{ env.name }}..."
+    SetDetailsPrint listonly
+    push '"$INSTDIR\_conda.exe" constructor --prefix "$INSTDIR{{ subdir }}" --rm-menus'
+    push 'Failed to delete menus in {{ env.name }}'
+    push 'WithLog'
+    call un.AbortRetryNSExecWait
+    SetDetailsPrint both
+{%- endfor %}
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "pre_uninstall"
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
+    !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
+
+    ${Print} "Removing files and folders..."
+    nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR"'
+
+    # In case the last command fails, run the slow method to remove leftover
+    RMDir /r /REBOOTOK "$INSTDIR"
+
+{%- endif %}
 
     ${If} $INSTALLER_NAME_FULL != ""
         DeleteRegKey SHCTX "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$INSTALLER_NAME_FULL"

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -190,6 +190,7 @@ Page Custom InstModePage_Create InstModePage_Leave
 # Custom options now differ depending on installation mode.
 Page Custom mui_AnaCustomOptions_Show
 !insertmacro MUI_PAGE_INSTFILES
+
 {%- for page in POST_INSTALL_PAGES %}
 {{ page }}
 {%- endfor %}
@@ -556,7 +557,7 @@ Function .onInit
     Push $R2
 
     InitPluginsDir
-{%- if TEMP_EXTRA_FILES|length != 0 %}
+{%- if TEMP_EXTRA_FILES | length != 0 %}
     SetOutPath $PLUGINSDIR
 {%- for file in TEMP_EXTRA_FILES %}
     File {{ file }}
@@ -1601,7 +1602,7 @@ Section "Uninstall"
     # The uninstallation may leave the install.log, the uninstaller,
     # and .conda_trash files behind, so remove those manually.
     ${If} ${FileExists} "$INSTDIR"
-    RMDir /r /REBOOTOK "$INSTDIR"
+        RMDir /r /REBOOTOK "$INSTDIR"
     ${EndIf}
 {%- else %}
 {%- for env in SETUP_ENVS | reverse %}

--- a/constructor/osx/checks_before_install.sh
+++ b/constructor/osx/checks_before_install.sh
@@ -18,11 +18,11 @@ if [[ -e "$PREFIX" ]]; then
 
     # By default, osascript doesn't allow user interaction, so we have to work
     # around it.  http://stackoverflow.com/a/11874852/161801
-    logger -p "install.info" "ERROR: __PATH_EXISTS_ERROR_TEXT__" || echo "ERROR: __PATH_EXISTS_ERROR_TEXT__"
+    logger -p "install.info" "ERROR: {{ path_exists_error_text }}" || echo "ERROR: {{ path_exists_error_text }}"
     (osascript -e "try
 tell application (path to frontmost application as text)
 set theAlertText to \"Chosen path already exists!\"
-set theAlertMessage to \"__PATH_EXISTS_ERROR_TEXT__\"
+set theAlertMessage to \"{{ path_exists_error_text }}\"
 display alert theAlertText message theAlertMessage as critical buttons {\"OK\"} default button {\"OK\"}
 end
 activate app (path to frontmost application as text)

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -12,7 +12,7 @@ notify() {
 # shellcheck disable=SC2050
 {%- if progress_notifications %}
 osascript <<EOF
-display notification "$1" with title "📦 Install __NAME__ __VERSION__"
+display notification "$1" with title "📦 Install {{ installer_name }} {{ installer_version }}"
 EOF
 {%- endif %}
 logger -p "install.info" "$1" || echo "$1"

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -18,6 +18,8 @@ EOF
 logger -p "install.info" "$1" || echo "$1"
 }
 
+{%- set channels = final_channels|join(",") %}
+
 unset DYLD_LIBRARY_PATH
 
 PREFIX="$2/{{ pkg_name_lower }}"
@@ -103,7 +105,9 @@ done
 # Cleanup!
 find "$PREFIX/pkgs" -type d -empty -exec rmdir {} \; 2>/dev/null || :
 
-{{ write_condarc }}
+{%- for condarc in write_condarc %}
+{{ condarc }}
+{%- endfor %}
 
 if ! "$PREFIX/bin/python" -V; then
     echo "ERROR running Python"

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -39,7 +39,9 @@ if [[ "${INSTALLER_UNATTENDED}" != "0" ]]; then
     INSTALLER_UNATTENDED="1"
 fi
 export PRE_OR_POST="{{ pre_or_post }}"
-{{ script_env_variables }}
+{%- for key, val in script_env_variables|items %}
+export {{ key }}='{{ val }}'
+{%- endfor %}
 
 # Run user-provided script
 if [ -f "$PREFIX/pkgs/user_${PRE_OR_POST}" ]; then

--- a/constructor/osx/run_user_script.sh
+++ b/constructor/osx/run_user_script.sh
@@ -10,7 +10,7 @@ notify() {
 # shellcheck disable=SC2050
 {%- if progress_notifications %}
 osascript <<EOF
-display notification "$1" with title "📦 Install __NAME__ __VERSION__"
+display notification "$1" with title "📦 Install {{ installer_name }} {{ installer_version }}"
 EOF
 {%- endif %}
 logger -p "install.info" "$1" || echo "$1"

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -335,8 +335,8 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
     variables["installer_name"] = info['name']
     variables["installer_version"] = info['version']
     variables["installer_platform"] = info['_platform']
-    variables["channels"] = ','.join(get_final_channels(info))
-    variables["write_condarc"] = '\n'.join(add_condarc(info))
+    variables["final_channels"] = get_final_channels(info)
+    variables["write_condarc"] = list(add_condarc(info))
     variables["path_exists_error_text"] = path_exists_error_text
     variables["progress_notifications"] = info.get('progress_notifications', False)
     variables["pre_or_post"] = user_script_type or '__PRE_OR_POST__'
@@ -346,8 +346,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
     variables["register_envs"] = str(info.get("register_envs", True)).lower()
     variables["virtual_specs"] = shlex.join(virtual_specs)
     variables["no_rcs_arg"] = info.get('_ignore_condarcs_arg', '')
-    variables["script_env_variables"] = '\n'.join(
-        [f"export {key}='{value}'" for key, value in info.get('script_env_variables', {}).items()])
+    variables["script_env_variables"] = info.get('script_env_variables', {})
 
     data = render_template(data, **variables)
 

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -73,7 +73,6 @@ def get_header(conda_exec, tarball, info):
     variables['has_conda'] = info['_has_conda']
     variables['enable_shortcuts'] = str(info['_enable_shortcuts']).lower()
     variables['check_path_spaces'] = info.get("check_path_spaces", True)
-    install_lines = list(add_condarc(info))
     # Omit __osx and __glibc because those are tested with shell code direcly
     virtual_specs = [
         spec
@@ -87,8 +86,8 @@ def get_header(conda_exec, tarball, info):
     variables['default_prefix'] = info.get('default_prefix', '${HOME:-/opt}/%s' % name.lower())
     variables['first_payload_size'] = getsize(conda_exec)
     variables['second_payload_size'] = getsize(tarball)
-    variables['install_commands'] = '\n'.join(install_lines)
-    variables['channels'] = ','.join(get_final_channels(info))
+    variables['write_condarc'] = list(add_condarc(info))
+    variables['final_channels'] = get_final_channels(info)
     variables['conclusion_text'] = info.get("conclusion_text", "installation finished.")
     variables['pycache'] = '__pycache__'
     variables['shortcuts'] = shortcuts_flags(info)
@@ -105,8 +104,7 @@ def get_header(conda_exec, tarball, info):
     min_glibc_version = virtual_specs.get("__glibc", {}).get("min") or ""
     variables['min_glibc_version'] = min_glibc_version
 
-    variables['script_env_variables'] = '\n'.join(
-        [f"export {key}='{value}'" for key, value in info.get('script_env_variables', {}).items()])
+    variables['script_env_variables'] = info.get('script_env_variables', {})
 
     return render_template(read_header_template(), **variables)
 

--- a/examples/custom_nsis_template/custom.nsi.tmpl
+++ b/examples/custom_nsis_template/custom.nsi.tmpl
@@ -5,11 +5,11 @@
 
 Unicode "true"
 
-#if enable_debugging is True
+{%- if enable_debugging %}
 # Special logging build needed for ENABLE_LOGGING
 # See https://nsis.sourceforge.io/Special_Builds
 !define ENABLE_LOGGING
-#endif
+{%- endif %}
 
 # Comes from https://nsis.sourceforge.io/Logging:Enable_Logs_Quickly
 !define LogSet "!insertmacro LogSetMacro"
@@ -114,27 +114,27 @@ BrandingText /TRIMLEFT "${COMPANY}"
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP __WELCOMEIMAGE__
 
 # Pages
-#if custom_welcome
+{%- if custom_welcome %}
 # Custom welcome file(s)
-@CUSTOM_WELCOME_FILE@
-#else
+{{ CUSTOM_WELCOME_FILE }}
+{%- else %}
 !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipPageIfUACInnerInstance
 !insertmacro MUI_PAGE_WELCOME
-#endif
+{%- endif %}
 !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipPageIfUACInnerInstance
 !insertmacro MUI_PAGE_LICENSE __LICENSEFILE__
 !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipPageIfUACInnerInstance
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE OnDirectoryLeave
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
-#if with_conclusion_text is True
+{%- if with_conclusion_text %}
 !define MUI_FINISHPAGE_TITLE __CONCLUSION_TITLE__
 !define MUI_FINISHPAGE_TITLE_3LINES
 !define MUI_FINISHPAGE_TEXT __CONCLUSION_TEXT__
-#endif
+{%- endif %}
 
 # Custom conclusion file(s)
-@CUSTOM_CONCLUSION_FILE@
+{{ CUSTOM_CONCLUSION_FILE }}
 
 !insertmacro MUI_PAGE_FINISH
 
@@ -248,8 +248,8 @@ Function .onInit
 
     # Select the correct registry to look at, depending
     # on whether it's a 32-bit or 64-bit installer
-    SetRegView @BITS@
-#if win64
+    SetRegView {{ BITS }}
+{%- if win64 %}
     # If we're a 64-bit installer, make sure it's 64-bit Windows
     ${IfNot} ${RunningX64}
         MessageBox MB_OK|MB_ICONEXCLAMATION \
@@ -259,7 +259,7 @@ Function .onInit
             /SD IDOK
         Abort
     ${EndIf}
-#endif
+{%- endif %}
 
     !insertmacro UAC_PageElevation_OnInit
     ${If} ${UAC_IsInnerInstance}
@@ -487,7 +487,7 @@ Function un.onInit
 
     # Select the correct registry to look at, depending
     # on whether it's a 32-bit or 64-bit installer
-    SetRegView @BITS@
+    SetRegView {{ BITS }}
 
     # Since the switch to a dual-mode installer (All Users/Just Me), the
     # uninstaller will inherit the requested execution level of the main
@@ -646,7 +646,7 @@ SectionEnd
 
 Section "Uninstall"
     # Remove menu items, path entries
-    DetailPrint "Deleting @NAME@ menus..."
+    DetailPrint "Deleting {{ NAME }} menus..."
     nsExec::ExecToLog '"$INSTDIR\_conda.exe" constructor --prefix "$INSTDIR" --rm-menus'
 
     # ensure that MSVC runtime DLLs are on PATH during uninstallation
@@ -705,10 +705,10 @@ Section "Uninstall"
 
 SectionEnd
 
-!if '@SIGNTOOL_COMMAND@' != ''
+!if '{{ SIGNTOOL_COMMAND }}' != ''
     # Signing for installer and uninstaller; nsis 3.08 required for uninstfinalize!
     # "= 0" comparison required to prevent both tasks running in parallel, which would cause signtool to fail
     # %1 is replaced by the installer and uninstaller paths, respectively
-    !finalize '@SIGNTOOL_COMMAND@ "%1"' = 0
-    !uninstfinalize '@SIGNTOOL_COMMAND@ "%1"' = 0
+    !finalize ' {{ SIGNTOOL_COMMAND }} "%1"' = 0
+    !uninstfinalize '{{ SIGNTOOL_COMMAND }} "%1"' = 0
 !endif

--- a/news/922-improve-jinja-integration
+++ b/news/922-improve-jinja-integration
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Improve use of Jinja for templating logic. (#901 via #922)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -290,7 +290,7 @@ def _run_installer(
         )
     else:
         raise ValueError(f"Unknown installer type: {installer.suffix}")
-    if check_sentinels:
+    if check_sentinels and not (installer.suffix == ".pkg" and ON_CI):
         _sentinel_file_checks(example_path, install_dir)
     if uninstall and installer.suffix == ".exe":
         _run_uninstaller_exe(install_dir, timeout=timeout, check=check_subprocess)
@@ -837,6 +837,8 @@ def test_virtual_specs_failed(tmp_path, request):
                 _check_installer_log(install_dir)
             continue
         elif installer.suffix == ".pkg":
+            if not ON_CI:
+                continue
             # The GUI does provide a better message with the min version and so on
             # but on the CLI we fail with this one instead
             msg = "Cannot install on volume"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -808,6 +808,8 @@ def test_cross_osx_building(tmp_path):
             "micromamba",
             "--platform",
             "osx-arm64",
+            "-c",
+            "conda-forge",
         ],
     )
     micromamba_arm64 = tmp_env / "bin" / "micromamba"

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -155,6 +155,8 @@ def test_template_shellcheck(
             "no_rcs_arg": "",
             "install_commands": "",  # TODO: Fill this in with actual value
             "conclusion_text": "Something",
+            "final_channels": "",
+            "write_condarc": "",
         },
     )
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -57,7 +57,7 @@ def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
         installer_name="Example",
         installer_version="1.2.3",
         installer_platform="osx-64",
-        channels="conda-forge",
+        final_channels=["conda-forge"],
         write_condarc="",
         path_exists_error_text="Error",
         progress_notifications=True,
@@ -144,7 +144,7 @@ def test_template_shellcheck(
             "installer_version": "1.2.3",
             "installer_platform": "linux-64",
             "installer_md5": "a0098a2c837f4cf50180cfc0a041b2af",
-            "script_env_variables": "",  # TODO: Fill this in with actual value
+            "script_env_variables": {},  # TODO: Fill this in with actual value
             "default_prefix": "/opt/Example",
             "license": "Some text",
             "total_installation_size_kb": "1024",


### PR DESCRIPTION
### Description

#892 introduced a small regression by missing a few template variables for PKG installers. In fixing this regression, I decided to expand the Jinja templating as described in #901.

Specifically, this PR removes custom Python code with Jinja templating logic, which removed a lot of custom Python formatting functions on Windows and simplified the data structures.

Additionally, I patched a few testing issues that broke tests for local test executions and when using the defaults channel.

Closes #901 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
