### PR TITLE
Fix installer option inconsistency between EXE/MSI

### DIFF
--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -367,7 +367,8 @@ def create_install_options_list(info: dict) -> list[dict]:
                     "name": f"{script_type}_install_script",
                     "title": f"{script_type.capitalize()}-install script",
                     "description": script_description,
-                    "default": False,
+                    # Mirror NSIS: default to enabled when the script exists.
+                    "default": bool(script),
                 }
             )
 

--- a/examples/scripts/post_install.bat
+++ b/examples/scripts/post_install.bat
@@ -2,19 +2,23 @@ echo Added by post-install script > "%PREFIX%\post_install_sentinel.txt"
 if not "%INSTALLER_NAME%" == "Scripts" exit 1
 if not "%INSTALLER_VER%" == "1.0.0" exit 1
 if not "%INSTALLER_PLAT%" == "win-64" exit 1
-if not "%INSTALLER_TYPE%" == "EXE" exit 1
-if not "%INSTALLER_UNATTENDED%" == "1" exit 1
+if not "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_TYPE%" == "MSI" exit 1
+rem INSTALLER_UNATTENDED is only set by EXE installers.
+if "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_UNATTENDED%" == "1" exit 1
 if "%PREFIX%" == "" exit 1
 if not "%CUSTOM_VARIABLE_1%" == "FIR$T-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1
 if not "%CUSTOM_VARIABLE_2%" == "$ECOND-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1
 if not exist "%PREFIX%\pre_install_sentinel.txt" exit 1
 
-if not exist "%INSTALLER_PATH%" (
-  echo ERROR: "INSTALLER_PATH=%INSTALLER_PATH%" points to a file that does not exist!
-  exit 1
-)
+rem INSTALLER_PATH and INSTALLER_PLUGINSDIR are only set by EXE installers.
+if "%INSTALLER_TYPE%" == "EXE" (
+  if not exist "%INSTALLER_PATH%" (
+    echo ERROR: "INSTALLER_PATH=%INSTALLER_PATH%" points to a file that does not exist!
+    exit 1
+  )
 
-if not exist "%INSTALLER_PLUGINSDIR%" (
-  echo ERROR: "INSTALLER_PLUGINSDIR=%INSTALLER_PLUGINSDIR%" points to a directory that does not exist!
-  exit 1
+  if not exist "%INSTALLER_PLUGINSDIR%" (
+    echo ERROR: "INSTALLER_PLUGINSDIR=%INSTALLER_PLUGINSDIR%" points to a directory that does not exist!
+    exit 1
+  )
 )

--- a/examples/scripts/post_install.bat
+++ b/examples/scripts/post_install.bat
@@ -3,7 +3,7 @@ if not "%INSTALLER_NAME%" == "Scripts" exit 1
 if not "%INSTALLER_VER%" == "1.0.0" exit 1
 if not "%INSTALLER_PLAT%" == "win-64" exit 1
 if not "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_TYPE%" == "MSI" exit 1
-rem INSTALLER_UNATTENDED is only set by EXE installers.
+rem INSTALLER_UNATTENDED is not yet set by MSI installers (see conda/constructor#1276).
 if "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_UNATTENDED%" == "1" exit 1
 if "%PREFIX%" == "" exit 1
 if not "%CUSTOM_VARIABLE_1%" == "FIR$T-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1

--- a/examples/scripts/pre_install.bat
+++ b/examples/scripts/pre_install.bat
@@ -2,7 +2,7 @@ if not "%INSTALLER_NAME%" == "Scripts" exit 1
 if not "%INSTALLER_VER%" == "1.0.0" exit 1
 if not "%INSTALLER_PLAT%" == "win-64" exit 1
 if not "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_TYPE%" == "MSI" exit 1
-rem INSTALLER_UNATTENDED is only set by EXE installers.
+rem INSTALLER_UNATTENDED is not yet set by MSI installers (see conda/constructor#1276).
 if "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_UNATTENDED%" == "1" exit 1
 if "%PREFIX%" == "" exit 1
 if not "%CUSTOM_VARIABLE_1%" == "FIR$T-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1

--- a/examples/scripts/pre_install.bat
+++ b/examples/scripts/pre_install.bat
@@ -1,8 +1,9 @@
 if not "%INSTALLER_NAME%" == "Scripts" exit 1
 if not "%INSTALLER_VER%" == "1.0.0" exit 1
 if not "%INSTALLER_PLAT%" == "win-64" exit 1
-if not "%INSTALLER_TYPE%" == "EXE" exit 1
-if not "%INSTALLER_UNATTENDED%" == "1" exit 1
+if not "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_TYPE%" == "MSI" exit 1
+rem INSTALLER_UNATTENDED is only set by EXE installers.
+if "%INSTALLER_TYPE%" == "EXE" if not "%INSTALLER_UNATTENDED%" == "1" exit 1
 if "%PREFIX%" == "" exit 1
 if not "%CUSTOM_VARIABLE_1%" == "FIR$T-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1
 if not "%CUSTOM_VARIABLE_2%" == "$ECOND-CUSTOM_STRING WITH SPACES AND @*! CHARACTERS" exit 1

--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -14,6 +14,7 @@ from constructor.briefcase import (
     _get_python_info,
     _get_script_env_variables,
     _setup_envs_commands,
+    create_install_options_list,
     create_uninstall_options_list,
     get_bundle_app_name,
     get_license,
@@ -643,6 +644,25 @@ def test_create_uninstall_options_list():
     assert "remove_user_data" in option_names
     assert "remove_caches" in option_names
     assert "remove_config_files" in option_names
+
+
+@pytest.mark.parametrize("script_type", ["pre", "post"])
+def test_install_options_script_default_enabled(tmp_path, script_type):
+    """Pre/post-install script options default to enabled when a script exists.
+
+    This mirrors the NSIS installer, which checks the box by default when the
+    script is present (see nsis/main.nsi.tmpl).
+    """
+    script = tmp_path / f"{script_type}_install.bat"
+    script.write_text("@echo script")
+
+    info = mock_info.copy()
+    info[f"{script_type}_install"] = str(script)
+    info[f"{script_type}_install_desc"] = "Custom script description"
+
+    options = create_install_options_list(info)
+    option = next(opt for opt in options if opt["name"] == f"{script_type}_install_script")
+    assert option["default"] is True
 
 
 def test_render_templates_with_virtual_specs():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
I noticed during local testing that two of the installer options default values were hardcoded `False` instead of using the same approach as the EXE installers. This PR fixes that and updates a test to account for this (since these were default `False` the test example pre/post uninstall/install scripts were never run by the MSI installer).

I also did another check to see if any other option was inconsistently set but these two were the only ones I found.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
