### PR TITLE
Fix `hash` keyword for `build_outputs` schema

### DIFF
--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -152,7 +152,7 @@ class HashBuildOutput(BaseModel):
     """
 
     model_config: ConfigDict = _base_config_dict
-    hash_: _HashBuildOutputOptions
+    hash: _HashBuildOutputOptions
 
 
 class InfoJsonBuildOutput(BaseModel):

--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -152,7 +152,7 @@ class HashBuildOutput(BaseModel):
     """
 
     model_config: ConfigDict = _base_config_dict
-    hash: _HashBuildOutputOptions
+    hash_: _HashBuildOutputOptions = Field(..., alias="hash")
 
 
 class InfoJsonBuildOutput(BaseModel):

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -47,7 +47,7 @@ def process_build_outputs(info):
 
 def dump_hash(info, algorithm=None):
     if not algorithm:
-        logger.warning("`hash` requires an algorithm. No has files will be output.")
+        logger.warning("`hash` requires an algorithm. No hash files will be output.")
         return ""
     if isinstance(algorithm, str):
         algorithm = [algorithm]

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -41,11 +41,14 @@ def process_build_outputs(info):
                 f"Available keys: {tuple(OUTPUT_HANDLERS.keys())}"
             )
         outpath = handler(info, **config)
-        logger.info("build_outputs: '%s' created '%s'.", name, outpath)
+        if outpath:
+            logger.info("build_outputs: '%s' created '%s'.", name, outpath)
 
 
 def dump_hash(info, algorithm=None):
-    algorithm = algorithm or []
+    if not algorithm:
+        logger.warning("`hash` requires an algorithm. No has files will be output.")
+        return ""
     if isinstance(algorithm, str):
         algorithm = [algorithm]
     algorithms = set(algorithm)

--- a/constructor/data/construct.schema.json
+++ b/constructor/data/construct.schema.json
@@ -188,12 +188,12 @@
       "additionalProperties": false,
       "description": "The hash of the installer files. The output file is designed to work with the `shasum` command and thus has POSIX line endings, including on Windows",
       "properties": {
-        "hash_": {
+        "hash": {
           "$ref": "#/$defs/_HashBuildOutputOptions"
         }
       },
       "required": [
-        "hash_"
+        "hash"
       ],
       "title": "HashBuildOutput",
       "type": "object"

--- a/examples/outputs/construct.yaml
+++ b/examples/outputs/construct.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=../../constructor/data/construct.schema.json
+"$schema": "../../constructor/data/construct.schema.json"
+
+name: Outputs
+version: X
+installer_type: sh  # [unix]
+installer_type: exe  # [win]
+channels:
+  - https://conda.anaconda.org/conda-forge
+specs:
+  - python=3.12
+  - conda # conda is required for extra_envs
+extra_envs:
+  py310:
+    specs:
+      - python=3.10
+  py311:
+    specs:
+      - python=3.11
+
+
+build_outputs:
+  - info.json
+  - pkgs_list
+  - pkgs_list:
+      env: py310
+  - lockfile
+  - lockfile:
+      env: py310
+  - licenses:
+      include_text: True
+      text_errors: replace
+  - hash:
+      algorithm:
+        - sha256
+        - md5
+initialize_by_default: false
+register_python: False

--- a/news/943-schema
+++ b/news/943-schema
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add JSON Schema for `construct.yml`, defined with a Pydantic model (not used at runtime). (#943)
+* Add JSON Schema for `construct.yml`, defined with a Pydantic model (not used at runtime). (#943, #979)
 
 ### Bug fixes
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1057,6 +1057,30 @@ def test_uninstallation_standalone(
             shutil.rmtree(system_rc.parent)
 
 
+def test_output_files(tmp_path):
+    input_path = _example_path("outputs")
+    for installer, _ in create_installer(input_path, tmp_path):
+        files_expected = [
+            f"{installer.name}.md5",
+            f"{installer.name}.sha256",
+            "info.json",
+            "licenses.json",
+            "pkg-list.base.txt",
+            "pkg-list.py310.txt",
+            "lockfile.base.txt",
+            "lockfile.py310.txt",
+        ]
+        files_not_expected = [
+            "pkg-list.py311.txt",
+            "lockfile.py311.txt",
+        ]
+        root_path = installer.parent
+        files_exist = [file for file in files_expected if (root_path / file).exists()]
+        assert sorted(files_exist) == sorted(files_expected)
+        files_exist = [file for file in files_not_expected if (root_path / file).exists()]
+        assert files_exist == []
+
+
 def test_regressions(tmp_path, request):
     input_path = _example_path("regressions")
     for installer, install_dir in create_installer(input_path, tmp_path):


### PR DESCRIPTION
### Description

The hash schema contained an incorrect key (`hash_` instead of `hash`), which is fixed in this PR. I also noticed that there are no tests to check that all outputs are generated (which would have caught this), so I added the test here.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?