### PR TITLE
Convert script and directory `_nsis.py` subcommands into NSIS code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,6 @@ jobs:
             && files+=(--file "tests/extra-requirements-${{ runner.os }}.txt")
           conda install ${files[@]} -y
           echo "NSIS_USING_LOG_BUILD=1" >> $GITHUB_ENV
-          echo "NSIS_SCRIPTS_RAISE_ERRORS=1" >> $GITHUB_ENV
           pip install -e . --no-deps --no-build-isolation
       - name: Set up conda executable
         run: |

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -215,44 +215,6 @@ def run_post_install():
             sys.exit(1)
 
 
-def run_pre_uninstall():
-    """
-    call the pre uninstall script, if the file exists
-    """
-    path = join(ROOT_PREFIX, 'pre_uninstall.bat')
-    if not isfile(path):
-        return
-    env = os.environ.copy()
-    env.setdefault('PREFIX', str(ROOT_PREFIX))
-    cmd_exe = os.path.join(os.environ['SystemRoot'], 'System32', 'cmd.exe')
-    if not os.path.isfile(cmd_exe):
-        cmd_exe = os.path.join(os.environ['windir'], 'System32', 'cmd.exe')
-    if not os.path.isfile(cmd_exe):
-        err("Error: running %s failed.  cmd.exe could not be found.  "
-            "Looked in SystemRoot and windir env vars.\n" % path)
-        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
-            sys.exit(1)
-    args = [cmd_exe, '/d', '/c', path]
-    import subprocess
-    try:
-        subprocess.check_call(args, env=env)
-    except subprocess.CalledProcessError:
-        err("Error: running %s failed\n" % path)
-        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
-            sys.exit(1)
-
-
-allusers = (not exists(join(ROOT_PREFIX, '.nonadmin')))
-# out('allusers is %s\n' % allusers)
-
-# This must be the same as conda's binpath_from_arg() in conda/cli/activate.py
-PATH_SUFFIXES = ('',
-                 os.path.join('Library', 'mingw-w64', 'bin'),
-                 os.path.join('Library', 'usr', 'bin'),
-                 os.path.join('Library', 'bin'),
-                 'Scripts')
-
-
 def remove_from_path(root_prefix=None):
     from _system_path import broadcast_environment_settings_change, remove_from_system_path
 
@@ -391,8 +353,6 @@ def main():
         add_condabin_to_path()
     elif cmd == 'rmpath':
         remove_from_path()
-    elif cmd == 'pre_uninstall':
-        run_pre_uninstall()
     elif cmd == 'del':
         assert len(sys.argv) == 3
         win_del(sys.argv[2].strip())

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -188,6 +188,17 @@ def rm_menus(prefix=None, root_prefix=None):
                     mk_menus(remove=True, prefix=env, root_prefix=root_prefix)
 
 
+allusers = (not exists(join(ROOT_PREFIX, '.nonadmin')))
+# out('allusers is %s\n' % allusers)
+
+# This must be the same as conda's binpath_from_arg() in conda/cli/activate.py
+PATH_SUFFIXES = ('',
+                 os.path.join('Library', 'mingw-w64', 'bin'),
+                 os.path.join('Library', 'usr', 'bin'),
+                 os.path.join('Library', 'bin'),
+                 'Scripts')
+
+
 def remove_from_path(root_prefix=None):
     from _system_path import broadcast_environment_settings_change, remove_from_system_path
 

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -188,33 +188,6 @@ def rm_menus(prefix=None, root_prefix=None):
                     mk_menus(remove=True, prefix=env, root_prefix=root_prefix)
 
 
-def run_post_install():
-    """
-    call the post install script, if the file exists
-    """
-    path = join(ROOT_PREFIX, 'pkgs', 'post_install.bat')
-    if not isfile(path):
-        return
-    env = os.environ.copy()
-    env.setdefault('PREFIX', str(ROOT_PREFIX))
-    cmd_exe = os.path.join(os.environ['SystemRoot'], 'System32', 'cmd.exe')
-    if not os.path.isfile(cmd_exe):
-        cmd_exe = os.path.join(os.environ['windir'], 'System32', 'cmd.exe')
-    if not os.path.isfile(cmd_exe):
-        err("Error: running %s failed.  cmd.exe could not be found.  "
-            "Looked in SystemRoot and windir env vars.\n" % path)
-        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
-            sys.exit(1)
-    args = [cmd_exe, '/d', '/c', path]
-    import subprocess
-    try:
-        subprocess.check_call(args, env=env)
-    except subprocess.CalledProcessError:
-        err("Error: running %s failed\n" % path)
-        if os.environ.get("NSIS_SCRIPTS_RAISE_ERRORS"):
-            sys.exit(1)
-
-
 def remove_from_path(root_prefix=None):
     from _system_path import broadcast_environment_settings_change, remove_from_system_path
 
@@ -329,8 +302,6 @@ def main():
     if cmd == 'mkmenus':
         pkg_names = [s.strip() for s in sys.argv[2:]]
         mk_menus(remove=False, pkg_names=pkg_names)
-    elif cmd == 'post_install':
-        run_post_install()
     elif cmd == 'rmmenus':
         rm_menus()
     elif cmd == 'rmreg':

--- a/constructor/nsis/_nsis.py
+++ b/constructor/nsis/_nsis.py
@@ -140,12 +140,6 @@ def mk_menus(remove=False, prefix=None, pkg_names=None, root_prefix=None):
             out("Processed %s successfully.\n" % shortcut)
 
 
-def mk_dirs():
-    envs_dir = join(ROOT_PREFIX, 'envs')
-    if not exists(envs_dir):
-        os.mkdir(envs_dir)
-
-
 def get_conda_envs_from_python_api():
     try:
         from conda.cli.python_api import Commands, run_command
@@ -379,8 +373,6 @@ def main():
         rm_menus()
     elif cmd == 'rmreg':
         rm_regkeys()
-    elif cmd == 'mkdirs':
-        mk_dirs()
     elif cmd == 'addpath':
         # These checks are probably overkill, but could be useful
         # if I forget to update something that uses this code.

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1414,11 +1414,10 @@ Section "Install"
     AddSize {{ SIZE }}
 
 {%- if has_conda %}
-    ${Print} "Initializing conda directories..."
-    push '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" mkdirs'
-    push 'Failed to initialize conda directories'
-    push 'WithLog'
-    call AbortRetryNSExecWait
+    StrCpy $R0 "$INSTDIR\envs"
+    ${IfNot} ${FileExists} "$R0"
+        CreateDirectory "$R0"
+    ${EndIf}
 {%- endif %}
 
     ${If} $Ana_PostInstall_State = ${BST_CHECKED}

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1617,7 +1617,6 @@ Section "Uninstall"
         call un.AbortRetryNSExecWait
     ${EndIf}
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
-    !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
 
     # Parse arguments
     StrCpy $R0 ""

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1600,7 +1600,12 @@ Section "Uninstall"
     ${EndIf}
 
 {%- if uninstall_with_conda_exe %}
-    !insertmacro AbortRetryNSExecWaitLibNsisCmd "pre_uninstall"
+    ${If} ${FilExists} "$INSTDIR\pkgs\pre_uninstall.bat"
+        ${Print} "Running pre_uninstall scripts..."
+        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
+        push "Failed to run pre_uninstall"
+        push 'WithLog'
+    ${EndIf}
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
 
@@ -1650,7 +1655,12 @@ Section "Uninstall"
     call un.AbortRetryNSExecWait
     SetDetailsPrint both
 {%- endfor %}
-    !insertmacro AbortRetryNSExecWaitLibNsisCmd "pre_uninstall"
+    ${If} ${FilExists} "$INSTDIR\pkgs\pre_uninstall.bat"
+        ${Print} "Running pre_uninstall scripts..."
+        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
+        push "Failed to run pre_uninstall"
+        push 'WithLog'
+    ${EndIf}
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -132,6 +132,19 @@ var /global InstMode # 0 = Just Me, 1 = All Users.
 !define JUST_ME 0
 !define ALL_USERS 1
 
+# Find cmd.exe
+var /global CMD_EXE
+ReadEnvStr $R0 SystemRoot
+ReadEnvStr $R1 windir
+${If} ${FileExists} "$R0"
+    StrCpy $CMD_EXE "$R0\System32\cmd.exe"
+${ElseIf} ${FileExists} "$R1"
+    StrCpy $CMD_EXE "$R1\System32\cmd.exe"
+${Else}
+    # Cross our fingers CMD is in PATH
+    StrCpy $CMD_EXE "cmd.exe"
+${EndIf}
+
 # Include this one after our defines
 !include "OptionsDialog.nsh"
 
@@ -1352,17 +1365,7 @@ Section "Install"
 
     IfFileExists "$INSTDIR\pkgs\pre_install.bat" 0 NoPreInstall
         ${Print} "Running pre_install scripts..."
-        ReadEnvStr $5 SystemRoot
-        ReadEnvStr $6 windir
-        # This 'FileExists' also returns True for directories
-        ${If} ${FileExists} "$5"
-            push '"$5\System32\cmd.exe" /D /C "$INSTDIR\pkgs\pre_install.bat"'
-        ${ElseIf} ${FileExists} "$6"
-            push '"$6\System32\cmd.exe" /D /C "$INSTDIR\pkgs\pre_install.bat"'
-        ${Else}
-            # Cross our fingers CMD is in PATH
-            push 'cmd.exe /D /C "$INSTDIR\pkgs\pre_install.bat"'
-        ${EndIf}
+        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_install.bat"'
         push "Failed to run pre_install"
         push 'WithLog'
         call AbortRetryNSExecWait

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -132,18 +132,21 @@ var /global InstMode # 0 = Just Me, 1 = All Users.
 !define JUST_ME 0
 !define ALL_USERS 1
 
-# Find cmd.exe
 var /global CMD_EXE
-ReadEnvStr $R0 SystemRoot
-ReadEnvStr $R1 windir
-${If} ${FileExists} "$R0"
-    StrCpy $CMD_EXE "$R0\System32\cmd.exe"
-${ElseIf} ${FileExists} "$R1"
-    StrCpy $CMD_EXE "$R1\System32\cmd.exe"
-${Else}
-    # Cross our fingers CMD is in PATH
-    StrCpy $CMD_EXE "cmd.exe"
-${EndIf}
+
+!macro FindCmdExe
+    # Find cmd.exe
+    ReadEnvStr $R0 SystemRoot
+    ReadEnvStr $R1 windir
+    ${If} ${FileExists} "$R0"
+        StrCpy $CMD_EXE "$R0\System32\cmd.exe"
+    ${ElseIf} ${FileExists} "$R1"
+        StrCpy $CMD_EXE "$R1\System32\cmd.exe"
+    ${Else}
+        # Cross our fingers CMD is in PATH
+        StrCpy $CMD_EXE "cmd.exe"
+    ${EndIf}
+!macroend
 
 # Include this one after our defines
 !include "OptionsDialog.nsh"
@@ -1239,6 +1242,8 @@ Section "Install"
         call OnDirectoryLeave
     ${EndIf}
 
+    !insertmacro FindCmdExe
+
     SetOutPath "$INSTDIR\Lib"
     File "{{ NSIS_DIR }}\_nsis.py"
     File "{{ NSIS_DIR }}\_system_path.py"
@@ -1365,7 +1370,7 @@ Section "Install"
 
     IfFileExists "$INSTDIR\pkgs\pre_install.bat" 0 NoPreInstall
         ${Print} "Running pre_install scripts..."
-        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_install.bat"'
+        push '$CMD_EXE /D /C "$INSTDIR\pkgs\pre_install.bat"'
         push "Failed to run pre_install"
         push 'WithLog'
         call AbortRetryNSExecWait
@@ -1426,7 +1431,7 @@ Section "Install"
     ${If} ${FileExists} "$INSTDIR\pkgs\post_install.bat"
         ${If} $Ana_PostInstall_State = ${BST_CHECKED}
             ${Print} "Running post install..."
-            push '${CMD_EXE} /D /C "$INSTDIR\pkgs\post_install.bat"'
+            push '$CMD_EXE /D /C "$INSTDIR\pkgs\post_install.bat"'
             push "Failed to run post_install"
             push 'WithLog'
             call AbortRetryNSExecWait
@@ -1547,6 +1552,8 @@ Section "Uninstall"
         !insertmacro un.ParseCommandLineArgs
     ${EndIf}
 
+    !insertmacro FindCmdExe
+
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_ROOT_PREFIX", "$INSTDIR")".r0'
 
     # ensure that MSVC runtime DLLs are on PATH during uninstallation
@@ -1602,9 +1609,9 @@ Section "Uninstall"
     ${EndIf}
 
 {%- if uninstall_with_conda_exe %}
-    ${If} ${FilExists} "$INSTDIR\pkgs\pre_uninstall.bat"
+    ${If} ${FileExists} "$INSTDIR\pkgs\pre_uninstall.bat"
         ${Print} "Running pre_uninstall scripts..."
-        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
+        push '$CMD_EXE /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
         push "Failed to run pre_uninstall"
         push 'WithLog'
         call un.AbortRetryNSExecWait
@@ -1658,9 +1665,9 @@ Section "Uninstall"
     call un.AbortRetryNSExecWait
     SetDetailsPrint both
 {%- endfor %}
-    ${If} ${FilExists} "$INSTDIR\pkgs\pre_uninstall.bat"
+    ${If} ${FileExists} "$INSTDIR\pkgs\pre_uninstall.bat"
         ${Print} "Running pre_uninstall scripts..."
-        push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
+        push '$CMD_EXE /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
         push "Failed to run pre_uninstall"
         push 'WithLog'
         call un.AbortRetryNSExecWait

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1423,12 +1423,14 @@ Section "Install"
     ${EndIf}
 {%- endif %}
 
-    ${If} $Ana_PostInstall_State = ${BST_CHECKED}
-        ${Print} "Running post install..."
-        push '"$INSTDIR\pythonw.exe" -E -s "$INSTDIR\Lib\_nsis.py" post_install'
-        push 'Failed to run post install script'
-        push 'WithLog'
-        call AbortRetryNSExecWait
+    ${If} ${FileExists} "$INSTDIR\pkgs\post_install.bat"
+        ${If} $Ana_PostInstall_State = ${BST_CHECKED}
+            ${Print} "Running post install..."
+            push '${CMD_EXE} /D /C "$INSTDIR\pkgs\post_install.bat"'
+            push "Failed to run post_install"
+            push 'WithLog'
+            call AbortRetryNSExecWait
+        ${EndIf}
     ${EndIf}
 
     ${If} $Ana_ClearPkgCache_State = ${BST_CHECKED}
@@ -1605,6 +1607,7 @@ Section "Uninstall"
         push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
         push "Failed to run pre_uninstall"
         push 'WithLog'
+        call un.AbortRetryNSExecWait
     ${EndIf}
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
@@ -1660,6 +1663,7 @@ Section "Uninstall"
         push '${CMD_EXE} /D /C "$INSTDIR\pkgs\pre_uninstall.bat"'
         push "Failed to run pre_uninstall"
         push 'WithLog'
+        call un.AbortRetryNSExecWait
     ${EndIf}
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmpath"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"

--- a/news/1069-port-nsispy-cmds-nsis
+++ b/news/1069-port-nsispy-cmds-nsis
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Port script execution and directory creation functions from `_nsis.py` to NSIS. (#1069)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -118,10 +118,6 @@ def run_examples(keep_artifacts=None, conda_exe=None, debug=False):
             if os.path.exists(os.path.join(fpath, "construct.yaml")):
                 example_paths.append(fpath)
 
-    # NSIS won't error out when running scripts unless
-    # we set this custom environment variable
-    os.environ["NSIS_SCRIPTS_RAISE_ERRORS"] = "1"
-
     parent_output = tempfile.mkdtemp()
     tested_files = set()
     which_errored = {}


### PR DESCRIPTION
### Description

Convert simple script and directory subcommands into NSIS code to further decouple the python dependency from EXE installers (#549). Scripts are already executed directly via `cmd.exe` for pre-install scripts and `mkdirs` is a simple directory creation command.

Note that this means that `post-install` and `pre-uninstall` script failures will cause the installation/uninstallation process to fail now. I think this is good behavior as it has masked issues in the past (see https://github.com/conda/constructor/pull/942 and https://github.com/conda/constructor/issues/1020).

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?