### PR TITLE
MSI: Add experimental warning and misc updates

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -235,7 +235,7 @@ The type of the installer being created. Possible values are:
 - `sh`: shell-based installer for Linux or macOS
 - `pkg`: macOS GUI installer built with Apple's `pkgbuild`
 - `exe`: Windows GUI installer built with NSIS
-- `msi`: Windows GUI installer built with Briefcase and WiX
+- `msi`: Windows GUI installer built with Briefcase and WiX (experimental)
 
 The default type is `sh` on Linux and macOS, and `exe` on Windows. A special
 value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well

--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -404,7 +404,7 @@ class ConstructorConfiguration(BaseModel):
     - `sh`: shell-based installer for Linux or macOS
     - `pkg`: macOS GUI installer built with Apple's `pkgbuild`
     - `exe`: Windows GUI installer built with NSIS
-    - `msi`: Windows GUI installer built with Briefcase and WiX
+    - `msi`: Windows GUI installer built with Briefcase and WiX (experimental)
 
     The default type is `sh` on Linux and macOS, and `exe` on Windows. A special
     value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -414,6 +414,7 @@ class Payload:
         Directory structure created during preparation:
 
             <root>/                          (temporary directory, see :attr:`root`)
+            ├── welcome.bmp, header.bmp, icon.ico  (branding images for WiX UI, not installed)
             └── <EXTERNAL_PACKAGE_PATH>/     (external_dir: contains the payload archive and conda exe)
                 └── base/                    (base_dir: represents the base conda environment)
                     └── pkgs/                (pkgs_dir: staging area for conda package distributions)
@@ -423,8 +424,9 @@ class Payload:
         external_dir = self.root / EXTERNAL_PACKAGE_PATH
         external_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate branding images for MSI installer (only if user provided custom images)
-        write_images(self.info, external_dir, installer_type="msi")
+        # Generate branding images at root level so they're not included in the payload.
+        # These are only used for WiX UI configuration.
+        write_images(self.info, self.root, installer_type="msi")
 
         # Note that the directory name "base" is also explicitly defined in `run_installation.bat`
         base_dir = external_dir / "base"
@@ -568,14 +570,15 @@ class Payload:
         }
 
         # Add optional branding images (only if user provided them in construct.yaml)
-        icon_ico = external / "icon.ico"
+        # Images are stored at root level, not in external_dir, to avoid bundling them in the payload
+        icon_ico = root / "icon.ico"
         if icon_ico.exists():
             # Briefcase expects icon path WITHOUT extension - it appends .ico
-            config["app"][app_name]["icon"] = str(external / "icon")
-        welcome_bmp = external / "welcome.bmp"
+            config["app"][app_name]["icon"] = str(root / "icon")
+        welcome_bmp = root / "welcome.bmp"
         if welcome_bmp.exists():
             config["app"][app_name]["installer_background"] = str(welcome_bmp)
-        header_bmp = external / "header.bmp"
+        header_bmp = root / "header.bmp"
         if header_bmp.exists():
             config["app"][app_name]["installer_banner"] = str(header_bmp)
 

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -267,30 +267,30 @@ def create_uninstall_options_list(info: dict) -> list[dict]:
 
 
 def create_install_options_list(info: dict) -> list[dict]:
-    """Returns a list of dicts with data formatted for the installation options page."""
+    """Returns a list of dicts with data formatted for the installation options page.
+
+    Options are ordered to match the EXE (NSIS) installer for consistency:
+    1. Create shortcuts
+    2. Add to PATH (initialize_conda)
+    3. Register Python
+    4. Clear package cache
+    5. Pre-install script
+    6. Post-install script
+    """
     options = []
 
-    # Register Python (if Python is bundled)
-    has_python = False
-    for item in info.get("_dists", []):
-        if item.startswith("python-"):
-            components = item.split("-")  # python-x.y.z-<build number>.suffix
-            python_version = ".".join(components[1].split(".")[:-1])  # create the string "x.y"
-            has_python = True
-            break
-
-    if has_python and info.get("register_python", True):
+    # 1. Enable shortcuts
+    if info.get("_enable_shortcuts", False) is True:
         options.append(
             {
-                "name": "register_python",
-                "title": f"Register {info['name']} as my default Python {python_version}.",
-                "description": "Allows other programs, such as VSCode, PyCharm, etc. to automatically "
-                f"detect {info['name']} as the primary Python {python_version} on the system.",
-                "default": info.get("register_python_default", False),
+                "name": "enable_shortcuts",
+                "title": "Create shortcuts",
+                "description": "Create shortcuts (supported packages only).",
+                "default": True,
             }
         )
 
-    # Initialize conda
+    # 2. Initialize conda (Add to PATH)
     initialize_conda = info.get("initialize_conda", "classic")
     if initialize_conda:
         if initialize_conda == "condabin":
@@ -313,7 +313,27 @@ def create_install_options_list(info: dict) -> list[dict]:
             }
         )
 
-    # Keep package option (presented to the user as a negation (clear package cache))
+    # 3. Register Python (if Python is bundled)
+    has_python = False
+    for item in info.get("_dists", []):
+        if item.startswith("python-"):
+            components = item.split("-")  # python-x.y.z-<build number>.suffix
+            python_version = ".".join(components[1].split(".")[:-1])  # create the string "x.y"
+            has_python = True
+            break
+
+    if has_python and info.get("register_python", True):
+        options.append(
+            {
+                "name": "register_python",
+                "title": f"Register {info['name']} as my default Python {python_version}.",
+                "description": "Allows other programs, such as VSCode, PyCharm, etc. to automatically "
+                f"detect {info['name']} as the primary Python {python_version} on the system.",
+                "default": info.get("register_python_default", False),
+            }
+        )
+
+    # 4. Clear package cache (presented to the user as a negation of keep_pkgs)
     clear_package_cache = not info.get("keep_pkgs", False)
     options.append(
         {
@@ -324,18 +344,7 @@ def create_install_options_list(info: dict) -> list[dict]:
         }
     )
 
-    # Enable shortcuts
-    if info.get("_enable_shortcuts", False) is True:
-        options.append(
-            {
-                "name": "enable_shortcuts",
-                "title": "Create shortcuts",
-                "description": "Create shortcuts (supported packages only).",
-                "default": True,
-            }
-        )
-
-    # Pre/Post install script
+    # 5 & 6. Pre/Post install script
     for script_type in ["pre", "post"]:
         script_description = info.get(f"{script_type}_install_desc", "")
         script = info.get(f"{script_type}_install", "")

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -433,8 +433,6 @@ class Payload:
         external_dir = self.root / EXTERNAL_PACKAGE_PATH
         external_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate branding images at root level so they're not included in the payload.
-        # These are only used for WiX UI configuration.
         write_images(self.info, self.root, installer_type="msi")
 
         # Note that the directory name "base" is also explicitly defined in `run_installation.bat`

--- a/constructor/data/construct.schema.json
+++ b/constructor/data/construct.schema.json
@@ -865,7 +865,7 @@
         }
       ],
       "default": null,
-      "description": "The type of the installer being created. Possible values are:\n- `sh`: shell-based installer for Linux or macOS\n- `pkg`: macOS GUI installer built with Apple's `pkgbuild`\n- `exe`: Windows GUI installer built with NSIS\n- `msi`: Windows GUI installer built with Briefcase and WiX\nThe default type is `sh` on Linux and macOS, and `exe` on Windows. A special value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well as `sh` on Linux and `exe` on Windows.",
+      "description": "The type of the installer being created. Possible values are:\n- `sh`: shell-based installer for Linux or macOS\n- `pkg`: macOS GUI installer built with Apple's `pkgbuild`\n- `exe`: Windows GUI installer built with NSIS\n- `msi`: Windows GUI installer built with Briefcase and WiX (experimental)\nThe default type is `sh` on Linux and macOS, and `exe` on Windows. A special value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well as `sh` on Linux and `exe` on Windows.",
       "title": "Installer Type"
     },
     "keep_pkgs": {

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -413,6 +413,9 @@ def main_build(
 
             create = winexe_create
         elif itype == "msi":
+            logger.warning(
+                "MSI installer support is experimental and may change in future releases."
+            )
             from .briefcase import create as briefcase_create
 
             create = briefcase_create

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -235,7 +235,7 @@ The type of the installer being created. Possible values are:
 - `sh`: shell-based installer for Linux or macOS
 - `pkg`: macOS GUI installer built with Apple's `pkgbuild`
 - `exe`: Windows GUI installer built with NSIS
-- `msi`: Windows GUI installer built with Briefcase and WiX
+- `msi`: Windows GUI installer built with Briefcase and WiX (experimental)
 
 The default type is `sh` on Linux and macOS, and `exe` on Windows. A special
 value of `all` builds _both_ `sh` and `pkg` installers on macOS, as well

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1767,13 +1767,15 @@ def test_regressions(tmp_path, request):
 @pytest.mark.skipif(not ON_CI, reason="CI only")
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
 def test_not_in_installed_menu_list_(tmp_path, request, no_registry):
-    """Verify the app is in the Installed Apps Menu (or not), based on the CLI arg '/NoRegistry'.
+    """Verify the app is in the Installed Apps Menu (or not), based on the NSIS-specific '/NoRegistry' flag.
     If NoRegistry=0, we expect to find the installer in the Menu, otherwise not.
     """
     input_path = _example_path("register_envs")  # The specific example we use here is not important
     options = ["/InstallationType=JustMe", f"/NoRegistry={no_registry}"]
     for installer, install_dir in create_installer(input_path, tmp_path):
         if installer.suffix == ".msi":
+            # MSI registration is handled by Windows Installer (msiexec) and cannot
+            # be disabled. The /NoRegistry flag is NSIS-specific.
             continue
         _run_installer(
             input_path,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds:
1. Experimental warning when building MSI installers.
2. Fix an issue where the installer branding was added to the installer payload (was unpacked next to `conda.exe`)
3. Re-arranges the order of the installer options such that it is now in line (and clarified) with the order we use for the `.exe` installers. This just adds consistency.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
