### PR TITLE
Update usage of id -un

### DIFF
--- a/constructor/osx/run_conda_init.sh
+++ b/constructor/osx/run_conda_init.sh
@@ -38,7 +38,7 @@ if [[ "${USER}" != "root" ]]; then
         while [[ "${file}" != "${HOME}" ]] && [[ "${file}" != "${PREFIX}" ]]; do
             # Check just in case the file wasn't created due to flaky conda init
             if [[ -f "${file}" ]] || [[ -d "${file}" ]]; then
-                OWNER=$(stat -f "%u" "${file}" | id -un)
+                OWNER=$(stat -f "%Su" "${file}")
                 if [[ "${OWNER}" == "root" ]]; then
                     if ! chown "${USER}" "${file}"; then
                         MSG="WARNING! Unable to change ownership of ${file} (owned by ${OWNER})."

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -125,7 +125,7 @@ chown -R "${USER}" "$PREFIX"
 CONDA_DIR="${HOME}/.conda"
 if [[ -d "${CONDA_DIR}" ]]; then
     if ! chown -R "${USER}" "${CONDA_DIR}"; then
-        OWNER=$(stat -f "%u" "${CONDA_DIR}" | id -un)
+        OWNER=$(stat -f "%Su" "${CONDA_DIR}")
         MSG="WARNING: Unable to change ownership of ${CONDA_DIR} (owned by ${OWNER})."
         logger -p "install.warning" "${MSG}" || echo "${MSG}"
     fi
@@ -133,7 +133,7 @@ fi
 CONDARC="${HOME}/.condarc"
 if [[ -f "${CONDARC}" ]]; then
     if ! chown "${USER}" "${CONDARC}"; then
-        OWNER=$(stat -f "%u" "${CONDARC}" | id -un)
+        OWNER=$(stat -f "%Su" "${CONDARC}")
         MSG="WARNING: Unable to change ownership of ${CONDARC} (owned by ${OWNER})."
         logger -p "install.warning" "${MSG}" || echo "${MSG}"
     fi

--- a/news/1223-fix-ownership-warning
+++ b/news/1223-fix-ownership-warning
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* PKG: Fix incorrect owner name in ownership warning messages. (#1223)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR updates some incorrect usage of `id -un`, source:
https://leancrew.com/all-this/man/man1/stat.html
- The special output specifier S may be used to indicate that the output, if applicable, should be in string format.
- u, g    User ID and group ID of file's owner (st_uid, st_gid).

Resolves https://github.com/conda/constructor/issues/1222.
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
