### PR TITLE
Use `windows-2022` for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,17 +66,17 @@ jobs:
             python-version: "3.12"
             conda-standalone: micromamba
           # WINDOWS
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.9"
             conda-standalone: conda-standalone-nightly
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.10"
             conda-standalone: conda-standalone
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.11"
             # conda-standalone: micromamba
             conda-standalone: conda-standalone-nightly
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.12"
             # conda-standalone: micromamba
             conda-standalone: conda-standalone-onedir
@@ -213,7 +213,7 @@ jobs:
             subdir: osx-64
           - runner: macos-latest
             subdir: osx-arm64
-          - runner: windows-latest
+          - runner: windows-2022
             subdir: win-64
     runs-on: ${{ matrix.runner }}
     steps:

--- a/news/1077-use-windows-2022
+++ b/news/1077-use-windows-2022
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Use `windows-2022` for integration tests. (#1077)


### PR DESCRIPTION
### Description

Ever since the migration of `windows-latest` from `windows-2022` to `windows-2025`, tests have been timing out. Pin the runner versions to `windows-2022` to unblock PRs.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?