### PR TITLE
Provide an option to ovewrite the existing directory by default on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 [//]: # (current developments)
 
 ## 2025-03-20   3.11.3:
-
 ### Bug fixes
 
 * Unset `CONDARC` and `MAMBARC` to prevent pre-existing configuration files from influencing the installation. (#962)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 [//]: # (current developments)
 
 ## 2025-03-20   3.11.3:
+
 ### Bug fixes
 
 * Unset `CONDARC` and `MAMBARC` to prevent pre-existing configuration files from influencing the installation. (#962)

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -239,6 +239,13 @@ Only affects `.sh` installers. If `False`, the installer launches
 an interactive wizard guiding the user through the available options. If
 `True`, the installer runs automatically as if `-b` was passed.
 
+### `force_by_default`
+
+Only affects `.sh` installers. If `True`, the installer will remove
+the existing installation without prompting the user. If `False`, the
+installer will stop if the installation path already exists. The user can
+override this option by passing `-f` to the installer.
+
 ### `signing_identity_name`
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -239,6 +239,14 @@ Only affects `.sh` installers. If `False`, the installer launches
 an interactive wizard guiding the user through the available options. If
 `True`, the installer runs automatically as if `-b` was passed.
 
+### `force_by_default`
+
+Only affects `.sh` installers. If `True`, the installer will remove the
+existing installation without prompting the user. If set, the user can
+disable this option with the `-e` option. If `False`, the installer will
+stop if the installation path already exists. The user can override this
+option by passing `-f` to the installer.
+
 ### `signing_identity_name`
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified

--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -239,13 +239,6 @@ Only affects `.sh` installers. If `False`, the installer launches
 an interactive wizard guiding the user through the available options. If
 `True`, the installer runs automatically as if `-b` was passed.
 
-### `force_by_default`
-
-Only affects `.sh` installers. If `True`, the installer will remove
-the existing installation without prompting the user. If `False`, the
-installer will stop if the installation path already exists. The user can
-override this option by passing `-f` to the installer.
-
 ### `signing_identity_name`
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified

--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -401,6 +401,14 @@ class ConstructorConfiguration(BaseModel):
     an interactive wizard guiding the user through the available options. If
     `True`, the installer runs automatically as if `-b` was passed.
     """
+    force_by_default: bool = False
+    """
+    Only affects `.sh` installers. If `True`, the installer will remove the
+    existing installation without prompting the user. If set, the user can
+    disable this option with the `-e` option. If `False`, the installer will
+    stop if the installation path already exists. The user can override this
+    option by passing `-f` to the installer.
+    """
     signing_identity_name: NonEmptyStr | None = None
     """
     By default, the MacOS pkg installer isn't signed. If an identity name is specified

--- a/constructor/data/construct.schema.json
+++ b/constructor/data/construct.schema.json
@@ -400,6 +400,12 @@
       "title": "Batch Mode",
       "type": "boolean"
     },
+    "force_by_default": {
+      "default": false,
+      "description": "Only affects `.sh` installers. If `True`, the installer will remove the existing installation without prompting the user. If set, the user can disable this option with the `-e` option. If `False`, the installer will stop if the installation path already exists. The user can override this option by passing `-f` to the installer.",
+      "title": "Force By Default",
+      "type": "boolean"
+    },
     "build_outputs": {
       "default": [],
       "description": "Additional artifacts to be produced after building the installer. It expects either a list of strings or single-key dictionaries.\nAllowed strings / keys: `hash`, `info.json`, `licenses`, `lockfile`, `pkgs_list`.",

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -87,7 +87,7 @@ THIS_FILE=$(basename "$0")
 THIS_PATH="$THIS_DIR/$THIS_FILE"
 PREFIX="{{ default_prefix }}"
 BATCH={{ 1 if batch_mode else 0 }}
-FORCE=0
+FORCE={{ 1 if force_by_default else 0 }}
 KEEP_PKGS={{ 1 if keep_pkgs else 0 }}
 SKIP_SCRIPTS=0
 {%- if enable_shortcuts == "true" %}
@@ -106,7 +106,11 @@ Installs ${INSTALLER_NAME} ${INSTALLER_VER}
 -b           run install in batch mode (without manual intervention),
              it is expected the license terms (if any) are agreed upon
 {%- endif %}
+{%- if force_by_default %}
 -f           no error if install prefix already exists
+{%- else %}
+-e           error if install prefix already exists
+{%- endif %}
 -h           print this help message and exit
 {%- if not keep_pkgs %}
 -k           do not clear the package cache after installation

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -110,6 +110,11 @@ def get_header(conda_exec, tarball, info):
     variables["min_glibc_version"] = min_glibc_version
 
     variables["script_env_variables"] = info.get("script_env_variables", {})
+    header_template = info.get("header_template", None)
+    if header_template is None:
+        template = read_header_template()
+    else:
+        header_template = str(header_template)
 
     return render_template(read_header_template(), **variables)
 

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -110,11 +110,6 @@ def get_header(conda_exec, tarball, info):
     variables["min_glibc_version"] = min_glibc_version
 
     variables["script_env_variables"] = info.get("script_env_variables", {})
-    header_template = info.get("header_template", None)
-    if header_template is None:
-        template = read_header_template()
-    else:
-        header_template = str(header_template)
 
     return render_template(read_header_template(), **variables)
 

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -63,6 +63,7 @@ def get_header(conda_exec, tarball, info):
     variables = ns_platform(info["_platform"])
     variables["keep_pkgs"] = bool(info.get("keep_pkgs", False))
     variables["batch_mode"] = bool(info.get("batch_mode", False))
+    variables["force_by_default"] = bool(info.get("force_by_default", False))
     variables["has_license"] = has_license
     if variables["batch_mode"] and has_license:
         raise Exception(

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -239,6 +239,14 @@ Only affects `.sh` installers. If `False`, the installer launches
 an interactive wizard guiding the user through the available options. If
 `True`, the installer runs automatically as if `-b` was passed.
 
+### `force_by_default`
+
+Only affects `.sh` installers. If `True`, the installer will remove the
+existing installation without prompting the user. If set, the user can
+disable this option with the `-e` option. If `False`, the installer will
+stop if the installation path already exists. The user can override this
+option by passing `-f` to the installer.
+
 ### `signing_identity_name`
 
 By default, the MacOS pkg installer isn't signed. If an identity name is specified

--- a/news/982-force
+++ b/news/982-force
@@ -1,0 +1,21 @@
+### Enhancements
+
+* shell based installers (Linux and macOS) now a configuration
+  option `force_by_default`, which will override existing
+  installations without prompting the user.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/982-force
+++ b/news/982-force
@@ -1,8 +1,6 @@
 ### Enhancements
 
-* shell based installers (Linux and macOS) now a configuration
-  option `force_by_default`, which will override existing
-  installations without prompting the user.
+* `SH` installers now accept the configuration option `force_by_default`, which will override existing   installations without prompting the user. (#982)
 
 ### Bug fixes
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -40,7 +40,7 @@ def run_shellcheck(script):
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="Only on MacOS")
-@pytest.mark.skipif(available_command("shellcheck") is False, reason="requires shellcheck")
+@pytest.mark.skipif(not available_command("shellcheck"), reason="requires shellcheck")
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])
 @pytest.mark.parametrize("check_path_spaces", [False, True])
 @pytest.mark.parametrize(
@@ -77,11 +77,12 @@ def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
     assert returncode == 0
 
 
-@pytest.mark.skipif(available_command("shellcheck") is False, reason="requires shellcheck")
+@pytest.mark.skipif(not available_command("shellcheck"), reason="requires shellcheck")
 @pytest.mark.parametrize("osx", [False, True])
 @pytest.mark.parametrize("direct_execute_post_install", [True])
 @pytest.mark.parametrize("direct_execute_pre_install", [True])
 @pytest.mark.parametrize("batch_mode", [True])
+@pytest.mark.parametrize("force_by_default", [True, False])
 @pytest.mark.parametrize("keep_pkgs", [True])
 @pytest.mark.parametrize("has_conda", [False, True])
 @pytest.mark.parametrize("has_license", [True])
@@ -105,6 +106,7 @@ def test_template_shellcheck(
     has_conda,
     keep_pkgs,
     batch_mode,
+    force_by_default,
     direct_execute_pre_install,
     direct_execute_post_install,
     check_path_spaces,
@@ -119,6 +121,7 @@ def test_template_shellcheck(
             "has_license": has_license,
             "osx": osx,
             "batch_mode": batch_mode,
+            "force_by_default": force_by_default,
             "keep_pkgs": keep_pkgs,
             "has_conda": has_conda,
             "x86": arch == "x86",


### PR DESCRIPTION
Provides an option for installers to be created with the `-f` option by default.

I would love to provide my users with the ability to do this.

We use constructor to "create a relocatable installer" and we don't expect our users to use for conda, but for the "remaining attached payload".

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
