### PR TITLE
Fix issue with docker test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2107,6 +2107,26 @@ def test_docker_image_build(tmp_path, platform_conda_exe, init):
         subprocess.run(["docker", "load", "-i", str(artifact)], check=True)
 
         if init in ("classic", "condabin", "mamba_v1", "mamba_v2"):
+            prefix = config.get("default_prefix", f"/opt/{config['name'].lower()}")
+            debug = subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    image_name,
+                    "/bin/bash",
+                    "-c",
+                    f"echo PATH=$PATH; "
+                    f"echo '--- {prefix}/condabin ---'; ls -la {prefix}/condabin 2>&1; "
+                    f"echo '--- {prefix}/bin/conda* ---'; ls -la {prefix}/bin/conda* 2>&1; "
+                    f"echo '--- which conda ---'; which conda 2>&1; "
+                    f"echo '--- condabin/conda shebang ---'; head -1 {prefix}/condabin/conda 2>&1",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            print("DEBUG condabin/PATH state:\n" + debug.stdout + debug.stderr)
+
             result = subprocess.run(
                 ["docker", "run", "--rm", image_name, "conda", "create", "--help"],
                 capture_output=True,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR is intended to debug an odd failure:
```
2026-07-01T15:27:53.2610907Z =========================== short test summary info ============================
2026-07-01T15:27:53.2611420Z SKIPPED [2] tests/test_examples.py:839: Windows only
2026-07-01T15:27:53.2611889Z SKIPPED [1] tests/test_examples.py:1030: macOS only
2026-07-01T15:27:53.2612399Z SKIPPED [1] tests/test_examples.py:1062: requires xcodebuild
2026-07-01T15:27:53.2612929Z SKIPPED [1] tests/test_examples.py:1097: requires xcodebuild
2026-07-01T15:27:53.2613447Z SKIPPED [1] tests/test_examples.py:1233: Windows only
2026-07-01T15:27:53.2614144Z SKIPPED [2] tests/test_examples.py:1256: AzureSignTool not available
2026-07-01T15:27:53.2614682Z SKIPPED [2] tests/test_examples.py:1390: macOS only
2026-07-01T15:27:53.2615112Z SKIPPED [1] tests/test_examples.py:1416: macOS only
2026-07-01T15:27:53.2615560Z SKIPPED [1] tests/test_examples.py:1625: Windows only
2026-07-01T15:27:53.2616032Z SKIPPED [4] tests/test_examples.py:1829: Windows only
2026-07-01T15:27:53.2616499Z SKIPPED [2] tests/test_examples.py:1991: Windows only
2026-07-01T15:27:53.2617830Z FAILED tests/test_examples.py::test_docker_image_build[linux-aarch64-condabin] - subprocess.CalledProcessError: Command '['docker', 'run', '--rm', 'test_docker_image:1.0.0', 'conda', 'create', '--help']' returned non-zero exit status 127.
2026-07-01T15:27:53.2619202Z ============ 1 failed, 35 passed, 18 skipped in 1745.26s (0:29:05) =============
```


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
