### PR TITLE
Unset `CONDARC` and `MAMBARC` during installation

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -78,6 +78,9 @@ export INSTALLER_NAME='{{ installer_name }}'
 export INSTALLER_VER='{{ installer_version }}'
 export INSTALLER_PLAT='{{ installer_platform }}'
 export INSTALLER_TYPE="SH"
+# Installers should ignore pre-existing configuration files.
+unset CONDARC
+unset MAMBARC
 
 THIS_DIR=$(DIRNAME=$(dirname "$0"); cd "$DIRNAME"; pwd)
 THIS_FILE=$(basename "$0")

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1313,6 +1313,9 @@ Section "Install"
     ${Else}
         System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_UNATTENDED", "0").r0'
     ${EndIf}
+    # Installers should ignore pre-existing configuration files.
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDARC", 0).r0'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("MAMBARC", 0).r0'
 
     ${If} '{{ VIRTUAL_SPECS }}' != ''
     # We need to specify CONDA_SOLVER=classic for conda-standalone

--- a/constructor/osx/prepare_installation.sh
+++ b/constructor/osx/prepare_installation.sh
@@ -23,6 +23,9 @@ PREFIX=$(cd "$PREFIX"; pwd)
 export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
+# Installers should ignore pre-existing configuration files.
+unset CONDARC
+unset MAMBARC
 # /COMMON UTILS
 
 chmod +x "$CONDA_EXEC"

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -27,6 +27,9 @@ PREFIX=$(cd "$PREFIX"; pwd)
 export PREFIX
 echo "PREFIX=$PREFIX"
 CONDA_EXEC="$PREFIX/_conda"
+# Installers should ignore pre-existing configuration files.
+unset CONDARC
+unset MAMBARC
 # /COMMON UTILS
 
 # Check whether the user wants shortcuts or not

--- a/news/962-unset-condarc-mambarc
+++ b/news/962-unset-condarc-mambarc
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Unset `CONDARC` and `MAMBARC` to prevent pre-existing configuration files from influencing the installation. (#962)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -948,6 +948,12 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
         condarc = tmp_path / "conda" / ".condarc"
     condarc.parent.mkdir(parents=True, exist_ok=True)
     condarc.write_text("safety_checks:\n  - very safe\n")
+
+    # If CONDARC or MAMBARC are set, micromamba will break when --no-rc is used.
+    # Installers should ignore those environment variables.
+    monkeypatch.setenv("CONDARC", str(condarc))
+    monkeypatch.setenv("MAMBARC", str(condarc))
+
     recipe_path = _example_path("customize_controls")
     input_path = tmp_path / "input"
     shutil.copytree(str(recipe_path), str(input_path))


### PR DESCRIPTION
### Description

Pre-existing configuration files should not influence the installation process, which is why standalone binaries are currently called with the `--no-rc` option. If `CONDARC` is set, this option is overwritten for `conda-standalone`. For `micromamba`, using `--no-rc` while `CONDARC` or `MAMBARC` are set results in an error.

To prevent this from happening, unset `CONDARC` and `MAMBARC` during the installation process.

I ran the tests with and without the code changes for `exe` on Windows and `sh` installers on Linux and they fail, so them passing is a sign that the changes are working as expected.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
