### PR TITLE
Check path length

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -549,7 +549,7 @@ Only applies if `register_python` is true.
 
 Check the length of the path where the distribution is installed to ensure nodejs
 can be installed.  Raise a message to request shorter paths (less than 46 character)
-or enable long paths on windows > 10 (require admin right). Default is True. (Windows only).
+or enable long paths on windows > 10 (require admin right). Default is False. (Windows only).
 
 ### `check_path_spaces`
 

--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -712,11 +712,11 @@ class ConstructorConfiguration(BaseModel):
 
     Only applies if `register_python` is true.
     """
-    check_path_length: bool | None = None
+    check_path_length: bool = False
     """
     Check the length of the path where the distribution is installed to ensure nodejs
     can be installed.  Raise a message to request shorter paths (less than 46 character)
-    or enable long paths on windows > 10 (require admin right). Default is True. (Windows only).
+    or enable long paths on windows > 10 (require admin right). Default is False. (Windows only).
     """
     check_path_spaces: bool = True
     """

--- a/constructor/data/construct.schema.json
+++ b/constructor/data/construct.schema.json
@@ -456,17 +456,10 @@
       "type": "array"
     },
     "check_path_length": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Check the length of the path where the distribution is installed to ensure nodejs can be installed. Raise a message to request shorter paths (less than 46 character) or enable long paths on windows > 10 (require admin right). Default is True. (Windows only).",
-      "title": "Check Path Length"
+      "default": false,
+      "description": "Check the length of the path where the distribution is installed to ensure nodejs can be installed. Raise a message to request shorter paths (less than 46 character) or enable long paths on windows > 10 (require admin right). Default is False. (Windows only).",
+      "title": "Check Path Length",
+      "type": "boolean"
     },
     "check_path_spaces": {
       "default": true,

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -233,7 +233,7 @@ def make_nsi(
     variables["initialize_by_default"] = info.get("initialize_by_default", None)
     variables["register_python"] = info.get("register_python", True)
     variables["register_python_default"] = info.get("register_python_default", None)
-    variables["check_path_length"] = info.get("check_path_length", None)
+    variables["check_path_length"] = info.get("check_path_length", False)
     variables["check_path_spaces"] = info.get("check_path_spaces", True)
     variables["keep_pkgs"] = info.get("keep_pkgs") or False
     variables["pre_install_exists"] = bool(info.get("pre_install"))

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -549,7 +549,7 @@ Only applies if `register_python` is true.
 
 Check the length of the path where the distribution is installed to ensure nodejs
 can be installed.  Raise a message to request shorter paths (less than 46 character)
-or enable long paths on windows > 10 (require admin right). Default is True. (Windows only).
+or enable long paths on windows > 10 (require admin right). Default is False. (Windows only).
 
 ### `check_path_spaces`
 

--- a/news/1036-check-path-length-docs
+++ b/news/1036-check-path-length-docs
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document that `check_path_length` defaults to `False` in line with prior behavior and declare
+  it as `bool` only in the schema. (#1036)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

The documentation states that `check_path_length` defaults to `True`. The code, however, indicates that the default value is `None` and has been `None` for a long time. So, the default behavior is `False`.

Correct the error in the documentation. Additionally, limit the type to `bool` since there is no special behavior for `None`.

Xref: #1022

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?