### PR TITLE
Explicitly add pip as dependency to test

### DIFF
--- a/examples/extra_envs/construct.yaml
+++ b/examples/extra_envs/construct.yaml
@@ -8,6 +8,7 @@ channels:
   - https://conda.anaconda.org/conda-forge
 specs:
   - python=3.10
+  - pip
   - conda # conda is required for extra_envs
   - miniforge_console_shortcut 1.*  # [win]
 exclude:  # [unix]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR contains a temporary workaround for https://github.com/conda/conda-libmamba-solver/issues/918.
The test fails because `conda-libmamba-solver` version `26.4.0` was recently released which enabled sharded repodata by default, which exposed the issue in the link.

Without the fix the test fails as:
```
.../pytest-of-runner/pytest-1/test_example_extra_envs0/install-ExtraEnvs-1.0.0-MacOSX-arm64-sh/bin/python -m pip -V
.../pytest-of-runner/pytest-1/test_example_extra_envs0/install-ExtraEnvs-1.0.0-MacOSX-arm64-sh/bin/python: No module named pip
```