### PR TITLE
Fix ownership of files created by `conda init` for `PKG` installers.

### DIFF
--- a/constructor/osx/checks_before_install.sh
+++ b/constructor/osx/checks_before_install.sh
@@ -31,7 +31,7 @@ end")
     exit 1
 fi
 
-#if check_path_spaces is True
+{%- if check_path_spaces %}
 # Check if the path has spaces
 case "$PREFIX" in
     *\ * )
@@ -51,6 +51,6 @@ end")
 
         ;;
 esac
-#endif
+{%- endif %}
 
 exit 0

--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -18,7 +18,10 @@ INIT_FILES=$("$PREFIX/bin/python" -m conda init --all | tee)
 # have the correct owner.
 if [[ "${USER}" != "root" ]]; then
     echo "Fixing permissions..."
-    read -r -a MODIFIED_FILES <<< "$(\
+    MODIFIED_FILES=()
+    while read -r line; do
+        MODIFIED_FILES+=("$line")
+    done <<< "$(\
       echo "${INIT_FILES}" |\
       awk '/modified/{print $2}' |\
       # Only grab files inside $HOME or $PREFIX.

--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -23,13 +23,18 @@ if [[ "${USER}" != "root" ]]; then
         MODIFIED_FILES+=("$line")
     done <<< "$(\
       echo "${INIT_FILES}" |\
-      awk '/modified/{print $2}' |\
+      grep -E "^modified" |\
+      sed -e 's/^modified */' |\
       # Only grab files inside $HOME or $PREFIX.
       # All init files should be there, but that may change, and it
       # is better to miss files than to have an infinite loop below.
       grep -E "^(${HOME}|${PREFIX})"\
     )"
     for file in "${MODIFIED_FILES[@]}"; do
+        # Defend against potential empty lines
+        if [[ "${file}" == "" ]]; then
+            continue
+        fi
         while [[ "${file}" != "${HOME}" ]] && [[ "${file}" != "${PREFIX}" ]]; do
             # Check just in case the file wasn't created due to flaky conda init
             if [[ -f "${file}" ]] || [[ -d "${file}" ]]; then

--- a/constructor/osx/update_path.sh
+++ b/constructor/osx/update_path.sh
@@ -24,7 +24,7 @@ if [[ "${USER}" != "root" ]]; then
     done <<< "$(\
       echo "${INIT_FILES}" |\
       grep -E "^modified" |\
-      sed -e 's/^modified */' |\
+      sed -e 's/^modified *//' |\
       # Only grab files inside $HOME or $PREFIX.
       # All init files should be there, but that may change, and it
       # is better to miss files than to have an infinite loop below.

--- a/news/939-pkg-conda-init-ownership
+++ b/news/939-pkg-conda-init-ownership
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix ownership of files created by `conda init` for `PKG` installers. (#939)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

When PKG installers are installed outside the `$HOME` directory, the installer installs as `root` (even though `$USER` is still the user executing the installer). This causes files and directories created by `conda init` to be owned by `root`. The current script appears to only pick up the first modified file so that some files are still owned by root. This PR fixes the issue by using a more bash v3 compliant way to read the multi-line string.

I'm not sure how this can be tested on the CI since the only time this problem appears is when the PKG installers are run interactively and the destination path is not inside `$HOME`. I don't know if this can be replicated on the CI.

However, I have created a Miniconda installer with this script and it had the correct permissions on macOS 12 and 15. It even fixed a previous installation that had the incorrect permissions.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] ~Add / update necessary tests?~
- [X] Add / update outdated documentation?