### PR TITLE
 Use `$INSTDIR\tmp` as the temporary directory for EXE to avoid Windows Defender errors

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1813,7 +1813,7 @@ Section "Uninstall"
     # being extracted into LOCALAPPDATA
     # See https://github.com/conda/constructor/issues/1243
     StrCpy $TmpDir "$INSTDIR\tmp"
-    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("TMP", "${TmpDir}")'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("TMP", "$TmpDir")'
     CreateDirectory "$TmpDir"
 
     # Extra info for pre_uninstall scripts

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1812,7 +1812,7 @@ Section "Uninstall"
     # Windows Defender does not get triggered by conda-standalone
     # being extracted into LOCALAPPDATA
     # See https://github.com/conda/constructor/issues/1243
-    StrCpy TmpDir "$INSTDIR\tmp"
+    StrCpy $TmpDir "$INSTDIR\tmp"
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("TMP", "${TmpDir}")'
     CreateDirectory "$TmpDir"
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -38,6 +38,7 @@ Unicode true
   !endif
 !macroend
 
+var /global TmpDir
 var /global QuietMode # "0" = print normally, "1" = do not print
 var /global StdOutHandle
 var /global StdOutHandleSet
@@ -1460,6 +1461,14 @@ Section "Install"
     # for users even during an all-users installation.
     !insertmacro setInstdirPermissions
 
+    # Create the temporary directory inside $INSTDIR so that
+    # Windows Defender does not get triggered by conda-standalone
+    # being extracted into LOCALAPPDATA
+    # See https://github.com/conda/constructor/issues/1243
+    StrCpy $TmpDir "$INSTDIR\tmp"
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("TMP", "$TmpDir")'
+    CreateDirectory $TmpDir
+
 {% if needs_python_exe %}
     SetOutPath "$INSTDIR\Lib"
     File "{{ NSIS_DIR }}\_nsis.py"
@@ -1714,6 +1723,9 @@ Section "Install"
     ${EndIf}
 
     WriteUninstaller "$INSTDIR\Uninstall-${NAME}.exe"
+    ${If} ${FileExists} "$TmpDir"
+        RMDir /r "$TmpDir"
+    ${EndIf}
 
     ${Print} "Setting installation directory permissions..."
     # Enable inheritance on all files inside $INSTDIR.
@@ -1795,6 +1807,14 @@ Section "Uninstall"
         IntOp $0 $0 + 1
         goto loop_py
     endloop_py:
+
+    # Create the temporary directory inside $INSTDIR so that
+    # Windows Defender does not get triggered by conda-standalone
+    # being extracted into LOCALAPPDATA
+    # See https://github.com/conda/constructor/issues/1243
+    StrCpy TmpDir "$INSTDIR\tmp"
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("TMP", "${TmpDir}")'
+    CreateDirectory "$TmpDir"
 
     # Extra info for pre_uninstall scripts
     System::Call 'kernel32::SetEnvironmentVariable(t,t)i("PREFIX", "$INSTDIR")'

--- a/news/1247-exe-create-temp-in-instdir
+++ b/news/1247-exe-create-temp-in-instdir
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* EXE: Create temporary directories inside `$INSTDIR` to avoid Windows Defender errors with `conda-standalone`. (#1243 via #1247)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Use `$INSTDIR\tmp` as the temporary directory to avoid Windows Defender errors.

When `conda-standalone` is called, it extracts itself into a [temporary directory](https://pyinstaller.org/en/stable/usage.html#defining-the-extraction-location). On Windows, this is done using the [`GetTempPathW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw) function, which looks for the `%TMP%` environment variable first, which defaults to `%LOCALAPPDATA%\Temp`.

Windows Defender may disallow using the user temporary directory for the expanded binary (see #1243), but does allow them to be extracted into different directories. A natural location for such as "local" temporary directory is the installation directory as is already done in the SH installer:  https://github.com/conda/constructor/blob/7cbad1abd101078059cd54db28a24fa5ba9520c5/constructor/header.sh

Closes #1243 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
