### PR TITLE
Fix Windows Canary Build collection crash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
         uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
         # TODO: remove 'dev-ra-fix-test-issue' from this condition once the
         # Canary Build fix on that branch is verified green and merged.
-        if: github.ref_name == 'main' || startsWith(github.ref_name, 'feature/') || github.ref_name == 'dev-ra-fix-test-issue'
+        # if: github.ref_name == 'main' || startsWith(github.ref_name, 'feature/')
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,8 +236,10 @@ jobs:
           python -m build --sdist --wheel . --outdir dist
 
       - name: Create and upload canary build
-        uses: conda/actions/canary-release@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
-        if: github.ref_name == 'main' || startsWith(github.ref_name, 'feature/')
+        uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
+        # TODO: remove 'dev-ra-fix-test-issue' from this condition once the
+        # Canary Build fix on that branch is verified green and merged.
+        if: github.ref_name == 'main' || startsWith(github.ref_name, 'feature/') || github.ref_name == 'dev-ra-fix-test-issue'
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}
@@ -245,3 +247,5 @@ jobs:
           anaconda-org-label: ${{ github.ref_name == 'main' && 'dev' || format('{0}-{1}', github.event.repository.name, github.ref_name) }}
           anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
           conda-build-arguments: '--override-channels -c conda-forge -c defaults'
+          # TODO: remove this once the fix on 'dev-ra-fix-test-issue' is verified green and merged.
+          upload: 'false'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,10 +236,7 @@ jobs:
           python -m build --sdist --wheel . --outdir dist
 
       - name: Create and upload canary build
-        uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
-        # TODO: remove 'dev-ra-fix-test-issue' from this condition once the
-        # Canary Build fix on that branch is verified green and merged.
-        # if: github.ref_name == 'main' || startsWith(github.ref_name, 'feature/')
+        uses: conda/actions/canary-release@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}
@@ -247,5 +244,4 @@ jobs:
           anaconda-org-label: ${{ github.ref_name == 'main' && 'dev' || format('{0}-{1}', github.event.repository.name, github.ref_name) }}
           anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
           conda-build-arguments: '--override-channels -c conda-forge -c defaults'
-          # TODO: remove this once the fix on 'dev-ra-fix-test-issue' is verified green and merged.
-          upload: 'false'
+          upload: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'feature/') }}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -702,7 +702,21 @@ def installer_types_for_example(
     Returns a tuple with a single skip marker if the example's installer types
     are not valid for the current platform (e.g., Windows-only examples on Linux).
     """
-    info = parse_construct(str(example_path / config_filename), platform=cc_platform)
+    config_path = example_path / config_filename
+    # conda-build's recipe test step only copies a subset of examples/ into its
+    # isolated test source tree (see recipe/meta.yaml test.source_files), so most
+    # examples are legitimately absent there even though this module is still
+    # collected in full. Skip rather than erroring so collection can complete.
+    if not config_path.exists():
+        return (
+            pytest.param(
+                "skip",
+                marks=pytest.mark.skip(
+                    reason=f"{config_path} not found (partial checkout, e.g. conda-build test env)"
+                ),
+            ),
+        )
+    info = parse_construct(str(config_path), platform=cc_platform)
     info["_platform"] = cc_platform
     try:
         return get_installer_type(info)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Windows Canary Build has been failing (https://github.com/conda/constructor/actions/runs/29743641137/job/88408197352) with:
```
INTERNALERROR> FileNotFoundError: ...\test_tmp\examples\customize_controls\construct.yaml
```
Cause: conda-build's recipe test step only copies a few `examples/` dirs into its test tree, but `test_examples.py` now evaluates `installer_types_for_example()` for every example at module/collection time, so missing files crash collection entirely.

Fix: `installer_types_for_example()` skips (with reason) if `construct.yaml` is missing, instead of raising.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
