### PR TITLE
docs: add CONTRIBUTING.md to fix broken link in PR workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to Constructor
+
+Thank you for your interest in contributing to Constructor!
+
+Please refer to the [conda contributing guide](https://docs.conda.io/projects/conda/en/latest/dev-guide/contributing.html) for general guidelines on how to contribute to conda projects.
+
+For Constructor-specific questions or issues, please open an issue on the [issue tracker](https://github.com/conda/constructor/issues) or start a discussion.
+
+Please also review our [Code of Conduct](https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md) before contributing.

--- a/news/1231.md
+++ b/news/1231.md
@@ -1,2 +1,2 @@
 ### Docs
-* Added `CONTRIBUTING.md` to fix broken link in PR workflow template.
+* Added `CONTRIBUTING.md` to fix broken link in PR workflow template (#1231).

--- a/news/1231.md
+++ b/news/1231.md
@@ -1,0 +1,2 @@
+### Docs
+* Added `CONTRIBUTING.md` to fix broken link in PR workflow template.


### PR DESCRIPTION
Hi! This PR fixes issue #1067.
The PR workflow template referenced a `CONTRIBUTING.md` file that didn't exist, so I added it to the root of the repo. The file points to the Conda contributing guide and the code of conduct.
I'm happy to make any changes if necessary. Hope this helps! 