### PR TITLE
Force log build for NSIS in test requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,10 @@ test:
     - examples/miniforge-mamba2
     - tests
   requires:
+    - nsis =*=*log*  # [win]
     - pip
     - pytest
-    - pywin32  # [win]
+    - pywin32        # [win]
   imports:
     - constructor
   commands:


### PR DESCRIPTION
### Description

Force the log build for NSIS to be installed into the test environment.