### PR TITLE
Fix MSI test for Windows Canary build

### DIFF
--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -8,6 +8,7 @@ except ModuleNotFoundError:
     import tomli as tomllib
 
 import pytest
+from PIL import Image
 
 from constructor.briefcase import (
     Payload,
@@ -1039,16 +1040,15 @@ def test_payload_pyproject_toml_installer_images(tmp_path, has_user_images):
     info = mock_info.copy()
 
     if has_user_images:
-        # Use existing test image from examples directory
-        repo_root = Path(__file__).parent.parent
-        example_image = (
-            repo_root / "examples" / "customized_welcome_conclusion" / "ExtraPagesExampleImg.bmp"
-        )
-        assert example_image.exists(), f"Test image not found: {example_image}"
+        # Create a minimal test image. We avoid using files from examples/ because canary
+        # builds run tests in an isolated conda-build environment where only the directories
+        # listed in recipe/meta.yaml's source_files are available.
+        test_image = tmp_path / "test_image.bmp"
+        Image.new("RGB", (10, 10), color="red").save(test_image)
 
-        info["welcome_image"] = str(example_image)
-        info["header_image"] = str(example_image)
-        info["icon_image"] = str(example_image)
+        info["welcome_image"] = str(test_image)
+        info["header_image"] = str(test_image)
+        info["icon_image"] = str(test_image)
 
     payload = Payload(info)
     payload.prepare()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR updates a test that was failing in the Windows canary build https://github.com/conda/constructor/actions/runs/27581405719/job/81677012823.
The issue was that the test was referencing a file (an image in this case) which isn't available because, Canary builds do:
- First builds a conda package from the source
- Then tests the installed package in an isolated environment (example) `D:\a\constructor\constructor\pkgs\constructor_1781618608424\test_tmp\`
- Only files listed in `recipe/meta.yaml` `source_files` are copied into this test environment
  - This is where it breaks because the file is not part of the environment.

Therefore, dynamically create a temporary image as part of the test and dont reference the example file. Originally when implementing this I only referenced the image because I just needed _any_ image in order to do the test.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
