### PR TITLE
MSI: Fix issue with wrong directory being add to PATH

### DIFF
--- a/constructor/briefcase/pre_uninstall.bat
+++ b/constructor/briefcase/pre_uninstall.bat
@@ -98,7 +98,7 @@ rem Remove PATH entries only for user-scoped installs (mirrors NSIS .nonadmin ch
 {%- set pathflag = "--condabin" if initialize_conda == "condabin" else "--classic" %}
 if exist "%BASE_PATH%\.nonadmin" (
     {{ tee("Removing from PATH...") }}
-    "%CONDA_EXE%" constructor windows path --remove=user --prefix "%INSTDIR%" {{ pathflag }} --log-file "%LOG%"
+    "%CONDA_EXE%" constructor windows path --remove=user --prefix "%BASE_PATH%" {{ pathflag }} --log-file "%LOG%"
     if errorlevel 1 ( exit /b %errorlevel% )
 )
 

--- a/constructor/briefcase/run_installation.bat
+++ b/constructor/briefcase/run_installation.bat
@@ -154,7 +154,7 @@ rem Add to PATH / run conda init if the option was selected
 {%- set pathflag = "--condabin" if initialize_conda == "condabin" else "--classic" %}
 if "%OPTION_INITIALIZE_CONDA%"=="1" (
     {{ tee("Adding to PATH...") }}
-    "%CONDA_EXE%" constructor windows path --prepend=user --prefix "%INSTDIR%" {{ pathflag }} --log-file "%LOG%"
+    "%CONDA_EXE%" constructor windows path --prepend=user --prefix "%BASE_PATH%" {{ pathflag }} --log-file "%LOG%"
     if errorlevel 1 ( exit /b %errorlevel% )
 )
 

--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -391,6 +391,30 @@ def test_render_templates_registry_uses_base_path():
     assert "%INSTDIR%\\Doc\\" not in text
 
 
+def test_render_templates_path_commands_use_base_path():
+    """Verify that the 'constructor windows path' commands use BASE_PATH
+    (INSTDIR\\base) and not INSTDIR directly, since the conda environment
+    lives in BASE_PATH in the MSI layout."""
+    info = mock_info.copy()
+    info["initialize_conda"] = "classic"
+    payload = Payload(info)
+    rendered_templates = payload.render_templates()
+
+    # Check run_installation.bat uses BASE_PATH for adding to PATH
+    run_installation = next(f for f in rendered_templates if f.name == "run_installation.bat")
+    run_text = run_installation.read_text(encoding="utf-8")
+
+    assert 'constructor windows path --prepend=user --prefix "%BASE_PATH%"' in run_text
+    assert 'constructor windows path --prepend=user --prefix "%INSTDIR%"' not in run_text
+
+    # Check pre_uninstall.bat uses BASE_PATH for removing from PATH
+    pre_uninstall = next(f for f in rendered_templates if f.name == "pre_uninstall.bat")
+    pre_text = pre_uninstall.read_text(encoding="utf-8")
+
+    assert 'constructor windows path --remove=user --prefix "%BASE_PATH%"' in pre_text
+    assert 'constructor windows path --remove=user --prefix "%INSTDIR%"' not in pre_text
+
+
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 def test_render_templates_nonadmin_created_for_user_install():
     """Verify that run_installation.bat creates a .nonadmin marker file


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Some testing revealed that we pass `INSTDIR` instead of `BASE_PATH` to `conda-standalone` resulting in the wrong directories being added to path.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
