### PR TITLE
correct extra files ref issue introduced in 0c80f9b

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
             && files+=(--file "dev/extra-requirements-${{ runner.os }}.txt")
           conda install ${files[@]} -y
           echo "NSIS_USING_LOG_BUILD=1" >> $GITHUB_ENV
+          echo "NSIS_SCRIPTS_RAISE_ERRORS=1" >> $GITHUB_ENV
           pip install -e . --no-deps --no-build-isolation
       - name: Set up conda executable
         run: |

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1265,7 +1265,7 @@ Section "Install"
     File {{ conda_exe }}
     File {{ pre_uninstall }}
 
-{%- for path, files in extra_files | items %}
+{%- for path, files in EXTRA_FILES | items %}
     SetOutPath {{ path }}
 {%- for file in files %}
     File {{ file }}

--- a/news/942-fix-win-extra_files
+++ b/news/942-fix-win-extra_files
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix extra_file functionality on exe installers. (#942)
+* Fix `extra_files` functionality on EXE installers. (#942)
 
 ### Deprecations
 

--- a/news/942-fix-win-extra_files
+++ b/news/942-fix-win-extra_files
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix extra_file functionality on exe installers. (#942)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Building windows installers using the latest version of constructor (3.11.1) has broken `extra_files`.  Reverting to 3.11.0 solves the issues.  This looks to have been introduced in 0c80f9b with the recent jinga changes and the casing of the extra_files var was changed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
