### PR TITLE
Migrate more test examples to use pytest parametrization

### DIFF
--- a/constructor/exceptions.py
+++ b/constructor/exceptions.py
@@ -57,3 +57,9 @@ class UnableToParseMissingJinja2(UnableToParse):
             """),
             ]
         )
+
+
+class InvalidInstallerTypeError(Exception):
+    """Raised when installer_type is invalid for the target platform."""
+
+    pass

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -30,6 +30,7 @@ from .construct import SCHEMA_PATH, ns_platform
 from .construct import parse as construct_parse
 from .construct import render as construct_render
 from .construct import verify as construct_verify
+from .exceptions import InvalidInstallerTypeError
 from .fcp import main as fcp_main
 from .utils import (
     StandaloneExe,
@@ -46,6 +47,13 @@ logger = logging.getLogger(__name__)
 
 
 def get_installer_type(info: dict):
+    """Return the installer type(s) to build for the given platform.
+
+    Raises
+    ------
+    InvalidInstallerTypeError
+        If the installer type is not valid for the target platform.
+    """
     osname, unused_arch = info["_platform"].split("-")
 
     os_allowed = {"linux": ("sh",), "osx": ("sh", "pkg"), "win": ("exe", "msi")}
@@ -62,28 +70,31 @@ def get_installer_type(info: dict):
         for t in itype:
             if t not in all_allowed:
                 all_allowed_str = ", ".join(sorted(all_allowed))
-                sys.exit("Error: invalid installer type '%s'; allowed: %s" % (t, all_allowed_str))
+                raise InvalidInstallerTypeError(
+                    f"invalid installer type '{t}'; allowed: {all_allowed_str}"
+                )
             if t not in os_allowed[osname]:
                 os_allowed_str = ", ".join(sorted(os_allowed[osname]))
-                sys.exit(
-                    "Error: invalid installer type '%s' for %s; allowed: %s"
-                    % (t, osname, os_allowed_str)
+                raise InvalidInstallerTypeError(
+                    f"invalid installer type '{t}' for {osname}; allowed: {os_allowed_str}"
                 )
         return tuple(itype)
     elif itype not in all_allowed:
-        all_allowed = ", ".join(sorted(all_allowed))
-        sys.exit("Error: invalid installer type '%s'; allowed: %s" % (itype, all_allowed))
+        all_allowed_str = ", ".join(sorted(all_allowed))
+        raise InvalidInstallerTypeError(
+            f"invalid installer type '{itype}'; allowed: {all_allowed_str}"
+        )
     elif itype == "docker":
         if osname != "linux":
-            sys.exit(
-                "Error: Docker features are only supported for Linux target platforms. "
+            raise InvalidInstallerTypeError(
+                "Docker features are only supported for Linux target platforms. "
                 "Use --platform linux-ARCH to build a Docker artifact."
             )
         return ("sh", "docker")
     elif itype not in os_allowed[osname]:
-        os_allowed = ", ".join(sorted(os_allowed[osname]))
-        sys.exit(
-            "Error: invalid installer type '%s' for %s; allowed: %s" % (itype, osname, os_allowed)
+        os_allowed_str = ", ".join(sorted(os_allowed[osname]))
+        raise InvalidInstallerTypeError(
+            f"invalid installer type '{itype}' for {osname}; allowed: {os_allowed_str}"
         )
     else:
         return (itype,)
@@ -234,7 +245,10 @@ def main_build(
     info["_debug"] = debug
     if installer_type:
         info["installer_type"] = installer_type
-    itypes = get_installer_type(info)
+    try:
+        itypes = get_installer_type(info)
+    except InvalidInstallerTypeError as e:
+        sys.exit(f"Error: {e}")
 
     if "docker" in itypes:
         if not info.get("docker_base_image"):

--- a/examples/azure_signtool/construct.yaml
+++ b/examples/azure_signtool/construct.yaml
@@ -3,7 +3,9 @@
 
 name: Signed_AzureSignTool
 version: 1.0.0
-installer_type: [exe, msi]  # [win]
+installer_type:
+  - exe
+  - msi
 channels:
   - https://repo.anaconda.com/pkgs/main/
 specs:

--- a/examples/azure_signtool/construct.yaml
+++ b/examples/azure_signtool/construct.yaml
@@ -3,7 +3,7 @@
 
 name: Signed_AzureSignTool
 version: 1.0.0
-installer_type: [exe, msi]
+installer_type: [exe, msi]  # [win]
 channels:
   - https://repo.anaconda.com/pkgs/main/
 specs:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -829,31 +829,35 @@ def test_example_customized_welcome_conclusion(tmp_path, request, installer_type
 
 
 @pytest.mark.parametrize("extra_pages", ("str", "list"))
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("exe_extra_pages"))
+)
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_example_extra_pages_win(tmp_path, request, extra_pages, monkeypatch):
+def test_example_extra_pages_win(tmp_path, request, extra_pages, installer_type, monkeypatch):
     if extra_pages == "list":
         monkeypatch.setenv("POST_INSTALL_PAGES_LIST", "1")
     input_path = _example_path("exe_extra_pages")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
-def test_example_extra_envs(tmp_path, request):
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("extra_envs")))
+def test_example_extra_envs(tmp_path, request, installer_type):
     input_path = _example_path("extra_envs")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
-        base = (install_dir / "base") if installer.suffix == ".msi" else install_dir
-        assert "@EXPLICIT" in (base / "conda-meta" / "initial-state.explicit.txt").read_text()
-        for env in base.glob("envs/*/conda-meta/"):
-            envtxt = env / "initial-state.explicit.txt"
-            assert envtxt.exists()
-            assert "@EXPLICIT" in envtxt.read_text()
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
+    base = (install_dir / "base") if installer_type == "msi" else install_dir
+    assert "@EXPLICIT" in (base / "conda-meta" / "initial-state.explicit.txt").read_text()
+    for env in base.glob("envs/*/conda-meta/"):
+        envtxt = env / "initial-state.explicit.txt"
+        assert envtxt.exists()
+        assert "@EXPLICIT" in envtxt.read_text()
 
-        if sys.platform.startswith("win"):
-            if installer.suffix == ".msi":
-                _run_uninstaller_msi(installer, install_dir)
-            else:
-                _run_uninstaller_exe(install_dir=install_dir)
+    if sys.platform.startswith("win"):
+        if installer_type == "msi":
+            _run_uninstaller_msi(installer, install_dir)
+        else:
+            _run_uninstaller_exe(install_dir=install_dir)
 
 
 @pytest.mark.parametrize(
@@ -1148,54 +1152,56 @@ def test_example_scripts(tmp_path, request, installer_type):
     ),
     reason="menuinst v2 requires conda-standalone>=23.11.0; micromamba is not supported yet",
 )
-def test_example_shortcuts(tmp_path, request):
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("shortcuts")))
+def test_example_shortcuts(tmp_path, request, installer_type):
     input_path = _example_path("shortcuts")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        # console_shortcut package uses hardcoded "Anaconda3" in its menu definition
-        distribution_name = "Anaconda3"
-        if sys.platform == "win32":
-            # Verify shortcuts don't exist before installation (not leftover from previous run (since EXE/MSI run in a loop))
-            for key in ("ProgramData", "AppData"):
-                start_menu = Path(os.environ[key]) / "Microsoft/Windows/Start Menu/Programs"
-                package_1 = start_menu / "Package 1"
-                if package_1.is_dir():
-                    assert not (package_1 / "A.lnk").is_file(), "A.lnk exists before installation"
-                    assert not (package_1 / "B.lnk").is_file(), "B.lnk exists before installation"
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    # console_shortcut package uses hardcoded "Anaconda3" in its menu definition
+    distribution_name = "Anaconda3"
+    if sys.platform == "win32":
+        # Verify shortcuts don't exist before this installation (not leftover from a
+        # previous per-type run)
+        for key in ("ProgramData", "AppData"):
+            start_menu = Path(os.environ[key]) / "Microsoft/Windows/Start Menu/Programs"
+            package_1 = start_menu / "Package 1"
+            if package_1.is_dir():
+                assert not (package_1 / "A.lnk").is_file(), "A.lnk exists before installation"
+                assert not (package_1 / "B.lnk").is_file(), "B.lnk exists before installation"
 
-        _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
-        # check that the shortcuts are created
-        if sys.platform == "win32":
-            for key in ("ProgramData", "AppData"):
-                start_menu = Path(os.environ[key]) / "Microsoft/Windows/Start Menu/Programs"
-                package_1 = start_menu / "Package 1"
-                console_shortcut_dir = start_menu / f"{distribution_name} (64-bit)"
-                if package_1.is_dir() and console_shortcut_dir.is_dir():
-                    assert (package_1 / "A.lnk").is_file()
-                    assert (package_1 / "B.lnk").is_file()
-                    # The shortcut created from the 'base' env
-                    # should not exist because we filtered it out in the YAML
-                    # We do expect one shortcut from 'another_env'
-                    assert not (console_shortcut_dir / "Anaconda Prompt.lnk").is_file()
-                    assert (console_shortcut_dir / "Anaconda Prompt (another_env).lnk").is_file()
-                    break
-            else:
-                raise AssertionError(f"No shortcuts found! Expected '{distribution_name} (64-bit)'")
-            if installer.suffix == ".msi":
-                _run_uninstaller_msi(installer, install_dir)
-            else:
-                _run_uninstaller_exe(install_dir)
-            assert not (package_1 / "A.lnk").is_file()
-            assert not (package_1 / "B.lnk").is_file()
-        elif sys.platform == "darwin":
-            applications = Path("~/Applications").expanduser()
-            print("Shortcuts found:", sorted(applications.glob("**/*.app")))
-            assert (applications / "A.app").exists()
-            assert (applications / "B.app").exists()
-        elif sys.platform == "linux":
-            applications = Path("~/.local/share/applications").expanduser()
-            print("Shortcuts found:", sorted(applications.glob("**/*.desktop")))
-            assert (applications / "package-1_a.desktop").exists()
-            assert (applications / "package-1_b.desktop").exists()
+    _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
+    # check that the shortcuts are created
+    if sys.platform == "win32":
+        for key in ("ProgramData", "AppData"):
+            start_menu = Path(os.environ[key]) / "Microsoft/Windows/Start Menu/Programs"
+            package_1 = start_menu / "Package 1"
+            console_shortcut_dir = start_menu / f"{distribution_name} (64-bit)"
+            if package_1.is_dir() and console_shortcut_dir.is_dir():
+                assert (package_1 / "A.lnk").is_file()
+                assert (package_1 / "B.lnk").is_file()
+                # The shortcut created from the 'base' env
+                # should not exist because we filtered it out in the YAML
+                # We do expect one shortcut from 'another_env'
+                assert not (console_shortcut_dir / "Anaconda Prompt.lnk").is_file()
+                assert (console_shortcut_dir / "Anaconda Prompt (another_env).lnk").is_file()
+                break
+        else:
+            raise AssertionError(f"No shortcuts found! Expected '{distribution_name} (64-bit)'")
+        if installer_type == "msi":
+            _run_uninstaller_msi(installer, install_dir)
+        else:
+            _run_uninstaller_exe(install_dir)
+        assert not (package_1 / "A.lnk").is_file()
+        assert not (package_1 / "B.lnk").is_file()
+    elif sys.platform == "darwin":
+        applications = Path("~/Applications").expanduser()
+        print("Shortcuts found:", sorted(applications.glob("**/*.app")))
+        assert (applications / "A.app").exists()
+        assert (applications / "B.app").exists()
+    elif sys.platform == "linux":
+        applications = Path("~/.local/share/applications").expanduser()
+        print("Shortcuts found:", sorted(applications.glob("**/*.desktop")))
+        assert (applications / "package-1_a.desktop").exists()
+        assert (applications / "package-1_b.desktop").exists()
 
 
 def _verify_windows_signature(installer: Path):
@@ -1217,7 +1223,8 @@ def _verify_windows_signature(installer: Path):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_example_signing(tmp_path, request):
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("signing")))
+def test_example_signing(tmp_path, request, installer_type):
     input_path = _example_path("signing")
     cert_path = tmp_path / "self-signed-cert.pfx"
     cert_pwd = "1234"
@@ -1226,15 +1233,16 @@ def test_example_signing(tmp_path, request):
     certificate_in_input_dir = input_path / "certificate.pfx"
     shutil.copy(str(cert_path), str(certificate_in_input_dir))
     request.addfinalizer(lambda: certificate_in_input_dir.unlink())
-    for installer, install_dir in create_installer(
+    installer, install_dir = create_single_installer(
         input_path,
         tmp_path,
+        installer_type,
         with_spaces=True,
         CONSTRUCTOR_SIGNING_CERTIFICATE=str(cert_path),
         CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD=cert_pwd,
-    ):
-        _verify_windows_signature(installer)
-        _run_installer(input_path, installer, install_dir, request=request)
+    )
+    _verify_windows_signature(installer)
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
@@ -1242,11 +1250,12 @@ def test_example_signing(tmp_path, request):
     not shutil.which("azuresigntool") and not os.environ.get("AZURE_SIGNTOOL_PATH"),
     reason="AzureSignTool not available",
 )
+@pytest.mark.parametrize("installer_type", ["exe"])
 @pytest.mark.parametrize(
     "auth_method",
     os.environ.get("AZURE_SIGNTOOL_TEST_AUTH_METHODS", "token,secret").split(","),
 )
-def test_azure_signtool(tmp_path, request, monkeypatch, auth_method):
+def test_azure_signtool(tmp_path, request, monkeypatch, auth_method, installer_type):
     """Test signing installers with AzureSignTool.
 
     There are three ways to authenticate with Azure: tokens, secrets, and managed identities.
@@ -1267,11 +1276,8 @@ def test_azure_signtool(tmp_path, request, monkeypatch, auth_method):
     else:
         pytest.skip(f"Unknown authentication method {auth_method}.")
     input_path = _example_path("azure_signtool")
-    for installer, install_dir in create_installer(
-        input_path,
-        tmp_path,
-    ):
-        _run_installer(input_path, installer, install_dir, request=request)
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
 @pytest.mark.parametrize(
@@ -1291,59 +1297,74 @@ def test_example_use_channel_remap(tmp_path, request, installer_type):
         assert pkg["channel"] == "private_repo"
 
 
-def test_example_from_existing_env(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("from_existing_env"))
+)
+def test_example_from_existing_env(tmp_path, request, installer_type):
     input_path = _example_path("from_existing_env")
     subprocess.check_call(
         [sys.executable, "-mconda", "create", "-p", tmp_path / "env", "-y", "python"]
     )
-    for installer, install_dir in create_installer(
+    installer, install_dir = create_single_installer(
         input_path,
         tmp_path,
+        installer_type,
         CONSTRUCTOR_TEST_EXISTING_ENV=str(tmp_path / "env"),
-    ):
-        _run_installer(input_path, installer, install_dir, request=request)
-        if installer.suffix == ".pkg" and not ON_CI:
-            return
-        for pkg in PrefixData(install_dir, interoperability=True).iter_records():
-            assert pkg["channel"] != "pypi"
+    )
+    _run_installer(input_path, installer, install_dir, request=request)
+    if installer_type == "pkg" and not ON_CI:
+        return
+    for pkg in PrefixData(install_dir, interoperability=True).iter_records():
+        assert pkg["channel"] != "pypi"
 
 
-def test_example_from_env_txt(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("from_env_txt"))
+)
+def test_example_from_env_txt(tmp_path, request, installer_type):
     input_path = _example_path("from_env_txt")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
-        if installer.suffix == ".pkg" and not ON_CI:
-            return
-        for pkg in PrefixData(install_dir, interoperability=True).iter_records():
-            assert pkg["channel"] != "pypi"
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
+    if installer_type == "pkg" and not ON_CI:
+        return
+    for pkg in PrefixData(install_dir, interoperability=True).iter_records():
+        assert pkg["channel"] != "pypi"
 
 
-def test_example_from_env_yaml(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("from_env_yaml"))
+)
+def test_example_from_env_yaml(tmp_path, request, installer_type):
     input_path = _example_path("from_env_yaml")
-    for installer, install_dir in create_installer(input_path, tmp_path, timeout=600):
-        _run_installer(input_path, installer, install_dir, request=request)
-        if installer.suffix == ".pkg" and not ON_CI:
-            return
-        for pkg in PrefixData(install_dir, interoperability=True).iter_records():
-            assert pkg["channel"] != "pypi"
+    installer, install_dir = create_single_installer(
+        input_path, tmp_path, installer_type, timeout=600
+    )
+    _run_installer(input_path, installer, install_dir, request=request)
+    if installer_type == "pkg" and not ON_CI:
+        return
+    for pkg in PrefixData(install_dir, interoperability=True).iter_records():
+        assert pkg["channel"] != "pypi"
 
 
 @pytest.mark.skipif(context.subdir != "linux-64", reason="Linux x64 only")
-def test_example_from_explicit(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("from_explicit"))
+)
+def test_example_from_explicit(tmp_path, request, installer_type):
     input_path = _example_path("from_explicit")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
-        if installer.suffix == ".pkg" and not ON_CI:
-            return
-        out = subprocess.check_output(
-            [sys.executable, "-mconda", "list", "-p", install_dir, "--explicit", "--md5"],
-            text=True,
-        )
-        expected = (input_path / "explicit_linux-64.txt").read_text()
-        # Filter comments
-        out = [line for line in out.split("\n") if not line.startswith("#")]
-        expected = [line for line in expected.split("\n") if not line.startswith("#")]
-        assert out == expected
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
+    if installer_type == "pkg" and not ON_CI:
+        return
+    out = subprocess.check_output(
+        [sys.executable, "-mconda", "list", "-p", install_dir, "--explicit", "--md5"],
+        text=True,
+    )
+    expected = (input_path / "explicit_linux-64.txt").read_text()
+    # Filter comments
+    out = [line for line in out.split("\n") if not line.startswith("#")]
+    expected = [line for line in expected.split("\n") if not line.startswith("#")]
+    assert out == expected
 
 
 @pytest.mark.parametrize(
@@ -1428,46 +1449,49 @@ def test_cross_build_example(tmp_path, platform_conda_exe):
         assert installer.exists()
 
 
-def test_virtual_specs_failed(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("virtual_specs_failed"))
+)
+def test_virtual_specs_failed(tmp_path, request, installer_type):
     """Verify that virtual packages listed via 'virtual_specs' are satisfied."""
     input_path = _example_path("virtual_specs_failed")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        process = _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            request=request,
-            check_subprocess=False,
-            uninstall=False,
-        )
-        # This example is configured to fail due to unsatisfiable virtual specs
-        if installer.suffix == ".exe":
-            with pytest.raises(AssertionError, match="Failed to check virtual specs"):
-                _check_installer_log(install_dir)
-            continue
-        elif installer.suffix == ".msi":
-            # MSI writes errors to install.log in the install directory
-            msi_post_install_log = install_dir / "install.log"
-            if msi_post_install_log.exists():
-                log_content = msi_post_install_log.read_text(encoding="utf-8", errors="replace")
-                assert "Failed to check virtual specs" in log_content
-            else:
-                # If log doesn't exist, installation failed before post-install script ran
-                assert process.returncode != 0
-            continue
-        elif installer.suffix == ".pkg":
-            if not ON_CI:
-                continue
-            # The GUI does provide a better message with the min version and so on
-            # but on the CLI we fail with this one instead
-            msg = "Cannot install on volume"
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    process = _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        request=request,
+        check_subprocess=False,
+        uninstall=False,
+    )
+    # This example is configured to fail due to unsatisfiable virtual specs
+    if installer_type == "exe":
+        with pytest.raises(AssertionError, match="Failed to check virtual specs"):
+            _check_installer_log(install_dir)
+        return
+    elif installer_type == "msi":
+        # MSI writes errors to install.log in the install directory
+        msi_post_install_log = install_dir / "install.log"
+        if msi_post_install_log.exists():
+            log_content = msi_post_install_log.read_text(encoding="utf-8", errors="replace")
+            assert "Failed to check virtual specs" in log_content
         else:
-            # The shell installer has its own Bash code for __glibc and __osx
-            # Other virtual specs like __cuda are checked by conda-standalone/micromamba
-            # and will fail with solver errors like PackagesNotFound etc
-            msg = "Installer requires"
-        assert process.returncode != 0
-        assert msg in process.stdout + process.stderr
+            # If log doesn't exist, installation failed before post-install script ran
+            assert process.returncode != 0
+        return
+    elif installer_type == "pkg":
+        if not ON_CI:
+            return
+        # The GUI does provide a better message with the min version and so on
+        # but on the CLI we fail with this one instead
+        msg = "Cannot install on volume"
+    else:
+        # The shell installer has its own Bash code for __glibc and __osx
+        # Other virtual specs like __cuda are checked by conda-standalone/micromamba
+        # and will fail with solver errors like PackagesNotFound etc
+        msg = "Installer requires"
+    assert process.returncode != 0
+    assert msg in process.stdout + process.stderr
 
 
 @pytest.mark.parametrize(
@@ -1487,21 +1511,24 @@ def test_virtual_specs_ok(tmp_path, request, installer_type):
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix only")
-def test_virtual_specs_override(tmp_path, request, monkeypatch):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("virtual_specs_failed"))
+)
+def test_virtual_specs_override(tmp_path, request, monkeypatch, installer_type):
     input_path = _example_path("virtual_specs_failed")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        if installer.name.endswith(".pkg"):
-            continue
-        monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "20")
-        monkeypatch.setenv("CONDA_OVERRIDE_OSX", "30")
-        _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            request=request,
-            check_subprocess=True,
-            uninstall=True,
-        )
+    if installer_type == "pkg":
+        pytest.skip("Override test is not applicable to .pkg installers")
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "20")
+    monkeypatch.setenv("CONDA_OVERRIDE_OSX", "30")
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        request=request,
+        check_subprocess=True,
+        uninstall=True,
+    )
 
 
 @pytest.mark.skipif(not ON_CI, reason="Run on CI only")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1258,7 +1258,9 @@ def test_example_signing(tmp_path, request, installer_type):
     not shutil.which("azuresigntool") and not os.environ.get("AZURE_SIGNTOOL_PATH"),
     reason="AzureSignTool not available",
 )
-@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("azure_signtool")))
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("azure_signtool"))
+)
 @pytest.mark.parametrize(
     "auth_method",
     os.environ.get("AZURE_SIGNTOOL_TEST_AUTH_METHODS", "token,secret").split(","),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2212,3 +2212,6 @@ def test_docker_image_build(tmp_path, platform_conda_exe, init):
 
     finally:
         subprocess.run(["docker", "rmi", image_name], check=False)
+        # Each parametrized run leaves behind buildx cache layers; without pruning,
+        # disk fills up across the 5 variants and later runs fail with ENOSPC.
+        subprocess.run(["docker", "builder", "prune", "-f"], check=False)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -809,16 +809,23 @@ def platform_conda_exe(request, tmp_path) -> tuple[str, Path]:
     return platform, conda_exe
 
 
-def test_example_customize_controls(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("customize_controls"))
+)
+def test_example_customize_controls(tmp_path, request, installer_type):
     input_path = _example_path("customize_controls")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
-def test_example_customized_welcome_conclusion(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type",
+    installer_types_for_example(_example_path("customized_welcome_conclusion")),
+)
+def test_example_customized_welcome_conclusion(tmp_path, request, installer_type):
     input_path = _example_path("customized_welcome_conclusion")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
 @pytest.mark.parametrize("extra_pages", ("str", "list"))
@@ -849,42 +856,50 @@ def test_example_extra_envs(tmp_path, request):
                 _run_uninstaller_exe(install_dir=install_dir)
 
 
-def test_example_extra_files(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("extra_files"))
+)
+def test_example_extra_files(tmp_path, request, installer_type):
     input_path = _example_path("extra_files")
-    for installer, install_dir in create_installer(input_path, tmp_path, with_spaces=True):
-        _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            request=request,
-            check_sentinels=CONSTRUCTOR_VERBOSE,
-            check_subprocess=CONSTRUCTOR_VERBOSE,
-        )
+    installer, install_dir = create_single_installer(
+        input_path, tmp_path, installer_type, with_spaces=True
+    )
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        request=request,
+        check_sentinels=CONSTRUCTOR_VERBOSE,
+        check_subprocess=CONSTRUCTOR_VERBOSE,
+    )
 
 
-def test_example_mirrored_channels(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("mirrored_channels"))
+)
+def test_example_mirrored_channels(tmp_path, request, installer_type):
     input_path = _example_path("mirrored_channels")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
 
-        expected_condarc = {
-            "channels": ["conda-forge"],
-            "mirrored_channels": {
-                "conda-forge": [
-                    "https://conda.anaconda.org/conda-forge",
-                    "https://conda.anaconda.org/mirror1",
-                    "https://conda.anaconda.org/mirror2",
-                ]
-            },
-        }
+    expected_condarc = {
+        "channels": ["conda-forge"],
+        "mirrored_channels": {
+            "conda-forge": [
+                "https://conda.anaconda.org/conda-forge",
+                "https://conda.anaconda.org/mirror1",
+                "https://conda.anaconda.org/mirror2",
+            ]
+        },
+    }
 
-        condarc_file = install_dir / ".condarc"
-        assert condarc_file.exists()
+    condarc_file = install_dir / ".condarc"
+    assert condarc_file.exists()
 
-        with open(condarc_file) as file:
-            condarc_data = YAML().load(file)
+    with open(condarc_file) as file:
+        condarc_data = YAML().load(file)
 
-        assert condarc_data == expected_condarc
+    assert condarc_data == expected_condarc
 
 
 def _check_miniforge(
@@ -978,18 +993,26 @@ def test_example_miniforge_mamba2(tmp_path, request, installer_type):
     )
 
 
-def test_example_noconda(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type",
+    installer_types_for_example(_example_path("noconda"), "constructor_input.yaml"),
+)
+def test_example_noconda(tmp_path, request, installer_type):
     input_path = _example_path("noconda")
-    for installer, install_dir in create_installer(
-        input_path, tmp_path, config_filename="constructor_input.yaml", with_spaces=True
-    ):
-        _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            config_filename="constructor_input.yaml",
-            request=request,
-        )
+    installer, install_dir = create_single_installer(
+        input_path,
+        tmp_path,
+        installer_type,
+        config_filename="constructor_input.yaml",
+        with_spaces=True,
+    )
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        config_filename="constructor_input.yaml",
+        request=request,
+    )
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
@@ -1109,10 +1132,13 @@ def test_macos_signing(tmp_path, self_signed_application_certificate_macos):
     assert validated_signatures == components
 
 
-def test_example_scripts(tmp_path, request):
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("scripts")))
+def test_example_scripts(tmp_path, request, installer_type):
     input_path = _example_path("scripts")
-    for installer, install_dir in create_installer(input_path, tmp_path, with_spaces=True):
-        _run_installer(input_path, installer, install_dir, request=request)
+    installer, install_dir = create_single_installer(
+        input_path, tmp_path, installer_type, with_spaces=True
+    )
+    _run_installer(input_path, installer, install_dir, request=request)
 
 
 @pytest.mark.skipif(
@@ -1248,18 +1274,21 @@ def test_azure_signtool(tmp_path, request, monkeypatch, auth_method):
         _run_installer(input_path, installer, install_dir, request=request)
 
 
-def test_example_use_channel_remap(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("use_channel_remap"))
+)
+def test_example_use_channel_remap(tmp_path, request, installer_type):
     input_path = _example_path("use_channel_remap")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
-        p = subprocess.run(
-            [sys.executable, "-m", "conda", "list", "--prefix", install_dir, "--json"],
-            capture_output=True,
-            text=True,
-        )
-        packages = json.loads(p.stdout)
-        for pkg in packages:
-            assert pkg["channel"] == "private_repo"
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request, uninstall=False)
+    p = subprocess.run(
+        [sys.executable, "-m", "conda", "list", "--prefix", install_dir, "--json"],
+        capture_output=True,
+        text=True,
+    )
+    packages = json.loads(p.stdout)
+    for pkg in packages:
+        assert pkg["channel"] == "private_repo"
 
 
 def test_example_from_existing_env(tmp_path, request):
@@ -1317,13 +1346,16 @@ def test_example_from_explicit(tmp_path, request):
         assert out == expected
 
 
-def test_register_envs(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("register_envs"))
+)
+def test_register_envs(tmp_path, request, installer_type):
     """Verify that 'register_envs: False' results in the environment not being registered."""
     input_path = _example_path("register_envs")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(input_path, installer, install_dir, request=request)
-        environments_txt = Path("~/.conda/environments.txt").expanduser().read_text()
-        assert str(install_dir) not in environments_txt
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(input_path, installer, install_dir, request=request)
+    environments_txt = Path("~/.conda/environments.txt").expanduser().read_text()
+    assert str(install_dir) not in environments_txt
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
@@ -1438,17 +1470,20 @@ def test_virtual_specs_failed(tmp_path, request):
         assert msg in process.stdout + process.stderr
 
 
-def test_virtual_specs_ok(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("virtual_specs_ok"))
+)
+def test_virtual_specs_ok(tmp_path, request, installer_type):
     input_path = _example_path("virtual_specs_ok")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            request=request,
-            check_subprocess=True,
-            uninstall=True,
-        )
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        request=request,
+        check_subprocess=True,
+        uninstall=True,
+    )
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix only")
@@ -1860,58 +1895,62 @@ def test_uninstallation_standalone(
             shutil.rmtree(system_rc.parent)
 
 
-def test_output_files(tmp_path):
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("outputs")))
+def test_output_files(tmp_path, installer_type):
     input_path = _example_path("outputs")
-    for installer, _ in create_installer(input_path, tmp_path):
-        files_expected = [
-            f"{installer.name}.md5",
-            f"{installer.name}.sha256",
-            "info.json",
-            "licenses.json",
-            "pkg-list.base.txt",
-            "pkg-list.py310.txt",
-            "lockfile.base.txt",
-            "lockfile.py310.txt",
-        ]
-        files_not_expected = [
-            "pkg-list.py311.txt",
-            "lockfile.py311.txt",
-        ]
-        root_path = installer.parent
-        files_exist = [file for file in files_expected if (root_path / file).exists()]
-        assert sorted(files_exist) == sorted(files_expected)
-        files_exist = [file for file in files_not_expected if (root_path / file).exists()]
-        assert files_exist == []
+    installer, _ = create_single_installer(input_path, tmp_path, installer_type)
+    files_expected = [
+        f"{installer.name}.md5",
+        f"{installer.name}.sha256",
+        "info.json",
+        "licenses.json",
+        "pkg-list.base.txt",
+        "pkg-list.py310.txt",
+        "lockfile.base.txt",
+        "lockfile.py310.txt",
+    ]
+    files_not_expected = [
+        "pkg-list.py311.txt",
+        "lockfile.py311.txt",
+    ]
+    root_path = installer.parent
+    files_exist = [file for file in files_expected if (root_path / file).exists()]
+    assert sorted(files_exist) == sorted(files_expected)
+    files_exist = [file for file in files_not_expected if (root_path / file).exists()]
+    assert files_exist == []
 
-        # Test that info.json contains serialized objects
-        info_json = json.loads((root_path / "info.json").read_text())
-        assert isinstance(info_json.get("_conda_exe_version"), str)
-        _all_pkg_records = info_json.get("_all_pkg_records")
-        assert isinstance(_all_pkg_records, list), "Package record is not a list."
-        assert len(_all_pkg_records) > 0, "Package record is empty."
-        assert isinstance(_all_pkg_records[0], dict), "Package record not serialized."
-        _records = info_json.get("_records")
-        assert isinstance(_records, list), "Package record for base is not a list."
-        assert len(_records) > 0, "Package record for base is empty."
-        assert isinstance(_records[0], dict), "Package record for base is not serialized."
-        for env, env_info in info_json.get("_extra_envs_info", {}).items():
-            _records = env_info.get("_records")
-            assert isinstance(_records, list), f"Record for {env} is not a list."
-            assert len(_records) > 0, f"Record for {env} is empty."
-            assert isinstance(_records[0], dict), f"Record for {env} is not serialized."
+    # Test that info.json contains serialized objects
+    info_json = json.loads((root_path / "info.json").read_text())
+    assert isinstance(info_json.get("_conda_exe_version"), str)
+    _all_pkg_records = info_json.get("_all_pkg_records")
+    assert isinstance(_all_pkg_records, list), "Package record is not a list."
+    assert len(_all_pkg_records) > 0, "Package record is empty."
+    assert isinstance(_all_pkg_records[0], dict), "Package record not serialized."
+    _records = info_json.get("_records")
+    assert isinstance(_records, list), "Package record for base is not a list."
+    assert len(_records) > 0, "Package record for base is empty."
+    assert isinstance(_records[0], dict), "Package record for base is not serialized."
+    for env, env_info in info_json.get("_extra_envs_info", {}).items():
+        _records = env_info.get("_records")
+        assert isinstance(_records, list), f"Record for {env} is not a list."
+        assert len(_records) > 0, f"Record for {env} is empty."
+        assert isinstance(_records[0], dict), f"Record for {env} is not serialized."
 
 
-def test_regressions(tmp_path, request):
+@pytest.mark.parametrize(
+    "installer_type", installer_types_for_example(_example_path("regressions"))
+)
+def test_regressions(tmp_path, request, installer_type):
     input_path = _example_path("regressions")
-    for installer, install_dir in create_installer(input_path, tmp_path):
-        _run_installer(
-            input_path,
-            installer,
-            install_dir,
-            request=request,
-            check_subprocess=True,
-            uninstall=True,
-        )
+    installer, install_dir = create_single_installer(input_path, tmp_path, installer_type)
+    _run_installer(
+        input_path,
+        installer,
+        install_dir,
+        request=request,
+        check_subprocess=True,
+        uninstall=True,
+    )
 
 
 @pytest.mark.parametrize("no_registry", (0, 1))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1258,7 +1258,7 @@ def test_example_signing(tmp_path, request, installer_type):
     not shutil.which("azuresigntool") and not os.environ.get("AZURE_SIGNTOOL_PATH"),
     reason="AzureSignTool not available",
 )
-@pytest.mark.parametrize("installer_type", ["exe"])
+@pytest.mark.parametrize("installer_type", installer_types_for_example(_example_path("azure_signtool")))
 @pytest.mark.parametrize(
     "auth_method",
     os.environ.get("AZURE_SIGNTOOL_TEST_AUTH_METHODS", "token,secret").split(","),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,6 +25,7 @@ from ruamel.yaml import YAML
 
 from constructor.conda_interface import cc_platform
 from constructor.construct import parse as parse_construct
+from constructor.exceptions import InvalidInstallerTypeError
 from constructor.main import get_installer_type
 from constructor.utils import (
     StandaloneExe,
@@ -687,10 +688,20 @@ def installer_types_for_example(
 
     Reuses constructor's own get_installer_type() so the test parametrization
     matches what the build actually produces.
+
+    Returns a tuple with a single skip marker if the example's installer types
+    are not valid for the current platform (e.g., Windows-only examples on Linux).
     """
     info = parse_construct(str(example_path / config_filename), platform=cc_platform)
     info["_platform"] = cc_platform
-    return get_installer_type(info)
+    try:
+        return get_installer_type(info)
+    except InvalidInstallerTypeError:
+        return (
+            pytest.param(
+                "skip", marks=pytest.mark.skip(reason="Example not valid for this platform")
+            ),
+        )
 
 
 def create_single_installer(
@@ -1253,7 +1264,6 @@ def test_example_signing(tmp_path, request, installer_type):
     _run_installer(input_path, installer, install_dir, request=request)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 @pytest.mark.skipif(
     not shutil.which("azuresigntool") and not os.environ.get("AZURE_SIGNTOOL_PATH"),
     reason="AzureSignTool not available",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -664,12 +664,18 @@ def _install_dir_for(
     workspace: Path,
     config_filename: str,
     with_spaces: bool,
+    short: bool = False,
 ) -> Path:
     install_dir_prefix = "i n s t a l l" if with_spaces else "install"
     if installer.suffix == ".pkg" and ON_CI:
         return Path("~").expanduser() / calculate_install_dir(input_dir / config_filename)
     elif installer.suffix == ".msi":
         return calculate_msi_install_path(input_dir / config_filename)
+    elif short:
+        # Each parametrized test already has its own workspace, so the installer
+        # stem/suffix are not needed to keep install dirs distinct. Keeping the
+        # name short avoids exceeding MAX_PATH on Windows (see from_env_txt).
+        return workspace / install_dir_prefix
     else:
         return workspace / f"{install_dir_prefix}-{installer.stem}-{installer.suffix[1:]}"
 
@@ -711,7 +717,9 @@ def create_single_installer(
     installer = next(output_dir.glob(f"*.{installer_type}"), None)
     if installer is None:
         raise FileNotFoundError(f"No .{installer_type} installer found in {output_dir}")
-    install_dir = _install_dir_for(installer, input_dir, workspace, config_filename, with_spaces)
+    install_dir = _install_dir_for(
+        installer, input_dir, workspace, config_filename, with_spaces, short=True
+    )
     return installer, install_dir
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This is a follow-up of https://github.com/conda/constructor/pull/1266, since that PR added the foundation, this PR migrates about half of the tests to the new layout (to simplify review). I am planning to a third (last) PR with the remaining tests.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
