### PR TITLE
MSI: Add support for signing of installers 

### DIFF
--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -22,7 +22,7 @@ else:
 
 from . import preconda
 from .jinja import render_template
-from .signing import create_signing_tool
+from .signing import create_windows_signing_tool
 from .utils import (
     DEFAULT_REVERSE_DOMAIN_ID,
     bat_echo_esc,
@@ -572,7 +572,7 @@ def create(info, verbose=False):
     # via the `conda constructor uninstall` command.
     info["uninstall_with_conda_exe"] = True
 
-    signing_tool = create_signing_tool(info)
+    signing_tool = create_windows_signing_tool(info)
 
     payload = Payload(info)
     try:
@@ -590,13 +590,13 @@ def create(info, verbose=False):
         if len(msi_paths) != 1:
             raise RuntimeError(f"Found {len(msi_paths)} MSI files in {dist_dir}, expected 1.")
 
+        if signing_tool:
+            signing_tool.sign(msi_paths[0])
+            signing_tool.verify_signature(msi_paths[0])
+
         outpath = Path(info["_outpath"])
         outpath.unlink(missing_ok=True)
         shutil.move(msi_paths[0], outpath)
-
-        if signing_tool:
-            signing_tool.sign(outpath)
-            signing_tool.verify_signature(outpath)
     finally:
         if not info.get("_debug"):
             payload.remove()

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -22,6 +22,7 @@ else:
 
 from . import preconda
 from .jinja import render_template
+from .signing import create_signing_tool
 from .utils import (
     DEFAULT_REVERSE_DOMAIN_ID,
     bat_echo_esc,
@@ -571,6 +572,8 @@ def create(info, verbose=False):
     # via the `conda constructor uninstall` command.
     info["uninstall_with_conda_exe"] = True
 
+    signing_tool = create_signing_tool(info)
+
     payload = Payload(info)
     try:
         payload.prepare()
@@ -590,6 +593,10 @@ def create(info, verbose=False):
         outpath = Path(info["_outpath"])
         outpath.unlink(missing_ok=True)
         shutil.move(msi_paths[0], outpath)
+
+        if signing_tool:
+            signing_tool.sign(outpath)
+            signing_tool.verify_signature(outpath)
     finally:
         if not info.get("_debug"):
             payload.remove()

--- a/constructor/signing.py
+++ b/constructor/signing.py
@@ -67,6 +67,10 @@ class SigningTool:
         """Verify the signed installer."""
         raise NotImplementedError("Signature verification not implemented for base class.")
 
+    def sign(self, file_path: str | Path):
+        """Sign the specified file."""
+        raise NotImplementedError("Signing not implemented for base class.")
+
 
 class WindowsSignTool(SigningTool):
     def __init__(self, certificate_file=None):
@@ -75,20 +79,48 @@ class WindowsSignTool(SigningTool):
             certificate_file=certificate_file,
         )
 
+    def _get_signing_params(self):
+        """Get signing parameters from environment."""
+        return {
+            "timestamp_server": os.environ.get(
+                "CONSTRUCTOR_SIGNTOOL_TIMESTAMP_SERVER_URL", "http://timestamp.sectigo.com"
+            ),
+            "timestamp_digest": os.environ.get("CONSTRUCTOR_SIGNTOOL_TIMESTAMP_DIGEST", "sha256"),
+            "file_digest": os.environ.get("CONSTRUCTOR_SIGNTOOL_FILE_DIGEST", "sha256"),
+            "password": os.environ.get("CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD"),
+        }
+
     def get_signing_command(self) -> str:
-        timestamp_server = os.environ.get(
-            "CONSTRUCTOR_SIGNTOOL_TIMESTAMP_SERVER_URL", "http://timestamp.sectigo.com"
-        )
-        timestamp_digest = os.environ.get("CONSTRUCTOR_SIGNTOOL_TIMESTAMP_DIGEST", "sha256")
-        file_digest = os.environ.get("CONSTRUCTOR_SIGNTOOL_FILE_DIGEST", "sha256")
+        params = self._get_signing_params()
         command = (
             f"{win_str_esc(self.executable)} sign /f {win_str_esc(self.certificate_file)} "
-            f"/tr {win_str_esc(timestamp_server)} /td {timestamp_digest} /fd {file_digest}"
+            f"/tr {win_str_esc(params['timestamp_server'])} /td {params['timestamp_digest']} "
+            f"/fd {params['file_digest']}"
         )
-        if "CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD" in os.environ:
+        if params["password"]:
             # signtool can get the password from the env var on its own
             command += ' /p "%CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD%"'
         return command
+
+    def sign(self, file_path: str | Path):
+        """Sign a file using signtool."""
+        params = self._get_signing_params()
+        command = [
+            self.executable,
+            "sign",
+            "/f",
+            str(self.certificate_file),
+            "/tr",
+            params["timestamp_server"],
+            "/td",
+            params["timestamp_digest"],
+            "/fd",
+            params["file_digest"],
+        ]
+        if params["password"]:
+            command.extend(["/p", params["password"]])
+        command.append(str(file_path))
+        check_call(command)
 
     def verify_signing_tool(self):
         super()._verify_tool_is_available()
@@ -119,6 +151,75 @@ class WindowsSignTool(SigningTool):
 class AzureSignTool(SigningTool):
     def __init__(self):
         super().__init__(os.environ.get("AZURE_SIGNTOOL_PATH", "AzureSignTool"))
+
+    def _get_signing_params(self):
+        """Get signing parameters from environment."""
+        required_env_vars = (
+            "AZURE_SIGNTOOL_KEY_VAULT_URL",
+            "AZURE_SIGNTOOL_KEY_VAULT_CERTIFICATE",
+        )
+        check_required_env_vars(required_env_vars)
+
+        return {
+            "key_vault_url": os.environ["AZURE_SIGNTOOL_KEY_VAULT_URL"],
+            "key_vault_certificate": os.environ["AZURE_SIGNTOOL_KEY_VAULT_CERTIFICATE"],
+            "timestamp_server": os.environ.get(
+                "AZURE_SIGNTOOL_TIMESTAMP_SERVER_URL", "http://timestamp.sectigo.com"
+            ),
+            "timestamp_digest": os.environ.get("AZURE_SIGNTOOL_TIMESTAMP_DIGEST", "sha256"),
+            "file_digest": os.environ.get("AZURE_SIGNTOOL_FILE_DIGEST", "sha256"),
+            "access_token": os.environ.get("AZURE_SIGNTOOL_KEY_VAULT_ACCESSTOKEN"),
+            "secret": os.environ.get("AZURE_SIGNTOOL_KEY_VAULT_SECRET"),
+            "client_id": os.environ.get("AZURE_SIGNTOOL_KEY_VAULT_CLIENT_ID"),
+            "tenant_id": os.environ.get("AZURE_SIGNTOOL_KEY_VAULT_TENANT_ID"),
+        }
+
+    def sign(self, file_path: str | Path):
+        """Sign a file using AzureSignTool."""
+        params = self._get_signing_params()
+        command = [
+            self.executable,
+            "sign",
+            "-v",
+            "-kvu",
+            params["key_vault_url"],
+            "-kvc",
+            params["key_vault_certificate"],
+            "-tr",
+            params["timestamp_server"],
+            "-td",
+            params["timestamp_digest"],
+            "-fd",
+            params["file_digest"],
+        ]
+
+        if params["access_token"]:
+            logger.info("AzureSignTool: signing binary using access token.")
+            command.extend(["-kva", params["access_token"]])
+        elif params["secret"]:
+            logger.info("AzureSignTool: signing binary using secret.")
+            check_required_env_vars(
+                (
+                    "AZURE_SIGNTOOL_KEY_VAULT_CLIENT_ID",
+                    "AZURE_SIGNTOOL_KEY_VAULT_TENANT_ID",
+                )
+            )
+            command.extend(
+                [
+                    "-kvi",
+                    params["client_id"],
+                    "-kvt",
+                    params["tenant_id"],
+                    "-kvs",
+                    params["secret"],
+                ]
+            )
+        else:
+            logger.info("AzureSignTool: signing binary using managed identity.")
+            command.append("-kvm")
+
+        command.append(str(file_path))
+        check_call(command)
 
     def get_signing_command(self) -> str:
         required_env_vars = (
@@ -261,3 +362,23 @@ class CodeSign(SigningTool):
         else:
             command = self.get_signing_command(bundle, entitlements=entitlements)
             explained_check_call(command)
+
+
+def create_signing_tool(info: dict) -> SigningTool | None:
+    """Create a signing tool based on construct.yaml configuration.
+
+    Returns None if no signing is configured.
+    """
+    signing_tool_name = info.get("windows_signing_tool")
+    if not signing_tool_name:
+        return None
+
+    if signing_tool_name == "signtool":
+        signing_tool = WindowsSignTool(certificate_file=info.get("signing_certificate"))
+    elif signing_tool_name == "azuresigntool":
+        signing_tool = AzureSignTool()
+    else:
+        raise ValueError(f"Unknown signing tool: {signing_tool_name}")
+
+    signing_tool.verify_signing_tool()
+    return signing_tool

--- a/constructor/signing.py
+++ b/constructor/signing.py
@@ -364,8 +364,8 @@ class CodeSign(SigningTool):
             explained_check_call(command)
 
 
-def create_signing_tool(info: dict) -> SigningTool | None:
-    """Create a signing tool based on construct.yaml configuration.
+def create_windows_signing_tool(info: dict) -> SigningTool | None:
+    """Create a Windows signing tool based on construct.yaml.
 
     Returns None if no signing is configured.
     """

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -24,7 +24,7 @@ from .imaging import write_images
 from .jinja import render_template
 from .preconda import copy_extra_files
 from .preconda import write_files as preconda_write_files
-from .signing import create_signing_tool
+from .signing import create_windows_signing_tool
 from .utils import (
     approx_size_kb,
     copy_conda_exe,
@@ -361,7 +361,7 @@ Error: no file %s
 
 def create(info, verbose=False):
     verify_nsis_install()
-    signing_tool = create_signing_tool(info)
+    signing_tool = create_windows_signing_tool(info)
     tmp_dir = tempfile.mkdtemp()
     preconda_write_files(info, tmp_dir)
     copied_extra_files = copy_extra_files(info.get("extra_files", []), tmp_dir)

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -17,13 +17,14 @@ import tempfile
 from os.path import abspath, basename, dirname, isfile, join
 from pathlib import Path
 from subprocess import check_output, run
+from typing import TYPE_CHECKING
 
 from .construct import ns_platform
 from .imaging import write_images
 from .jinja import render_template
 from .preconda import copy_extra_files
 from .preconda import write_files as preconda_write_files
-from .signing import AzureSignTool, WindowsSignTool
+from .signing import create_signing_tool
 from .utils import (
     approx_size_kb,
     copy_conda_exe,
@@ -33,6 +34,9 @@ from .utils import (
     shortcuts_flags,
     win_str_esc,
 )
+
+if TYPE_CHECKING:
+    from .signing import AzureSignTool, WindowsSignTool
 
 NSIS_DIR = join(abspath(dirname(__file__)), "nsis")
 MAKENSIS_EXE = abspath(join(sys.prefix, "NSIS", "makensis.exe"))
@@ -357,15 +361,7 @@ Error: no file %s
 
 def create(info, verbose=False):
     verify_nsis_install()
-    signing_tool = None
-    if signing_tool_name := info.get("windows_signing_tool"):
-        if signing_tool_name == "signtool":
-            signing_tool = WindowsSignTool(certificate_file=info.get("signing_certificate"))
-        elif signing_tool_name == "azuresigntool":
-            signing_tool = AzureSignTool()
-        else:
-            raise ValueError(f"Unknown signing tool: {signing_tool_name}")
-        signing_tool.verify_signing_tool()
+    signing_tool = create_signing_tool(info)
     tmp_dir = tempfile.mkdtemp()
     preconda_write_files(info, tmp_dir)
     copied_extra_files = copy_extra_files(info.get("extra_files", []), tmp_dir)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1029,6 +1029,24 @@ def test_example_shortcuts(tmp_path, request):
             assert (applications / "package-1_b.desktop").exists()
 
 
+def _verify_windows_signature(installer: Path):
+    """Verify a Windows installer has a valid signature."""
+    proc = subprocess.run(
+        [
+            "powershell",
+            "-c",
+            f"$sig = Get-AuthenticodeSignature -LiteralPath '{installer}';$sig.Status.value__",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        raise AssertionError(f"Failed to verify signature for {installer}: {proc.stderr}")
+    status = int(proc.stdout.strip())
+    # 0 = Valid, 1 = UnknownError (self-signed certs), >1 = Error/NotSigned
+    assert status <= 1, f"Signature verification failed for {installer}: status={status}"
+
+
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 def test_example_signing(tmp_path, request):
     input_path = _example_path("signing")
@@ -1046,6 +1064,7 @@ def test_example_signing(tmp_path, request):
         CONSTRUCTOR_SIGNING_CERTIFICATE=str(cert_path),
         CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD=cert_pwd,
     ):
+        _verify_windows_signature(installer)
         _run_installer(input_path, installer, install_dir, request=request)
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Adds code signing support for MSI installers built via Briefcase, reusing the existing EXE signing infrastructure.

- Add `sign()` method to `WindowsSignTool` and `AzureSignTool` for direct file signing (post-build)
- Extract signing tool initialization into `create_signing_tool()` factory to reduce duplication
- Sign MSI after Briefcase builds it, using the same `windows_signing_tool`/`signing_certificate` config as EXE
- Add signature verification to `test_example_signing`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
