### PR TITLE
Use the latest `conda` for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           activate-environment: constructor-dev
+          auto-update-conda: true
           environment-file: dev/environment.yml
           python-version: ${{ matrix.python-version }}
       - name: Install AzureSignTool

--- a/news/1011-auto-update-conda
+++ b/news/1011-auto-update-conda
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Always use the latest `conda` version for tests. (#1011)


### PR DESCRIPTION
### Description

CI runs, particularly on Windows, have been unstable, and often fail to install `conda-standalone` because of a 400 HTTP status code. It is possible that this is due to a problem in `conda-anaconda-telemetry`: https://github.com/anaconda/conda-anaconda-telemetry/issues/127

A new version has been released and hotfixed (https://github.com/AnacondaRecipes/repodata-hotfixes/pull/257), but Miniconda does not carry that version, yet.

Auto-update `conda` to install the new version. Using the latest `conda` allows including such hotfixes in the future and can be a good canary for issues with new `conda` versions.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?