### PR TITLE
Set NSIS_USING_BUILD_LOG to 1 in recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - pydantic >=2
 
 test:
+  script_env:                  # [win]
+    - NSIS_USING_BUILD_LOG: 1  # [win]
   source_files:
     - examples/miniforge
     - examples/miniforge-mamba2


### PR DESCRIPTION
### Description

Canary builds on Windows are failing because the environment variable for creating logs is not set.