### PR TITLE
Enforce LF line endings for checksum files

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -854,7 +854,8 @@ _type:_ list<br/>
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
-- `hash`: The hash of the installer files.
+- `hash`: The hash of the installer files. The output file is designed to work with the `shasum`
+  command and thus has POSIX line endings, including on Windows. Options:
     - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -65,7 +65,7 @@ def dump_hash(info, algorithm=None):
                     filehashes[algo].update(buffer)
         for algo, filehash in filehashes.items():
             outpath = Path(f"{installer}.{algo}")
-            with open(outpath, newline="\n") as f:
+            with open(outpath, "w", newline="\n") as f:
                 f.write(f"{filehash.hexdigest()}  {installer.name}\n")
             outpaths.append(str(outpath.absolute()))
     return ", ".join(outpaths)

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -65,7 +65,7 @@ def dump_hash(info, algorithm=None):
                     filehashes[algo].update(buffer)
         for algo, filehash in filehashes.items():
             outpath = Path(f"{installer}.{algo}")
-            outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n")
+            outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n", newline='\n')
             outpaths.append(str(outpath.absolute()))
     return ", ".join(outpaths)
 

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -65,7 +65,8 @@ def dump_hash(info, algorithm=None):
                     filehashes[algo].update(buffer)
         for algo, filehash in filehashes.items():
             outpath = Path(f"{installer}.{algo}")
-            outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n", newline="\n")
+            with open(outpath, newline="\n") as f:
+                f.write(f"{filehash.hexdigest()}  {installer.name}\n")
             outpaths.append(str(outpath.absolute()))
     return ", ".join(outpaths)
 

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -65,7 +65,7 @@ def dump_hash(info, algorithm=None):
                     filehashes[algo].update(buffer)
         for algo, filehash in filehashes.items():
             outpath = Path(f"{installer}.{algo}")
-            outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n", newline='\n')
+            outpath.write_text(f"{filehash.hexdigest()}  {installer.name}\n", newline="\n")
             outpaths.append(str(outpath.absolute()))
     return ", ".join(outpaths)
 

--- a/constructor/construct.py
+++ b/constructor/construct.py
@@ -629,7 +629,8 @@ Supports the same values as `extra_files`.
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
-- `hash`: The hash of the installer files.
+- `hash`: The hash of the installer files. The output file is designed to work with the `shasum`
+  command and thus has POSIX line endings, including on Windows. Options:
     - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -854,7 +854,8 @@ _type:_ list<br/>
 Additional artifacts to be produced after building the installer.
 It expects either a list of strings or single-key dictionaries:
 Allowed keys are:
-- `hash`: The hash of the installer files.
+- `hash`: The hash of the installer files. The output file is designed to work with the `shasum`
+  command and thus has POSIX line endings, including on Windows. Options:
     - `algorithm` (str or list): The hash algorithm. Must be among `hashlib`'s available algorithms:
        https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available
 - `info.json`: The internal `info` object, serialized to JSON. Takes no options.

--- a/news/938-checksum-file-newline
+++ b/news/938-checksum-file-newline
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Enforce POSIX newline characters in checksum files to allow `shasum -c` on Windows. (#938)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,38 +1,49 @@
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
 
 from constructor.build_outputs import dump_hash
 
+TEST_FILES = {
+    "test.txt": {
+        "content": "test string",
+        "sha256": "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
+        "md5": "6f8db599de986fab7a21625b7916589c",
+    },
+    "test2.txt": {
+        "content": "another test",
+        "sha256": "64320dd12e5c2caeac673b91454dac750c08ba333639d129671c2f58cb5d0ad1",
+        "md5": "5e8862cd73694287ff341e75c95e3c6a",
+    },
+}
 
-def test_hash_dump(tmp_path):
-    testfile = tmp_path / "test.txt"
-    testfile.write_text("test string")
-    testfile = tmp_path / "test2.txt"
-    testfile.write_text("another test")
-    expected = {
-        "sha256": (
-            "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
-            "64320dd12e5c2caeac673b91454dac750c08ba333639d129671c2f58cb5d0ad1",
-        ),
-        "md5": (
-            "6f8db599de986fab7a21625b7916589c",
-            "5e8862cd73694287ff341e75c95e3c6a",
-        ),
-    }
+
+@pytest.mark.parametrize(
+    "algorithm,context",
+    (
+        pytest.param("bad algorithm", pytest.raises(ValueError), id="invalid algorithm"),
+        pytest.param("sha256", nullcontext(), id="string"),
+        pytest.param(["sha256", "md5"], nullcontext(), id="list"),
+    ),
+
+)
+def test_hash_dump(tmp_path, algorithm, context):
     info = {
-        "_outpath": [
-            str(tmp_path / "test.txt"),
-            str(tmp_path / "test2.txt"),
-        ]
+        "_outpath": []
     }
-    with pytest.raises(ValueError):
-        dump_hash(info, algorithm="bad_algorithm")
-    dump_hash(info, algorithm=["sha256", "md5"])
-    for f, file in enumerate(info["_outpath"]):
-        for algorithm in expected:
-            hashfile = Path(f"{file}.{algorithm}")
-            assert hashfile.exists()
-            filehash, filename = hashfile.read_text().strip().split()
-            assert filehash == expected[algorithm][f]
-            assert filename == Path(file).name
+    for file, data in TEST_FILES.items():
+        testfile = tmp_path / file
+        testfile.write_text(data["content"])
+        info["_outpath"].append(str(testfile))
+    with context:
+        dump_hash(info, algorithm=algorithm)
+        if isinstance(algorithm, str):
+            algorithm = [algorithm]
+        for file in info["_outpath"]:
+            for algo in algorithm:
+                hashfile = Path(f"{file}.{algo}")
+                assert hashfile.exists()
+                filehash, filename = hashfile.read_text().strip().split()
+                assert filename == Path(file).name
+                assert filehash == TEST_FILES[filename][algo]

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -44,6 +44,9 @@ def test_hash_dump(tmp_path, algorithm, context):
             for algo in algorithm:
                 hashfile = Path(f"{file}.{algo}")
                 assert hashfile.exists()
-                filehash, filename = hashfile.read_text().strip().split()
+                with open(hashfile, newline="") as f:
+                    content = f.read()
+                assert "\r" not in content
+                filehash, filename = content.strip().split()
                 assert filename == Path(file).name
                 assert filehash == TEST_FILES[filename][algo]


### PR DESCRIPTION
### Description

On Windows, the checksum files are output with `CRLF` line endings, which breaks the `shasum -c` check because it will treat `\r` as part of the file name. Since the output files are written to work with `shasum`, POSIX line endings needs to be enforced.

I also decided to refactor the tests and parametrize them to cover every use case.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
