### PR TITLE
Refactor the test examples to parametrize per installer type

### DIFF
--- a/constructor/main.py
+++ b/constructor/main.py
@@ -211,6 +211,7 @@ def main_build(
     conda_exe: str = "conda.exe",
     config_filename: str = "construct.yaml",
     debug: bool = False,
+    installer_type: str | None = None,
 ):
     logger.info("platform: %s", platform)
     if not os.path.isfile(conda_exe):
@@ -245,6 +246,13 @@ def main_build(
                 "Install Docker Buildx to proceed, or remove `docker_image_format` to "
                 "generate the Dockerfile without building the portable image."
             )
+    if installer_type:
+        if installer_type not in itypes:
+            sys.exit(
+                f"Error: installer type '{installer_type}' not available for this "
+                f"config/platform; allowed: {', '.join(itypes)}"
+            )
+        itypes = (installer_type,)
 
     if platform != cc_platform and "pkg" in itypes and not cc_platform.startswith("osx-"):
         sys.exit("Error: cannot construct a macOS 'pkg' installer on '%s'" % cc_platform)
@@ -619,6 +627,15 @@ def main(argv=None):
     )
 
     p.add_argument(
+        "--installer-type",
+        help="Build only this installer type (sh, pkg, exe, msi). "
+        "Primarily for testing; overrides 'installer_type' from the config.",
+        action="store",
+        metavar="TYPE",
+        dest="installer_type",
+    )
+
+    p.add_argument(
         "dir_path",
         help="directory containing construct.yaml",
         action="store",
@@ -690,6 +707,7 @@ https://github.com/conda/conda-standalone/releases""".lstrip()
         conda_exe=conda_exe,
         config_filename=args.config_filename,
         debug=args.debug,
+        installer_type=args.installer_type,
     )
 
 

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -232,6 +232,8 @@ def main_build(
     info["_download_dir"] = join(cache_dir, platform)
     info["_conda_exe"] = abspath(conda_exe)
     info["_debug"] = debug
+    if installer_type:
+        info["installer_type"] = installer_type
     itypes = get_installer_type(info)
 
     if "docker" in itypes:
@@ -246,14 +248,6 @@ def main_build(
                 "Install Docker Buildx to proceed, or remove `docker_image_format` to "
                 "generate the Dockerfile without building the portable image."
             )
-    if installer_type:
-        if installer_type not in itypes:
-            sys.exit(
-                f"Error: installer type '{installer_type}' not available for this "
-                f"config/platform; allowed: {', '.join(itypes)}"
-            )
-        itypes = (installer_type,)
-
     if platform != cc_platform and "pkg" in itypes and not cc_platform.startswith("osx-"):
         sys.exit("Error: cannot construct a macOS 'pkg' installer on '%s'" % cc_platform)
 

--- a/news/1266-add-installer-type-cli
+++ b/news/1266-add-installer-type-cli
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add a `--installer-type` command line option to build only a single installer type (`sh`, `pkg`, `exe`, or `msi`), overriding `installer_type` from the configuration. (#1266)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,6 +25,7 @@ from ruamel.yaml import YAML
 
 from constructor.conda_interface import cc_platform
 from constructor.construct import parse as parse_construct
+from constructor.main import get_installer_type
 from constructor.utils import (
     StandaloneExe,
     check_version,
@@ -611,17 +612,22 @@ def _run_installer(
     return process
 
 
-def create_installer(
+def _build_installers(
     input_dir: Path,
     workspace: Path,
+    installer_type: str | None = None,
     conda_exe=CONSTRUCTOR_CONDA_EXE,
     debug=CONSTRUCTOR_DEBUG,
-    with_spaces=False,
     timeout=420,
     config_filename="construct.yaml",
     extra_constructor_args: Iterable[str] = None,
     **env_vars,
-) -> Generator[tuple[Path, Path], None, None]:
+) -> Path:
+    """Run constructor and return the output directory holding the artifact(s).
+
+    installer_type=None builds all applicable types (current behavior); a value
+    passes --installer-type to build exactly one.
+    """
     if sys.platform.startswith("win") and conda_exe and _is_micromamba(conda_exe):
         pytest.skip("Micromamba is not supported on Windows yet.")
 
@@ -639,7 +645,8 @@ def create_installer(
         "--config-filename",
         config_filename,
     ]
-
+    if installer_type:
+        cmd += ["--installer-type", installer_type]
     if conda_exe:
         cmd.extend(["--conda-exe", conda_exe])
     if debug:
@@ -648,8 +655,87 @@ def create_installer(
         cmd.extend(extra_constructor_args)
 
     _execute(cmd, timeout=timeout, **env_vars)
+    return output_dir
 
+
+def _install_dir_for(
+    installer: Path,
+    input_dir: Path,
+    workspace: Path,
+    config_filename: str,
+    with_spaces: bool,
+) -> Path:
     install_dir_prefix = "i n s t a l l" if with_spaces else "install"
+    if installer.suffix == ".pkg" and ON_CI:
+        return Path("~").expanduser() / calculate_install_dir(input_dir / config_filename)
+    elif installer.suffix == ".msi":
+        return calculate_msi_install_path(input_dir / config_filename)
+    else:
+        return workspace / f"{install_dir_prefix}-{installer.stem}-{installer.suffix[1:]}"
+
+
+def installer_types_for_example(
+    example_path: Path, config_filename: str = "construct.yaml"
+) -> tuple[str, ...]:
+    """Installer types this example builds on the current platform.
+
+    Reuses constructor's own get_installer_type() so the test parametrization
+    matches what the build actually produces.
+    """
+    info = parse_construct(str(example_path / config_filename), platform=cc_platform)
+    info["_platform"] = cc_platform
+    return get_installer_type(info)
+
+
+def create_single_installer(
+    input_dir: Path,
+    workspace: Path,
+    installer_type: str,
+    *,
+    with_spaces=False,
+    timeout=420,
+    config_filename="construct.yaml",
+    extra_constructor_args: Iterable[str] = None,
+    **env_vars,
+) -> tuple[Path, Path]:
+    """Build exactly one installer type; return (installer_path, install_dir)."""
+    output_dir = _build_installers(
+        input_dir,
+        workspace,
+        installer_type=installer_type,
+        timeout=timeout,
+        config_filename=config_filename,
+        extra_constructor_args=extra_constructor_args,
+        **env_vars,
+    )
+    installer = next(output_dir.glob(f"*.{installer_type}"), None)
+    if installer is None:
+        raise FileNotFoundError(f"No .{installer_type} installer found in {output_dir}")
+    install_dir = _install_dir_for(installer, input_dir, workspace, config_filename, with_spaces)
+    return installer, install_dir
+
+
+def create_installer(
+    input_dir: Path,
+    workspace: Path,
+    conda_exe=CONSTRUCTOR_CONDA_EXE,
+    debug=CONSTRUCTOR_DEBUG,
+    with_spaces=False,
+    timeout=420,
+    config_filename="construct.yaml",
+    extra_constructor_args: Iterable[str] = None,
+    **env_vars,
+) -> Generator[tuple[Path, Path], None, None]:
+    output_dir = _build_installers(
+        input_dir,
+        workspace,
+        conda_exe=conda_exe,
+        debug=debug,
+        timeout=timeout,
+        config_filename=config_filename,
+        extra_constructor_args=extra_constructor_args,
+        **env_vars,
+    )
 
     def _sort_by_extension(path):
         "Return shell installers first so they are run before the GUI ones"
@@ -657,17 +743,9 @@ def create_installer(
 
     installers = (p for p in output_dir.iterdir() if p.suffix in (".exe", ".msi", ".sh", ".pkg"))
     for installer in sorted(installers, key=_sort_by_extension):
-        if installer.suffix == ".pkg" and ON_CI:
-            install_dir = Path("~").expanduser() / calculate_install_dir(
-                input_dir / config_filename
-            )
-        elif installer.suffix == ".msi":
-            install_dir = calculate_msi_install_path(input_dir / config_filename)
-        else:
-            install_dir = (
-                workspace / f"{install_dir_prefix}-{installer.stem}-{installer.suffix[1:]}"
-            )
-
+        install_dir = _install_dir_for(
+            installer, input_dir, workspace, config_filename, with_spaces
+        )
         yield installer, install_dir
         if KEEP_ARTIFACTS_PATH:
             try:
@@ -695,6 +773,17 @@ def _example_path(example_name):
 def _is_micromamba(path) -> bool:
     name, _ = identify_conda_exe(path)
     return name == StandaloneExe.MAMBA
+
+
+def test_installer_types_for_example_matches_platform():
+    """Validate any example with 'installer_type: all'; and that the resolved types match the platform set."""
+    types = installer_types_for_example(_example_path("miniforge"))
+    if sys.platform.startswith("linux"):
+        assert types == ("sh",)
+    elif sys.platform == "darwin":
+        assert types == ("sh", "pkg")
+    elif sys.platform.startswith("win"):
+        assert types == ("exe", "msi")
 
 
 @pytest.fixture(params=["linux-aarch64"])
@@ -798,75 +887,95 @@ def test_example_mirrored_channels(tmp_path, request):
         assert condarc_data == expected_condarc
 
 
-@pytest.mark.xfail(
+def _check_miniforge(
+    input_path, installer_name, installer_version, installer_type, tmp_path, request
+):
+    """Helper function for the existing miniforge examples."""
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    if installer_type == "sh":
+        # try both batch and interactive installations
+        install_dirs = (install_dir / "batch", install_dir / "interactive")
+        installer_inputs = (None, f"\nyes\n{install_dir / 'interactive'}\nno\nno\n")
+    else:
+        install_dirs = (install_dir,)
+        installer_inputs = (None,)
+    for installer_input, install_dir in zip(installer_inputs, install_dirs):
+        _run_installer(
+            input_path,
+            installer,
+            install_dir,
+            installer_input=installer_input,
+            request=request,
+            # PKG installers use their own install path, so we can't check sentinels
+            # via `install_dir`
+            check_sentinels=installer_type != "pkg",
+            uninstall=False,
+        )
+        # Check that key metadata files are in place
+        assert install_dir.glob("conda-meta/*.json")
+        assert install_dir.glob("pkgs/cache/*.json")  # enables offline installs
+        # Check that the installer info file is in place
+        info_file_name = ".installer.info"
+        if installer_type == "msi":
+            info_file = install_dir / "base" / info_file_name
+        else:
+            info_file = install_dir / info_file_name
+        assert info_file.is_file()
+        installer_info = json.loads(info_file.read_text())
+        assert installer_info["name"] == installer_name
+        assert installer_info["version"] == installer_version
+        assert installer_info["platform"] == cc_platform
+        assert installer_info["type"] == installer_type
+        if installer_type == "pkg" and ON_CI:
+            _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / installer_name)
+        if installer_type == "exe":
+            for key in ("ProgramData", "AppData"):
+                start_menu_dir = Path(
+                    os.environ[key],
+                    "Microsoft/Windows/Start Menu/Programs/Miniforge3",
+                )
+                if start_menu_dir.is_dir():
+                    assert list(start_menu_dir.glob("Miniforge*.lnk"))
+                    break
+            else:
+                raise AssertionError("Could not find Start Menu folder for miniforge")
+            _run_uninstaller_exe(install_dir)
+            assert not list(start_menu_dir.glob("Miniforge*.lnk"))
+        elif installer_type == "msi":
+            # TODO: Start menus
+            _run_uninstaller_msi(installer, install_dir)
+
+
+_MINIFORGE_XFAIL = pytest.mark.xfail(
     (
         CONDA_EXE == StandaloneExe.CONDA
         and not check_version(CONDA_EXE_VERSION, min_version="23.11.0a0")
     ),
     reason="Known issue with conda-standalone<=23.10: shortcuts are created but not removed.",
 )
+
+
+@_MINIFORGE_XFAIL
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("miniforge")))
+def test_example_miniforge(tmp_path, request, installer_type):
+    _check_miniforge(
+        _example_path("miniforge"), "Miniforge3", "25.0.0-1", installer_type, tmp_path, request
+    )
+
+
+@_MINIFORGE_XFAIL
 @pytest.mark.parametrize(
-    "example, installer_name, installer_version",
-    [
-        ("miniforge", "Miniforge3", "25.0.0-1"),
-        ("miniforge-mamba2", "Miniforge3-mamba2", "25.1.1-0"),
-    ],
+    "installer_type", installer_types_for_example(_example_path("miniforge-mamba2"))
 )
-def test_example_miniforge(tmp_path, request, example, installer_name, installer_version):
-    input_path = _example_path(example)
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        if installer.suffix == ".sh":
-            # try both batch and interactive installations
-            install_dirs = (install_dir / "batch", install_dir / "interactive")
-            installer_inputs = (None, f"\nyes\n{install_dir / 'interactive'}\nno\nno\n")
-        else:
-            install_dirs = (install_dir,)
-            installer_inputs = (None,)
-        for installer_input, install_dir in zip(installer_inputs, install_dirs):
-            _run_installer(
-                input_path,
-                installer,
-                install_dir,
-                installer_input=installer_input,
-                request=request,
-                # PKG installers use their own install path, so we can't check sentinels
-                # via `install_dir`
-                check_sentinels=installer.suffix != ".pkg",
-                uninstall=False,
-            )
-            # Check that key metadata files are in place
-            assert install_dir.glob("conda-meta/*.json")
-            assert install_dir.glob("pkgs/cache/*.json")  # enables offline installs
-            # Check that the installer info file is in place
-            info_file_name = ".installer.info"
-            if installer.suffix == ".msi":
-                info_file = install_dir / "base" / info_file_name
-            else:
-                info_file = install_dir / info_file_name
-            assert info_file.is_file()
-            installer_info = json.loads(info_file.read_text())
-            assert installer_info["name"] == installer_name
-            assert installer_info["version"] == installer_version
-            assert installer_info["platform"] == cc_platform
-            assert installer_info["type"] == installer.suffix[1:]
-            if installer.suffix == ".pkg" and ON_CI:
-                _sentinel_file_checks(input_path, Path(os.environ["HOME"]) / installer_name)
-            if installer.suffix == ".exe":
-                for key in ("ProgramData", "AppData"):
-                    start_menu_dir = Path(
-                        os.environ[key],
-                        "Microsoft/Windows/Start Menu/Programs/Miniforge3",
-                    )
-                    if start_menu_dir.is_dir():
-                        assert list(start_menu_dir.glob("Miniforge*.lnk"))
-                        break
-                else:
-                    raise AssertionError("Could not find Start Menu folder for miniforge")
-                _run_uninstaller_exe(install_dir)
-                assert not list(start_menu_dir.glob("Miniforge*.lnk"))
-            elif installer.suffix == ".msi":
-                # TODO: Start menus
-                _run_uninstaller_msi(installer, install_dir)
+def test_example_miniforge_mamba2(tmp_path, request, installer_type):
+    _check_miniforge(
+        _example_path("miniforge-mamba2"),
+        "Miniforge3-mamba2",
+        "25.1.1-0",
+        installer_type,
+        tmp_path,
+        request,
+    )
 
 
 def test_example_noconda(tmp_path, request):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,4 +49,4 @@ def test_installer_type_flag_invalid_for_platform(tmp_path):
     bad = "sh" if sys.platform.startswith("win") else "exe"
     with pytest.raises(SystemExit) as exc:
         main([str(tmp_path), "--installer-type", bad, "--dry-run"])
-    assert "not available" in str(exc.value)
+    assert "invalid installer type" in str(exc.value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,21 @@
+import sys
 from textwrap import dedent
 
+import pytest
+
 from constructor.main import main
+
+_CONSTRUCT = dedent(
+    """
+    name: test_installer_type_flag
+    version: 1.0.0
+    installer_type: all
+    channels:
+      - conda-forge
+    specs:
+      - ca-certificates
+    """
+)
 
 
 def test_dry_run(tmp_path):
@@ -17,3 +32,21 @@ def test_dry_run(tmp_path):
     )
     (tmp_path / "construct.yaml").write_text(inputfile)
     main([str(tmp_path), "--dry-run"])
+
+
+def test_installer_type_flag_valid(tmp_path):
+    """Test that --installer-type dont exit with error for valid types."""
+    (tmp_path / "construct.yaml").write_text(_CONSTRUCT)
+    # No need to test all types
+    itype = "exe" if sys.platform.startswith("win") else "sh"
+    assert main([str(tmp_path), "--installer-type", itype, "--dry-run"]) is None
+
+
+def test_installer_type_flag_invalid_for_platform(tmp_path):
+    """Test that a type not valid for the current platform/config exits with the expected error message."""
+    (tmp_path / "construct.yaml").write_text(_CONSTRUCT)
+    # Pick a type that is never valid on this platform.
+    bad = "sh" if sys.platform.startswith("win") else "exe"
+    with pytest.raises(SystemExit) as exc:
+        main([str(tmp_path), "--installer-type", bad, "--dry-run"])
+    assert "not available" in str(exc.value)


### PR DESCRIPTION
### Description
Solves https://github.com/conda/constructor/issues/1146. The file `test_examples.py` runs every applicable installer type for an example in a single constructor call and loops over them, which interleaves build/run output and gives no test isolation. When one type fails, the others are masked or skipped, making CI failures painful to debug.

This PR adds the infrastructure to run each installer type as its own pytest item:
- A flag `--installer-type` to allow testing a specific installer type via the CLI
- Removes the for-loop for iterating over installer types - now uses pytest parametrization (which is based on the `installer_types` field in each example recipe).
- For demonstrating the changes, this PR migrates only `test_example_miniforge` (split into `miniforge` and `miniforge-mamba2`, each parametrized over its own recipe's types).

The remaining example tests are intentionally left unchanged here to keep this PR small and easy to review. A follow-up PR is expected once this is approved and merged.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
