### PR TITLE
fix: skip mkdir ~/.conda when register_envs is false

### DIFF
--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -599,7 +599,9 @@ export FORCE
 # Avoid silent errors when $HOME is not writable
 # https://github.com/conda/constructor/pull/669
 #}
+{%- if register_envs == "true" %}
 test -d ~/.conda || mkdir -p ~/.conda >/dev/null 2>/dev/null || test -d ~/.conda || mkdir ~/.conda
+{%- endif %}
 
 printf "\nInstalling base environment...\n\n"
 

--- a/news/mkdir-conda-guard
+++ b/news/mkdir-conda-guard
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Skip creating `~/.conda` in shell installers when `register_envs` is false.
+  Avoids a spurious failure when `$HOME` is read-only. (#1215)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

In https://github.com/DIRACGrid/DIRACOS2/issues/174 we saw that the unconditional `mkdir ~/.conda` at the top of the base-environment install section fails under read-only `$HOME`. As this installer disables env registration it does not need `~/.conda/`, so gate the `mkdir` on `register_envs` being `true`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
