### PR TITLE
SH: Move OS checks before architecture checks

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -213,6 +213,38 @@ fi
 
 if [ "$BATCH" = "0" ] # interactive mode
 then
+{%- if osx %}
+    if [ "$(uname)" != "Darwin" ]; then
+        printf "WARNING:\\n"
+        printf "    Your operating system does not appear to be macOS, \\n"
+        printf "    but you are trying to install a macOS version of %s.\\n" "${INSTALLER_NAME}"
+        printf "    Are sure you want to continue the installation? [yes|no]\\n"
+        printf "[no] >>> "
+        read -r ans
+        ans=$(echo "${ans}" | tr '[:lower:]' '[:upper:]')
+        if [ "$ans" != "YES" ] && [ "$ans" != "Y" ]
+        then
+            printf "Aborting installation\\n"
+            exit 2
+        fi
+    fi
+{%- elif linux %}
+    if [ "$(uname)" != "Linux" ]; then
+        printf "WARNING:\\n"
+        printf "    Your operating system does not appear to be Linux, \\n"
+        printf "    but you are trying to install a Linux version of %s.\\n" "${INSTALLER_NAME}"
+        printf "    Are sure you want to continue the installation? [yes|no]\\n"
+        printf "[no] >>> "
+        read -r ans
+        ans=$(echo "${ans}" | tr '[:lower:]' '[:upper:]')
+        if [ "$ans" != "YES" ] && [ "$ans" != "Y" ]
+        then
+            printf "Aborting installation\\n"
+            exit 2
+        fi
+    fi
+{%- endif %}
+
 {%- if x86 and not x86_64 %}
     if [ "$(uname -m)" = "x86_64" ]; then
         printf "WARNING:\\n"
@@ -296,38 +328,6 @@ then
         printf "WARNING:\\n"
         printf "    Your machine hardware does not appear to be aarch64, \\n"
         printf "    but you are trying to install an aarch64 version of %s.\\n" "${INSTALLER_NAME}"
-        printf "    Are sure you want to continue the installation? [yes|no]\\n"
-        printf "[no] >>> "
-        read -r ans
-        ans=$(echo "${ans}" | tr '[:lower:]' '[:upper:]')
-        if [ "$ans" != "YES" ] && [ "$ans" != "Y" ]
-        then
-            printf "Aborting installation\\n"
-            exit 2
-        fi
-    fi
-{%- endif %}
-
-{%- if osx %}
-    if [ "$(uname)" != "Darwin" ]; then
-        printf "WARNING:\\n"
-        printf "    Your operating system does not appear to be macOS, \\n"
-        printf "    but you are trying to install a macOS version of %s.\\n" "${INSTALLER_NAME}"
-        printf "    Are sure you want to continue the installation? [yes|no]\\n"
-        printf "[no] >>> "
-        read -r ans
-        ans=$(echo "${ans}" | tr '[:lower:]' '[:upper:]')
-        if [ "$ans" != "YES" ] && [ "$ans" != "Y" ]
-        then
-            printf "Aborting installation\\n"
-            exit 2
-        fi
-    fi
-{%- elif linux %}
-    if [ "$(uname)" != "Linux" ]; then
-        printf "WARNING:\\n"
-        printf "    Your operating system does not appear to be Linux, \\n"
-        printf "    but you are trying to install a Linux version of %s.\\n" "${INSTALLER_NAME}"
         printf "    Are sure you want to continue the installation? [yes|no]\\n"
         printf "[no] >>> "
         read -r ans

--- a/news/1153-macos-architecture-checks
+++ b/news/1153-macos-architecture-checks
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add architecture checks to macOS SH and PKG installers. (#1153)
+* Add architecture checks to macOS SH and PKG installers. (#1153, #1165)
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

In SH installers, architecture checks are currently run before OS checks. When running a `linux-64` installer on `osx-arm64`, users would first get the message that the installer has the wrong architecture instead of being on the wrong operating system.

I think it makes more sense to check for the operating system first than going through the architectures.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?