### PR TITLE
Add installer attributes for name, version, platform, and type to .installer.info

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1502,6 +1502,7 @@ Section "Install"
     SetOutPath "$INSTDIR"
     File {{ conda_exe }}
     File {{ pre_uninstall }}
+    File {{ installer_info }}
 
 {%- for path, files in EXTRA_FILES | items %}
     SetOutPath "{{ path }}"

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -49,6 +49,7 @@ except ImportError:
     import ruamel_json as json
 
 files = (
+    ".installer.info",
     "pkgs/.constructor-build.info",
     "pkgs/urls",
     "pkgs/urls.txt",
@@ -164,6 +165,15 @@ def write_files(info: dict, workspace: str):
     os.makedirs(pkgs_dir, exist_ok=True)
     with open(join(pkgs_dir, ".constructor-build.info"), "w") as fo:
         json.dump(system_info(), fo)
+
+    out = {
+        "name": info.get("name"),
+        "version": info.get("version"),
+        "platform": info.get("platform"),
+        "type": info.get("installer_type"),
+    }
+    with open(join(workspace, ".installer.info"), "w") as fo:
+        json.dump(out, fo)
 
     all_urls = info["_urls"].copy()
     for env_info in info.get("_extra_envs_info", {}).values():

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -49,7 +49,7 @@ except ImportError:
     import ruamel_json as json
 
 files = (
-    "pkgs/.constructor-build.info",
+    ".constructor-build.info",
     "pkgs/urls",
     "pkgs/urls.txt",
     "conda-meta/initial-state.explicit.txt",
@@ -113,7 +113,7 @@ def write_index_cache(info: dict, dst_dir: str, used_packages: list[str]):
             os.unlink(join(cache_dir, cache_file))
 
 
-def system_info():
+def system_info(info: dict):
     out = {
         "constructor": CONSTRUCTOR_VERSION,
         "conda": CONDA_INTERFACE_VERSION,
@@ -123,6 +123,10 @@ def system_info():
         "machine": platform.machine(),
         "platform_full": platform.version(),
     }
+    out["installer_name"] = info.get("installer_name", "Unknown")
+    out["installer_version"] = info.get("installer_version", "Unknown")
+    out["installer_platform"] = info.get("installer_platform", "Unknown")
+    out["installer_type"] = info.get("installer_type", "Unknown")
     if sys.platform == "darwin":
         out["extra"] = platform.mac_ver()
     elif sys.platform.startswith("linux"):
@@ -162,8 +166,8 @@ def write_files(info: dict, workspace: str):
     os.makedirs(join(workspace, "conda-meta"), exist_ok=True)
     pkgs_dir = join(workspace, "pkgs")
     os.makedirs(pkgs_dir, exist_ok=True)
-    with open(join(pkgs_dir, ".constructor-build.info"), "w") as fo:
-        json.dump(system_info(), fo)
+    with open(join(workspace, ".constructor-build.info"), "w") as fo:
+        json.dump(system_info(info), fo)
 
     all_urls = info["_urls"].copy()
     for env_info in info.get("_extra_envs_info", {}).values():

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -169,7 +169,7 @@ def write_files(info: dict, workspace: str):
     out = {
         "name": info.get("name"),
         "version": info.get("version"),
-        "platform": info.get("platform"),
+        "platform": info.get("_platform"),
         "type": info.get("installer_type"),
     }
     with open(join(workspace, ".installer.info"), "w") as fo:

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -49,7 +49,7 @@ except ImportError:
     import ruamel_json as json
 
 files = (
-    ".constructor-build.info",
+    "pkgs/.constructor-build.info",
     "pkgs/urls",
     "pkgs/urls.txt",
     "conda-meta/initial-state.explicit.txt",
@@ -113,7 +113,7 @@ def write_index_cache(info: dict, dst_dir: str, used_packages: list[str]):
             os.unlink(join(cache_dir, cache_file))
 
 
-def system_info(info: dict):
+def system_info():
     out = {
         "constructor": CONSTRUCTOR_VERSION,
         "conda": CONDA_INTERFACE_VERSION,
@@ -123,10 +123,6 @@ def system_info(info: dict):
         "machine": platform.machine(),
         "platform_full": platform.version(),
     }
-    out["installer_name"] = info.get("installer_name", "Unknown")
-    out["installer_version"] = info.get("installer_version", "Unknown")
-    out["installer_platform"] = info.get("installer_platform", "Unknown")
-    out["installer_type"] = info.get("installer_type", "Unknown")
     if sys.platform == "darwin":
         out["extra"] = platform.mac_ver()
     elif sys.platform.startswith("linux"):
@@ -166,8 +162,8 @@ def write_files(info: dict, workspace: str):
     os.makedirs(join(workspace, "conda-meta"), exist_ok=True)
     pkgs_dir = join(workspace, "pkgs")
     os.makedirs(pkgs_dir, exist_ok=True)
-    with open(join(workspace, ".constructor-build.info"), "w") as fo:
-        json.dump(system_info(info), fo)
+    with open(join(pkgs_dir, ".constructor-build.info"), "w") as fo:
+        json.dump(system_info(), fo)
 
     all_urls = info["_urls"].copy()
     for env_info in info.get("_extra_envs_info", {}).values():

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -187,6 +187,7 @@ def make_nsi(
         "pre_install": "@pre_install.bat",
         "post_install": "@post_install.bat",
         "pre_uninstall": "@pre_uninstall.bat",
+        "installer_info": "@.installer.info",
         "index_cache": "@" + join("pkgs", "cache"),
         "repodata_record": "@" + join("pkgs", "repodata_record.json"),
     }

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -187,7 +187,6 @@ def make_nsi(
         "pre_install": "@pre_install.bat",
         "post_install": "@post_install.bat",
         "pre_uninstall": "@pre_uninstall.bat",
-        "installer_info": "@.constructor-build.info",
         "index_cache": "@" + join("pkgs", "cache"),
         "repodata_record": "@" + join("pkgs", "repodata_record.json"),
     }

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -187,6 +187,7 @@ def make_nsi(
         "pre_install": "@pre_install.bat",
         "post_install": "@post_install.bat",
         "pre_uninstall": "@pre_uninstall.bat",
+        "installer_info": "@.constructor-build.info",
         "index_cache": "@" + join("pkgs", "cache"),
         "repodata_record": "@" + join("pkgs", "repodata_record.json"),
     }

--- a/news/1260-installer-attributes
+++ b/news/1260-installer-attributes
@@ -16,5 +16,5 @@
 
 ### Other
 
-* Add `installer_name`, `installer_version`, `installer_platform`, and `installer_type`
-  attributes to the `.constructor-build.info` file, so this information can be persistently stored. (#1250)
+* Add the `installer` name, version, platform and type attributes to a `.installer.info` file in the main `workspace` directory,
+  so this information can be persistently stored. (#1250)

--- a/news/1260-installer-attributes
+++ b/news/1260-installer-attributes
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add `installer_name`, `installer_version`, `installer_platform`, and `installer_type` 
+  attributes to the `.constructor-build.info` file, so this information can be persistently stored. (#1250)

--- a/news/1260-installer-attributes
+++ b/news/1260-installer-attributes
@@ -16,5 +16,5 @@
 
 ### Other
 
-* Add `installer_name`, `installer_version`, `installer_platform`, and `installer_type` 
+* Add `installer_name`, `installer_version`, `installer_platform`, and `installer_type`
   attributes to the `.constructor-build.info` file, so this information can be persistently stored. (#1250)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,6 +22,7 @@ from conda.core.prefix_data import PrefixData
 from conda.models.version import VersionOrder as Version
 from ruamel.yaml import YAML
 
+from constructor.conda_interface import SUPPORTED_PLATFORMS
 from constructor.utils import (
     StandaloneExe,
     check_version,
@@ -596,6 +597,14 @@ def test_example_miniforge(tmp_path, request, example):
             # Check that key metadata files are in place
             assert install_dir.glob("conda-meta/*.json")
             assert install_dir.glob("pkgs/cache/*.json")  # enables offline installs
+            # Check that the installer info file is in place
+            assert (install_dir / ".installer.info").is_file()
+            with open(install_dir / ".installer.info") as f:
+                installer_info = json.load(f)
+            assert installer_info["name"] == "Miniforge3" if example == "miniforge" else "Miniforge3-mamba2"
+            assert installer_info["version"] == "25.0.0-1" if example == "miniforge" else "25.1.1-0"
+            assert installer_info["platform"] in SUPPORTED_PLATFORMS
+            assert installer_info["type"] == installer.suffix[1:]
             if installer.suffix == ".pkg" and ON_CI:
                 basename = "Miniforge3" if example == "miniforge" else "Miniforge3-mamba2"
                 _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / basename)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ from conda.core.prefix_data import PrefixData
 from conda.models.version import VersionOrder as Version
 from ruamel.yaml import YAML
 
-from constructor.conda_interface import SUPPORTED_PLATFORMS
+from constructor.conda_interface import cc_platform, SUPPORTED_PLATFORMS
 from constructor.utils import (
     StandaloneExe,
     check_version,
@@ -609,7 +609,7 @@ def test_example_miniforge(tmp_path, request, example, installer_name, installer
             installer_info = json.loads(info_file.read_text())
             assert installer_info["name"] == installer_name
             assert installer_info["version"] == installer_version
-            assert installer_info["platform"] in SUPPORTED_PLATFORMS
+            assert installer_info["platform"] == cc_platform
             assert installer_info["type"] == installer.suffix[1:]
             if installer.suffix == ".pkg" and ON_CI:
                 _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / installer_name)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -571,10 +571,13 @@ def test_example_mirrored_channels(tmp_path, request):
     ),
     reason="Known issue with conda-standalone<=23.10: shortcuts are created but not removed.",
 )
-@pytest.mark.parametrize("example, installer_name, installer_version", [
-    ("miniforge", "Miniforge3", "25.0.0-1"),
-    ("miniforge-mamba2", "Miniforge3-mamba2", "25.1.1-0"),
-])
+@pytest.mark.parametrize(
+    "example, installer_name, installer_version",
+    [
+        ("miniforge", "Miniforge3", "25.0.0-1"),
+        ("miniforge-mamba2", "Miniforge3-mamba2", "25.1.1-0"),
+    ],
+)
 def test_example_miniforge(tmp_path, request, example, installer_name, installer_version):
     input_path = _example_path(example)
     for installer, install_dir in create_installer(input_path, tmp_path):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -573,6 +573,12 @@ def test_example_mirrored_channels(tmp_path, request):
 )
 @pytest.mark.parametrize("example", ("miniforge", "miniforge-mamba2"))
 def test_example_miniforge(tmp_path, request, example):
+    if example == "miniforge":
+        installer_name = "Miniforge3"
+        installer_version = "25.0.0-1"
+    elif example == "miniforge-mamba2":
+        installer_name = "Miniforge3-mamba2"
+        installer_version = "25.1.1-0"
     input_path = _example_path(example)
     for installer, install_dir in create_installer(input_path, tmp_path):
         if installer.suffix == ".sh":
@@ -601,17 +607,12 @@ def test_example_miniforge(tmp_path, request, example):
             assert (install_dir / ".installer.info").is_file()
             with open(install_dir / ".installer.info") as f:
                 installer_info = json.load(f)
-            assert (
-                installer_info["name"] == "Miniforge3"
-                if example == "miniforge"
-                else "Miniforge3-mamba2"
-            )
-            assert installer_info["version"] == "25.0.0-1" if example == "miniforge" else "25.1.1-0"
+            assert installer_info["name"] == installer_name
+            assert installer_info["version"] == installer_version
             assert installer_info["platform"] in SUPPORTED_PLATFORMS
             assert installer_info["type"] == installer.suffix[1:]
             if installer.suffix == ".pkg" and ON_CI:
-                basename = "Miniforge3" if example == "miniforge" else "Miniforge3-mamba2"
-                _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / basename)
+                _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / installer_name)
             if installer.suffix == ".exe":
                 for key in ("ProgramData", "AppData"):
                     start_menu_dir = Path(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -601,7 +601,11 @@ def test_example_miniforge(tmp_path, request, example):
             assert (install_dir / ".installer.info").is_file()
             with open(install_dir / ".installer.info") as f:
                 installer_info = json.load(f)
-            assert installer_info["name"] == "Miniforge3" if example == "miniforge" else "Miniforge3-mamba2"
+            assert (
+                installer_info["name"] == "Miniforge3"
+                if example == "miniforge"
+                else "Miniforge3-mamba2"
+            )
             assert installer_info["version"] == "25.0.0-1" if example == "miniforge" else "25.1.1-0"
             assert installer_info["platform"] in SUPPORTED_PLATFORMS
             assert installer_info["type"] == installer.suffix[1:]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -604,9 +604,9 @@ def test_example_miniforge(tmp_path, request, example, installer_name, installer
             assert install_dir.glob("conda-meta/*.json")
             assert install_dir.glob("pkgs/cache/*.json")  # enables offline installs
             # Check that the installer info file is in place
-            assert (install_dir / ".installer.info").is_file()
-            with open(install_dir / ".installer.info") as f:
-                installer_info = json.load(f)
+            info_file = install_dir / ".installer.info"
+            assert info_file.is_file()
+            installer_info = json.loads(info_file.read_text())
             assert installer_info["name"] == installer_name
             assert installer_info["version"] == installer_version
             assert installer_info["platform"] in SUPPORTED_PLATFORMS

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -571,14 +571,11 @@ def test_example_mirrored_channels(tmp_path, request):
     ),
     reason="Known issue with conda-standalone<=23.10: shortcuts are created but not removed.",
 )
-@pytest.mark.parametrize("example", ("miniforge", "miniforge-mamba2"))
-def test_example_miniforge(tmp_path, request, example):
-    if example == "miniforge":
-        installer_name = "Miniforge3"
-        installer_version = "25.0.0-1"
-    elif example == "miniforge-mamba2":
-        installer_name = "Miniforge3-mamba2"
-        installer_version = "25.1.1-0"
+@pytest.mark.parametrize("example, installer_name, installer_version", [
+    ("miniforge", "Miniforge3", "25.0.0-1"),
+    ("miniforge-mamba2", "Miniforge3-mamba2", "25.1.1-0"),
+])
+def test_example_miniforge(tmp_path, request, example, installer_name, installer_version):
     input_path = _example_path(example)
     for installer, install_dir in create_installer(input_path, tmp_path):
         if installer.suffix == ".sh":

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ from conda.core.prefix_data import PrefixData
 from conda.models.version import VersionOrder as Version
 from ruamel.yaml import YAML
 
-from constructor.conda_interface import cc_platform, SUPPORTED_PLATFORMS
+from constructor.conda_interface import cc_platform
 from constructor.utils import (
     StandaloneExe,
     check_version,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR adds attributes to a `.installer.info` file stored in the `workspace` directory for persistent storage.

The installer attributes are stored in JSON format using the following keys:

- `name`
- `version`
- `platform`
- `type`

This information is being stored so other services, such as telemetry, can find details about the installer that was used to setup `conda`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
