### PR TITLE
Set `CONDA_QUIET=1` for exe installers

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1296,6 +1296,9 @@ Section "Install"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_EXTRA_SAFETY_CHECKS", "no").r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_ROOT_PREFIX", "$INSTDIR")".r0'
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_PKGS_DIRS", "$INSTDIR\pkgs")".r0'
+    # Spinners in conda write a new character with each movement of the spinner.
+    # For long installation times, this may cause a buffer overflow, crashing the installer.
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_QUIET", "1")".r0'
     # Extra info for pre and post install scripts
     # NOTE: If more vars are added, make sure to update the examples/scripts tests too
     #       There's a similar block for the pre_uninstall script, further down this file.
@@ -1526,6 +1529,10 @@ Section "Uninstall"
     # our newest Python builds have a patch that allows us to control the PATH search stuff much more
     #   carefully.  More info at https://docs.conda.io/projects/conda/en/latest/user-guide/troubleshooting.html#solution
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_DLL_SEARCH_MODIFICATION_ENABLE", "1").r0'
+
+    # Spinners in conda write a new character with each movement of the spinner.
+    # For long installation times, this may cause a buffer overflow, crashing the installer.
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_QUIET", "1")".r0'
 
     # Read variables the uninstaller needs from the registry
     StrCpy $R0 "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"

--- a/news/950-conda-quiet-exe
+++ b/news/950-conda-quiet-exe
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Set `CONDA_QUIET=1` for EXE installers to avoid crashes due to NSIS log buffer overflows. (#944 via #950)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Since `conda 24.11.0`, transactions have a spinner instead of the "working" keyword to indicate progress. This spinner is not handled well in the NSIS log, writing characters for each movement of the spinner. For slow installations or large installer files, this results in very long lines.

It is suspected that this causes an overflow and crashing installers. This is evidenced by the fact that a crashing installer can be made to work when setting `CONDA_QUIET=1` (or downgrading `conda-standalone` to `v24.9.2.`, which doesn't have the spinner).

To avoid these overflow crashes, set `CONDA_QUIET=1` for EXE installers. Closes #944.

![Screenshot 2025-03-04 at 11 29 31 AM](https://github.com/user-attachments/assets/d684b2f1-a012-441d-8f19-07eab476dfb0)
![Screenshot 2025-03-04 at 11 34 08 AM](https://github.com/user-attachments/assets/7485be40-29fa-4a0e-acbf-c06850081c2d)

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?