### PR TITLE
MSI: Improve font usage for license text page

### DIFF
--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -126,11 +126,43 @@ def get_bundle_app_name(info, name):
     return bundle, app_name
 
 
-def get_license(info):
-    """Retrieve the specified license as a dict or return a placeholder if not set."""
+def txt_to_rtf(txt: str) -> str:
+    """Convert plain text to RTF with Segoe UI font.
 
+    Uses Segoe UI at 9pt for better readability than Briefcase's default Courier.
+    """
+    # Escape RTF special characters: \ { }
+    escaped = txt.replace("\\", "\\\\").replace("{", "\\{").replace("}", "\\}")
+
+    # Segoe UI, 9pt (18 half-points)
+    rtf_lines = ["{\\rtf1\\ansi\\deff0 {\\fonttbl {\\f0 Segoe UI;}}\\f0\\fs18"]
+    for line in escaped.split("\n"):
+        if line.strip():
+            rtf_lines.append(line.rstrip() + " ")
+        else:
+            rtf_lines.append("\\par\\par")
+    rtf_lines.append("}")
+
+    return "\n".join(rtf_lines)
+
+
+def get_license(info, root: Path = None):
+    """Retrieve the specified license as a dict or return a placeholder if not set.
+
+    If a .txt license file is provided and root is specified, converts it to RTF
+    with a readable font (Segoe UI) instead of relying on Briefcase's default Courier.
+
+    :param root: Payload directory to write the converted RTF file to.
+    """
     if "license_file" in info:
-        return {"file": info["license_file"]}
+        license_path = Path(info["license_file"])
+        # If already RTF or no root to write to, return as-is
+        if license_path.suffix.lower() == ".rtf" or root is None:
+            return {"file": str(license_path)}
+        # Convert txt to rtf with better font
+        rtf_path = root / "LICENSE.rtf"
+        rtf_path.write_text(txt_to_rtf(license_path.read_text(encoding="utf-8")), encoding="utf-8")
+        return {"file": str(rtf_path)}
 
     placeholder_license = Path(__file__).parent / "nsis" / "placeholder_license.txt"
     return {"file": str(placeholder_license)}  # convert to str for TOML serialization
@@ -512,7 +544,7 @@ class Payload:
             "project_name": name,
             "bundle": bundle,
             "version": version,
-            "license": get_license(self.info),
+            "license": get_license(self.info, root),
             "app": {
                 app_name: {
                     "formal_name": f"{self.info['name']} {self.info['version']}",

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -134,12 +134,19 @@ def txt_to_rtf(txt: str) -> str:
     # Escape RTF special characters: \ { }
     escaped = txt.replace("\\", "\\\\").replace("{", "\\{").replace("}", "\\}")
 
-    # Segoe UI, 9pt (18 half-points)
+    # RTF header breakdown:
+    #   \rtf1    - RTF version 1
+    #   \ansi    - ANSI character set
+    #   \deff0   - default font is font 0
+    #   \fonttbl - font table definition
+    #   \f0      - use font 0 (Segoe UI)
+    #   \fs18    - font size 18 half-points (9pt)
     rtf_lines = ["{\\rtf1\\ansi\\deff0 {\\fonttbl {\\f0 Segoe UI;}}\\f0\\fs18"]
     for line in escaped.split("\n"):
         if line.strip():
             rtf_lines.append(line.rstrip() + " ")
         else:
+            # \par = paragraph break (two for visual separation between paragraphs)
             rtf_lines.append("\\par\\par")
     rtf_lines.append("}")
 
@@ -149,7 +156,7 @@ def txt_to_rtf(txt: str) -> str:
 def get_license(info, root: Path = None):
     """Retrieve the specified license as a dict or return a placeholder if not set.
 
-    If a .txt license file is provided and root is specified, converts it to RTF
+    If root is specified and the license file is not already RTF, converts it to RTF
     with a readable font (Segoe UI) instead of relying on Briefcase's default Courier.
 
     :param root: Payload directory to write the converted RTF file to.

--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -16,7 +16,9 @@ from constructor.briefcase import (
     _setup_envs_commands,
     create_uninstall_options_list,
     get_bundle_app_name,
+    get_license,
     get_name_version,
+    txt_to_rtf,
 )
 from constructor.conda_interface import cc_platform
 
@@ -1085,3 +1087,54 @@ def test_payload_pyproject_toml_installer_images(tmp_path, has_user_images):
         assert "installer_banner" not in app, (
             "installer_banner should not be present without user image"
         )
+
+
+def test_txt_to_rtf():
+    """Test txt_to_rtf produces valid RTF with correct font and escaping."""
+    text = "Foo\\Bar\n\n{braces}\n\nEnd"
+    result = txt_to_rtf(text)
+
+    # RTF header with Segoe UI font at 9pt
+    assert result.startswith("{\\rtf1\\ansi\\deff0 {\\fonttbl {\\f0 Segoe UI;}}\\f0\\fs18")
+    assert result.endswith("}")
+    # Escaping
+    assert "Foo\\\\Bar" in result
+    assert "\\{braces\\}" in result
+    # Blank lines become paragraph breaks
+    assert result.count("\\par\\par") == 2
+
+
+@pytest.mark.parametrize(
+    "license_file, root_provided, expect_conversion",
+    [
+        (None, False, False),  # No license → placeholder
+        ("license.rtf", True, False),  # RTF file → no conversion
+        ("license.txt", True, True),  # TXT + root → convert
+        ("license.txt", False, False),  # TXT + no root → no conversion
+    ],
+)
+def test_get_license_scenarios(tmp_path, license_file, root_provided, expect_conversion):
+    """Test get_license handles different file types and root scenarios."""
+    if license_file is None:
+        info = {}
+    else:
+        src = tmp_path / license_file
+        if license_file.endswith(".rtf"):
+            src.write_text("{\\rtf1 existing}", encoding="utf-8")
+        else:
+            src.write_text("Plain text license", encoding="utf-8")
+        info = {"license_file": str(src)}
+
+    root = tmp_path / "payload" if root_provided else None
+    if root:
+        root.mkdir()
+
+    result = get_license(info, root=root)
+
+    if license_file is None:
+        assert "placeholder_license.txt" in result["file"]
+    elif expect_conversion:
+        assert result["file"] == str(root / "LICENSE.rtf")
+        assert "Segoe UI" in (root / "LICENSE.rtf").read_text(encoding="utf-8")
+    else:
+        assert result["file"] == str(tmp_path / license_file)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
The MSI installer license text is by default displayed in Courier font because Briefcase's default `txt_to_rtf()` converter uses Courier with no font size specified. This PR adds a font handling to the license text if the file is not in `rtf`, making the displayed text prettier (and most importantly easier to read).

This branch is created from the same branch as https://github.com/conda/constructor/pull/1241 so I put this in draft right now.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
