### PR TITLE
Fix AzureSignTool signature verification for paths with spaces

### DIFF
--- a/constructor/signing.py
+++ b/constructor/signing.py
@@ -193,7 +193,7 @@ class AzureSignTool(SigningTool):
             logger.error("Could not verify signature: PowerShell not found.")
             return
         command = (
-            f"$sig = Get-AuthenticodeSignature -LiteralPath {installer_file};"
+            f"$sig = Get-AuthenticodeSignature -LiteralPath '{installer_file}';"
             "$sig.Status.value__;"
             "$sig.StatusMessage"
         )

--- a/examples/azure_signtool/construct.yaml
+++ b/examples/azure_signtool/construct.yaml
@@ -3,7 +3,7 @@
 
 name: Signed_AzureSignTool
 version: 1.0.0
-installer_type: exe
+installer_type: [exe, msi]
 channels:
   - https://repo.anaconda.com/pkgs/main/
 specs:

--- a/news/1273-fix-msi-signing-spaces
+++ b/news/1273-fix-msi-signing-spaces
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `AzureSignTool` signature verification failing for installer paths that contain spaces. (#1273)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,23 @@
+import sys
+
+import pytest
+
+from constructor.signing import AzureSignTool
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+def test_azure_verify_signature_quotes_path_with_spaces(mocker):
+    """Test that installer paths containing spaces are quoted in the PowerShell command."""
+    tool = AzureSignTool()
+    installer = r"C:\Users\runner\Some Product\foo.msi"
+
+    mocker.patch("constructor.signing.shutil.which", return_value="powershell")
+    mock_run = mocker.patch("constructor.signing.run")
+    mock_run.return_value.stderr = ""
+    mock_run.return_value.stdout = "0\nSignature verified.\n"
+
+    tool.verify_signature(installer)
+
+    # argv passed to run() is ["powershell", "-c", command]
+    command = mock_run.call_args.args[0][2]
+    assert f"-LiteralPath '{installer}'" in command


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`AzureSignTool.verify_signature` interpolated the installer path into the PowerShell `Get-AuthenticodeSignature` command without quoting it. When the path contained a space, PowerShell split it into multiple positional arguments and failed with `A positional parameter cannot be found that accepts argument...`.
This is not a new bug but was discovered when trying to add signing of MSI installers to a CI workflow (whose Briefcase output is nested under a `<name> <version>` directory - always contains a space).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
