### PR TITLE
Fix md5 checks for onedir conda-standalone

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -473,7 +473,7 @@ cd "$PREFIX"
 unset PYTHON_SYSCONFIGDATA_NAME _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
 # the first binary payload: the standalone conda executable
-printf "Unpacking bootstrapper ...\n"
+printf "Unpacking bootstrapper...\n"
 CONDA_EXEC="$PREFIX/_conda"
 extract_range "${boundary0}" "${boundary1}" > "$CONDA_EXEC"
 chmod +x "$CONDA_EXEC"

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -89,7 +89,7 @@ def get_header(conda_exec, tarball, info):
     variables["installer_name"] = name
     variables["installer_version"] = info["version"]
     variables["installer_platform"] = info["_platform"]
-    variables["installer_md5"] = hash_files([conda_exec, tarball])
+    variables["installer_md5"] = hash_files([conda_exec, *info["_internal_conda_files"], tarball])
     variables["default_prefix"] = info.get("default_prefix", "${HOME:-/opt}/%s" % name.lower())
     variables["first_payload_size"] = getsize(conda_exec)
     variables["second_payload_size"] = getsize(tarball)
@@ -196,13 +196,13 @@ def create(info, verbose=False):
         t.add(join(info["_download_dir"], fn), "pkgs/" + fn)
     t.close()
 
-    internal_conda_files = copy_conda_exe(tmp_dir, "_conda", info["_conda_exe"])
-    if internal_conda_files:
+    info["_internal_conda_files"] = copy_conda_exe(tmp_dir, "_conda", info["_conda_exe"])
+    if info["_internal_conda_files"]:
         conda_exe_payloads: dict[str, tuple[int, int, bool]] = {}
         memfile = BytesIO()
         start = 0
         end = 0
-        for path in internal_conda_files:
+        for path in info["_internal_conda_files"]:
             relative_path = str(path.relative_to(tmp_dir))
             memfile.write(path.read_bytes())
             size = os.path.getsize(path)

--- a/news/993-onedir
+++ b/news/993-onedir
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add compatibility for `onedir` variants of `conda-standalone`, which are pre-extracted and have smaller start overheads. (#993)
+* Add compatibility for `onedir` variants of `conda-standalone`, which are pre-extracted and have smaller start overheads. (#993, #1007)
 
 ### Bug fixes
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -234,7 +234,9 @@ def _run_installer_sh(
         if CONSTRUCTOR_DEBUG:
             cmd.append("-x")
         cmd += [installer, "-b", *options, "-p", install_dir]
-    return _execute(cmd, installer_input=installer_input, timeout=timeout, check=check)
+    process = _execute(cmd, installer_input=installer_input, timeout=timeout, check=check)
+    if "WARNING: md5sum mismatch of tar archive" in process.stdout + process.stderr:
+        raise AssertionError("MD5 mismatch in SH payload!")
 
 
 def _run_installer_pkg(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -237,6 +237,7 @@ def _run_installer_sh(
     process = _execute(cmd, installer_input=installer_input, timeout=timeout, check=check)
     if "WARNING: md5sum mismatch of tar archive" in process.stdout + process.stderr:
         raise AssertionError("MD5 mismatch in SH payload!")
+    return process
 
 
 def _run_installer_pkg(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Noticed this warning while debugging other PR locally:

```
PREFIX=/Users/jrodriguez/condabin
WARNING: md5sum mismatch of tar archive
expected: be440733d74e4252c543459b65442660
     got: ecdfe394654062976a7fcc9a70f589eb
Unpacking bootstrapper...
Unpacking payload...
```

I forgot to hash the extra `_internal/` files in #993.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
