### PR TITLE
Add examples to test source files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
 test:
   source_files:
-    - examples
+    - examples/miniforge
     - tests
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
 
 test:
   source_files:
+    - examples
     - tests
   requires:
     - pip


### PR DESCRIPTION
### Description

Canary builds are failing because the examples are missing in the source files for tests.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?