### PR TITLE
Fix typo in NSIS log environment variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
 test:
   script_env:                  # [win]
-    - NSIS_USING_BUILD_LOG: 1  # [win]
+    - NSIS_USING_LOG_BUILD: 1  # [win]
   source_files:
     - examples/miniforge
     - examples/miniforge-mamba2


### PR DESCRIPTION
### Description

The name of the variable is `NSIS_USING_LOG_BUILD`, not `NSIS_USING_BUILD_LOG`.
