### PR TITLE
Update test; use lazy import

### DIFF
--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -8,7 +8,6 @@ except ModuleNotFoundError:
     import tomli as tomllib
 
 import pytest
-from PIL import Image
 
 from constructor.briefcase import (
     Payload,
@@ -1040,6 +1039,10 @@ def test_payload_pyproject_toml_installer_images(tmp_path, has_user_images):
     info = mock_info.copy()
 
     if has_user_images:
+        # Imported lazily: pillow is a Windows/macOS-only dependency (see recipe/meta.yaml),
+        # so a module-level import would break test collection on Linux (e.g. canary builds).
+        from PIL import Image
+
         # Create a minimal test image. We avoid using files from examples/ because canary
         # builds run tests in an isolated conda-build environment where only the directories
         # listed in recipe/meta.yaml's source_files are available.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed this test failed: https://github.com/conda/constructor/actions/runs/27795032460/job/82713863768
```
ModuleNotFoundError: No module named 'PIL'
```
I recall we discussed this in a separate PR, because why don't the other linux tests fail when we have `- pillow >=3.1  # [osx or win]`? To my understanding that selector is a `conda-build` recipe selector and is not honored in the other jobs - for example looking at the other linux jobs you can see in the logs that `pillow` is installed.

That being said, I updated the test to do a lazy import since the test is a Windows test anyway.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
