### PR TITLE
Add environment variables to pre-uninstall script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,43 +39,43 @@ jobs:
       matrix:
         include:
           # UBUNTU
-          # - os: ubuntu-latest
-          #   python-version: "3.10"
-          #   conda-standalone: conda-standalone
-          # - os: ubuntu-latest
-          #   python-version: "3.11"
-          #   conda-standalone: conda-standalone-nightly
-          # - os: ubuntu-latest
-          #   python-version: "3.12"
-          #   conda-standalone: micromamba
-          # - os: ubuntu-latest
-          #   python-version: "3.13"
-          #   conda-standalone: conda-standalone-onedir
-          #   check-docs-schema: true
-          # # MACOS
-          # - os: macos-15-intel
-          #   python-version: "3.10"
-          #   conda-standalone: conda-standalone-nightly
-          # - os: macos-15-intel
-          #   python-version: "3.11"
-          #   conda-standalone: conda-standalone-onedir
-          # - os: macos-latest
-          #   python-version: "3.12"
-          #   conda-standalone: conda-standalone
-          # - os: macos-latest
-          #   python-version: "3.13"
-          #   conda-standalone: micromamba
-          # # WINDOWS
-          # - os: windows-2022
-          #   python-version: "3.10"
-          #   conda-standalone: conda-standalone-nightly
-          # - os: windows-2022
-          #   python-version: "3.11"
-          #   conda-standalone: conda-standalone
-          # - os: windows-2022
-          #   python-version: "3.12"
-          #   # conda-standalone: micromamba
-          #   conda-standalone: conda-standalone-nightly
+          - os: ubuntu-latest
+            python-version: "3.10"
+            conda-standalone: conda-standalone
+          - os: ubuntu-latest
+            python-version: "3.11"
+            conda-standalone: conda-standalone-nightly
+          - os: ubuntu-latest
+            python-version: "3.12"
+            conda-standalone: micromamba
+          - os: ubuntu-latest
+            python-version: "3.13"
+            conda-standalone: conda-standalone-onedir
+            check-docs-schema: true
+          # MACOS
+          - os: macos-15-intel
+            python-version: "3.10"
+            conda-standalone: conda-standalone-nightly
+          - os: macos-15-intel
+            python-version: "3.11"
+            conda-standalone: conda-standalone-onedir
+          - os: macos-latest
+            python-version: "3.12"
+            conda-standalone: conda-standalone
+          - os: macos-latest
+            python-version: "3.13"
+            conda-standalone: micromamba
+          # WINDOWS
+          - os: windows-2022
+            python-version: "3.10"
+            conda-standalone: conda-standalone-nightly
+          - os: windows-2022
+            python-version: "3.11"
+            conda-standalone: conda-standalone
+          - os: windows-2022
+            python-version: "3.12"
+            # conda-standalone: micromamba
+            conda-standalone: conda-standalone-nightly
           - os: windows-2022
             python-version: "3.13"
             # conda-standalone: micromamba
@@ -156,7 +156,7 @@ jobs:
           CONSTRUCTOR_SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x86/signtool.exe"
         run: |
           rm -rf coverage.json
-          pytest -ra -vvv --cov=constructor --cov-branch tests/test_examples.py -k 'test_uninstallation_standalone'
+          pytest -ra -vvv --cov=constructor --cov-branch tests/test_examples.py
           coverage run --branch --append -m constructor -V
           coverage json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
         run: conda config --show-sources
       - name: Run unit tests
         run: |
-          pytest -vv --cov=constructor --cov-branch tests/ -m "not examples"
+          pytest -ra -vvv --cov=constructor --cov-branch tests/ -m "not examples"
           coverage run --branch --append -m constructor -V
           coverage json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -156,7 +156,7 @@ jobs:
           CONSTRUCTOR_SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x86/signtool.exe"
         run: |
           rm -rf coverage.json
-          pytest -vv --cov=constructor --cov-branch tests/test_examples.py
+          pytest -ra -vvv --cov=constructor --cov-branch tests/test_examples.py
           coverage run --branch --append -m constructor -V
           coverage json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,43 +39,43 @@ jobs:
       matrix:
         include:
           # UBUNTU
-          - os: ubuntu-latest
-            python-version: "3.10"
-            conda-standalone: conda-standalone
-          - os: ubuntu-latest
-            python-version: "3.11"
-            conda-standalone: conda-standalone-nightly
-          - os: ubuntu-latest
-            python-version: "3.12"
-            conda-standalone: micromamba
-          - os: ubuntu-latest
-            python-version: "3.13"
-            conda-standalone: conda-standalone-onedir
-            check-docs-schema: true
-          # MACOS
-          - os: macos-15-intel
-            python-version: "3.10"
-            conda-standalone: conda-standalone-nightly
-          - os: macos-15-intel
-            python-version: "3.11"
-            conda-standalone: conda-standalone-onedir
-          - os: macos-latest
-            python-version: "3.12"
-            conda-standalone: conda-standalone
-          - os: macos-latest
-            python-version: "3.13"
-            conda-standalone: micromamba
-          # WINDOWS
-          - os: windows-2022
-            python-version: "3.10"
-            conda-standalone: conda-standalone-nightly
-          - os: windows-2022
-            python-version: "3.11"
-            conda-standalone: conda-standalone
-          - os: windows-2022
-            python-version: "3.12"
-            # conda-standalone: micromamba
-            conda-standalone: conda-standalone-nightly
+          # - os: ubuntu-latest
+          #   python-version: "3.10"
+          #   conda-standalone: conda-standalone
+          # - os: ubuntu-latest
+          #   python-version: "3.11"
+          #   conda-standalone: conda-standalone-nightly
+          # - os: ubuntu-latest
+          #   python-version: "3.12"
+          #   conda-standalone: micromamba
+          # - os: ubuntu-latest
+          #   python-version: "3.13"
+          #   conda-standalone: conda-standalone-onedir
+          #   check-docs-schema: true
+          # # MACOS
+          # - os: macos-15-intel
+          #   python-version: "3.10"
+          #   conda-standalone: conda-standalone-nightly
+          # - os: macos-15-intel
+          #   python-version: "3.11"
+          #   conda-standalone: conda-standalone-onedir
+          # - os: macos-latest
+          #   python-version: "3.12"
+          #   conda-standalone: conda-standalone
+          # - os: macos-latest
+          #   python-version: "3.13"
+          #   conda-standalone: micromamba
+          # # WINDOWS
+          # - os: windows-2022
+          #   python-version: "3.10"
+          #   conda-standalone: conda-standalone-nightly
+          # - os: windows-2022
+          #   python-version: "3.11"
+          #   conda-standalone: conda-standalone
+          # - os: windows-2022
+          #   python-version: "3.12"
+          #   # conda-standalone: micromamba
+          #   conda-standalone: conda-standalone-nightly
           - os: windows-2022
             python-version: "3.13"
             # conda-standalone: micromamba
@@ -156,7 +156,7 @@ jobs:
           CONSTRUCTOR_SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x86/signtool.exe"
         run: |
           rm -rf coverage.json
-          pytest -ra -vvv --cov=constructor --cov-branch tests/test_examples.py
+          pytest -ra -vvv --cov=constructor --cov-branch tests/test_examples.py -k 'test_uninstallation_standalone'
           coverage run --branch --append -m constructor -V
           coverage json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1822,6 +1822,9 @@ Section "Uninstall"
     ${Else}
         System::Call 'kernel32::SetEnvironmentVariable(t,t)i("INSTALLER_UNATTENDED", "0")'
     ${EndIf}
+{%- for key, escaped_val in SCRIPT_ENV_VARIABLES | items %}
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("{{ key }}", {{ escaped_val }})'
+{%- endfor %}
 
 {%- if uninstall_with_conda_exe %}
     # Parse uninstall options

--- a/news/1206-add-env-to-pre-uininstall
+++ b/news/1206-add-env-to-pre-uininstall
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add script environment variables to pre-uninstall scripts. (#1206)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/1206-add-env-to-pre-uininstall
+++ b/news/1206-add-env-to-pre-uininstall
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add script environment variables to pre-uninstall scripts. (#1206)
+* EXE: Add script environment variables to pre-uninstall scripts. (#1206)
 
 ### Bug fixes
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -928,7 +928,7 @@ def test_register_envs(tmp_path, request):
         assert str(install_dir) not in environments_txt
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="MacOS only")
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
 @pytest.mark.parametrize("domains", ({}, {"enable_anywhere": "false", "enable_localSystem": True}))
 def test_pkg_distribution_domains(tmp_path, domains):
     recipe_path = _example_path("osxpkg")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1348,7 +1348,6 @@ def test_uninstallation_standalone(
     remove_config_files: str | None,
     tmp_path: Path,
 ):
-    yaml = YAML()
     recipe_path = _example_path("uninstall_with_conda_exe")
     input_path = tmp_path / "input"
     shutil.copytree(str(recipe_path), str(input_path))
@@ -1393,12 +1392,14 @@ def test_uninstallation_standalone(
     for file in user_files:
         (user_files_dir / file).touch()
         assert (user_files_dir / file).exists()
+    yaml = YAML()
     construct_yaml_file = input_path / "construct.yaml"
     with construct_yaml_file.open() as file:
         construct_yaml = yaml.load(file)
     construct_yaml["script_env_variables"] = {"USER_FILES": str(user_files_dir)}
     with construct_yaml_file.open(mode="w") as file:
         yaml.dump(construct_yaml, file)
+    assert user_files_dir.exists()
 
     installer, install_dir = next(create_installer(input_path, tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
@@ -1411,6 +1412,7 @@ def test_uninstallation_standalone(
     )
 
     # Ensure that the installation set up environments.txt
+    assert user_files_dir.exists()
     dot_conda_dir = tmp_path / ".conda"
     assert dot_conda_dir.exists()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1356,8 +1356,6 @@ def test_uninstallation_standalone(
     # Set up files for removal.
     # Since conda-standalone is extensively tested upstream,
     # only set up a minimum set of files.
-    dot_conda_dir = tmp_path / ".conda"
-    assert dot_conda_dir.exists()
 
     # Minimum set of files needed for an index cache
     pkg_cache = tmp_path / "pkgs"
@@ -1411,6 +1409,10 @@ def test_uninstallation_standalone(
         check_subprocess=True,
         uninstall=False,
     )
+
+    # Ensure that the installation set up environments.txt
+    dot_conda_dir = tmp_path / ".conda"
+    assert dot_conda_dir.exists()
 
     try:
         _run_uninstaller_exe(install_dir, check=True, options=uninstall_options)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1327,7 +1327,7 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
 
 @pytest.mark.skipif(
     CONDA_EXE == StandaloneExe.CONDA and check_version(CONDA_EXE_VERSION, min_version="24.11.0"),
-    reason="Requires conda-standalone 24.11.x or newer",
+    reason=f"Requires conda-standalone 24.11.x or newer (is {CONDA_EXE_VERSION})",
 )
 @pytest.mark.skipif(not sys.platform == "win32", reason="Windows only")
 @pytest.mark.skipif(not ON_CI, reason="CI only - Interacts with system files")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1410,7 +1410,7 @@ def test_uninstallation_standalone(
         uninstall=False,
     )
 
-    # Ensure that the installation set up environments.txt
+    # Ensure that the installation has set up environments.txt
     dot_conda_dir = tmp_path / ".conda"
     assert dot_conda_dir.exists()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1399,7 +1399,6 @@ def test_uninstallation_standalone(
     construct_yaml["script_env_variables"] = {"USER_FILES": str(user_files_dir)}
     with construct_yaml_file.open(mode="w") as file:
         yaml.dump(construct_yaml, file)
-    assert user_files_dir.exists()
 
     installer, install_dir = next(create_installer(input_path, tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
@@ -1412,7 +1411,6 @@ def test_uninstallation_standalone(
     )
 
     # Ensure that the installation set up environments.txt
-    assert user_files_dir.exists()
     dot_conda_dir = tmp_path / ".conda"
     assert dot_conda_dir.exists()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1353,16 +1353,6 @@ def test_uninstallation_standalone(
     input_path = tmp_path / "input"
     shutil.copytree(str(recipe_path), str(input_path))
 
-    installer, install_dir = next(create_installer(input_path, tmp_path))
-    monkeypatch.setenv("USERPROFILE", str(tmp_path))
-    _run_installer(
-        input_path,
-        installer,
-        install_dir,
-        check_subprocess=True,
-        uninstall=False,
-    )
-
     # Set up files for removal.
     # Since conda-standalone is extensively tested upstream,
     # only set up a minimum set of files.
@@ -1411,6 +1401,16 @@ def test_uninstallation_standalone(
     construct_yaml["script_env_variables"] = {"USER_FILES": str(user_files_dir)}
     with construct_yaml_file.open(mode="w") as file:
         yaml.dump(construct_yaml, file)
+
+    installer, install_dir = next(create_installer(input_path, tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        check_subprocess=True,
+        uninstall=False,
+    )
 
     try:
         _run_uninstaller_exe(install_dir, check=True, options=uninstall_options)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1326,7 +1326,8 @@ def test_ignore_condarc_files(tmp_path, monkeypatch, request):
 
 
 @pytest.mark.skipif(
-    CONDA_EXE == StandaloneExe.CONDA and check_version(CONDA_EXE_VERSION, min_version="24.11.0"),
+    CONDA_EXE == StandaloneExe.CONDA
+    and not check_version(CONDA_EXE_VERSION, min_version="24.11.0"),
     reason=f"Requires conda-standalone 24.11.x or newer (is {CONDA_EXE_VERSION})",
 )
 @pytest.mark.skipif(not sys.platform == "win32", reason="Windows only")


### PR DESCRIPTION
### Description

Add environment variables to the `pre-uninstall` scripts, which is required for the `test_uninstallation_standalone` test to pass. Also fix the overall logic of the test.

I also increased the verbosity of the tests and added an output summary. This makes the reasons for skipped tests more transparent.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?