### PR TITLE
Add `setuptools_scm` to recipe

### DIFF
--- a/news/951-add-setuptools-scm
+++ b/news/951-add-setuptools-scm
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add `setuptools-scm` to build recipe. (#951)

--- a/news/951-add-setuptools-scm
+++ b/news/951-add-setuptools-scm
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Add `setuptools-scm` to build recipe. (#951)
+* Add `setuptools_scm` to build recipe. (#951)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python  # >=3.8
     - pip
     - setuptools >=70.1
-    - setuptools-scm >=6.2
+    - setuptools_scm >=6.2
   run:
     - conda >=4.6
     - python  # >=3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python  # >=3.8
     - pip
     - setuptools >=70.1
+    - setuptools-scm >=6.2
   run:
     - conda >=4.6
     - python  # >=3.8


### PR DESCRIPTION
### Description

The build recipe is missing `setuptools_scm`. See: https://github.com/conda/constructor/blob/99d883d068b7948c3584b1db2908289e109ba5e7/pyproject.toml#L2

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?