### PR TITLE
Fix misleading conda init prompt wording

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -739,7 +739,9 @@ if [ "$BATCH" = "0" ]; then
 
     printf "Do you wish to update your shell profile to add '%s/condabin' to PATH?\\n" "$PREFIX"
     printf "This will enable you to run 'conda' anywhere, without injecting a shell function.\\n"
-    printf "You can undo this by running \`conda init --condabin --reverse? [yes|no]\\n"
+    printf "You can undo this by running \`conda init --condabin --reverse\`\\n"
+    printf "\\n"
+    printf "Do you wish to update your shell profile? [yes|no]\\n"
     printf "[%s] >>> " "$DEFAULT"
     read -r ans
     if [ "$ans" = "" ]; then
@@ -764,8 +766,10 @@ if [ "$BATCH" = "0" ]; then
     printf "\\n"
     printf "conda config --set auto_activate_base false\\n"
     printf "\\n"
-    printf "You can undo this by running \`conda init --reverse \$SHELL\`? [yes|no]\\n"
-    printf "[%s] >>> " "$DEFAULT"
+    printf "Note: You can undo this later by running \`conda init --reverse \$SHELL\`\\n"
+    printf "\\n"
+    printf "Proceed with initialization? [yes|no]\\n"
+    printf "[%s] >>> " "$DEFAULT"„
     read -r ans
     if [ "$ans" = "" ]; then
         ans=$DEFAULT

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -739,9 +739,9 @@ if [ "$BATCH" = "0" ]; then
 
     printf "Do you wish to update your shell profile to add '%s/condabin' to PATH?\\n" "$PREFIX"
     printf "This will enable you to run 'conda' anywhere, without injecting a shell function.\\n"
-    printf "You can undo this by running \`conda init --condabin --reverse\`\\n"
+    printf "Note: You can undo this by running \`conda init --condabin --reverse\`\\n"
     printf "\\n"
-    printf "Do you wish to update your shell profile? [yes|no]\\n"
+    printf "Proceed with initialization? [yes|no]\\n"
     printf "[%s] >>> " "$DEFAULT"
     read -r ans
     if [ "$ans" = "" ]; then

--- a/news/1040-misleading-conda-init-prompt
+++ b/news/1040-misleading-conda-init-prompt
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fixed misleading wording for shell initialization in installation prompt.
+* SH: Fixed misleading wording for shell initialization in installation prompt. (#1039 via #1340)
 
 ### Deprecations
 

--- a/news/1040-misleading-conda-init-prompt
+++ b/news/1040-misleading-conda-init-prompt
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed misleading wording for shell initialization in installation prompt.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

This PR fixes the confusing installer prompt shown after conda installation.  
[Misleading wording on install: conda init yes/no appears tied to both initialization and reverse command #1039](https://github.com/conda/constructor/issues/1039) 
Previously, the prompt wording made it appear as though there were two separate yes/no choices:  

1. whether to initialize conda automatically, and  
2. whether to run the reverse command.  

In reality, only the first is a choice, while the `conda init --reverse $SHELL` text is meant as an informational note about undoing the change later.  
The new wording separates these two parts clearly.  

### Checklist - did you ...

- ~~[ ] Add a file to the `news` directory ([using the template]~~(https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~~[ ] Add / update necessary tests?~~
- ~~[ ] Add / update outdated documentation?~~
