### PR TITLE
Record conda-ship runtime ownership during installation

### DIFF
--- a/CONSTRUCT.md
+++ b/CONSTRUCT.md
@@ -312,6 +312,32 @@ a dictionary, which will be converted to a YAML string for writing. _Note:_ if t
 option is used, then all other options related to the construction of a `.condarc`
 file (`write_condarc`, `conda_default_channels`, etc.) are ignored.
 
+### `conda_ship_runtime`
+
+Record a conda-ship stamped executable as part of the mandatory installer
+transaction. The executable must already be included in the installed
+prefix, either through a package or `extra_files`.
+
+Constructor records `direct` ownership and the `constructor` installation
+kind by default. Set `managed_prefix` to a separate subdirectory of the
+constructor prefix. The runtime executable must live outside that
+subdirectory so it can bootstrap the managed prefix. SH installers may
+omit `managed_prefix` to initialize the runtime's stamped per-user default.
+PKG, EXE, and MSI installers require it because their mandatory
+installation steps may run with elevated credentials. An installer with
+its own ongoing updater may instead set `ownership` to `external` and
+provide an `instruction`. EXE runtime values cannot contain single or
+double quotes. MSI runtime values cannot contain double quotes.
+
+```
+conda_ship_runtime:
+  executable: conda
+  managed_prefix: runtime
+```
+
+Supported for SH, PKG, EXE, and MSI installers. It is not a
+`post_install` script and cannot be skipped with the user-script options.
+
 ### `company`
 
 Name of the company/entity responsible for the installer.

--- a/constructor/_schema.py
+++ b/constructor/_schema.py
@@ -35,6 +35,10 @@ SCHEMA_PATH = HERE / "data" / "construct.schema.json"
 NAME_REGEX = VERSION_REGEX = r"^[a-zA-Z0-9_]([a-zA-Z0-9._-]*[a-zA-Z0-9_])?$"
 ENV_NAME_REGEX = r"^[^/:# ]+$"
 NonEmptyStr = Annotated[str, Field(min_length=1)]
+CondaShipInstallation = Annotated[
+    str,
+    Field(min_length=1, max_length=64, pattern=r"^[a-z0-9][a-z0-9-]*$"),
+]
 _base_config_dict = ConfigDict(
     extra="forbid",
     use_attribute_docstrings=True,
@@ -68,6 +72,36 @@ class PkgDomains(StrEnum):
 class CondaInitialization(StrEnum):
     CLASSIC = "classic"
     CONDABIN = "condabin"
+
+
+class CondaShipRuntime(BaseModel):
+    model_config: ConfigDict = _base_config_dict
+
+    executable: NonEmptyStr = ...
+    """
+    Path to the conda-ship stamped executable, relative to the constructor
+    prefix.
+    """
+    managed_prefix: NonEmptyStr | None = None
+    """
+    Optional path to the runtime's managed prefix, relative to the constructor
+    prefix. When omitted, the executable uses its stamped default.
+    """
+    ownership: Literal["direct", "external"] = "direct"
+    """
+    Who updates the installed executable. Constructor installations normally
+    use `direct`. Use `external` only when the installer is maintained by an
+    external updater.
+    """
+    installation: CondaShipInstallation = "constructor"
+    """
+    Installation kind recorded in the conda-ship runtime metadata.
+    """
+    instruction: NonEmptyStr | None = None
+    """
+    Update instruction shown for an externally owned installation. Required
+    when `ownership` is `external` and not valid for `direct`.
+    """
 
 
 class ChannelRemap(BaseModel):
@@ -495,6 +529,32 @@ class ConstructorConfiguration(BaseModel):
     a dictionary, which will be converted to a YAML string for writing. _Note:_ if this
     option is used, then all other options related to the construction of a `.condarc`
     file (`write_condarc`, `conda_default_channels`, etc.) are ignored.
+    """
+    conda_ship_runtime: CondaShipRuntime | None = None
+    """
+    Record a conda-ship stamped executable as part of the mandatory installer
+    transaction. The executable must already be included in the installed
+    prefix, either through a package or `extra_files`.
+
+    Constructor records `direct` ownership and the `constructor` installation
+    kind by default. Set `managed_prefix` to a separate subdirectory of the
+    constructor prefix. The runtime executable must live outside that
+    subdirectory so it can bootstrap the managed prefix. SH installers may
+    omit `managed_prefix` to initialize the runtime's stamped per-user default.
+    PKG, EXE, and MSI installers require it because their mandatory
+    installation steps may run with elevated credentials. An installer with
+    its own ongoing updater may instead set `ownership` to `external` and
+    provide an `instruction`. EXE runtime values cannot contain single or
+    double quotes. MSI runtime values cannot contain double quotes.
+
+    ```
+    conda_ship_runtime:
+      executable: conda
+      managed_prefix: runtime
+    ```
+
+    Supported for SH, PKG, EXE, and MSI installers. It is not a
+    `post_install` script and cannot be skipped with the user-script options.
     """
     company: NonEmptyStr | None = None
     """

--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -25,6 +25,7 @@ else:
 
 from . import preconda
 from ._schema import InstallerTypes
+from .conda_ship import batch_runtime_installation
 from .jinja import render_template
 from .signing import create_windows_signing_tool
 from .utils import (
@@ -542,6 +543,7 @@ class Payload:
             "installer_name": self.info.get("name", ""),
             "installer_version": self.info.get("version", ""),
             "installer_platform": self.info.get("_platform", ""),
+            "conda_ship_runtime": batch_runtime_installation(self.info),
         }
 
         # Render the templates now using jinja and the defined context

--- a/constructor/briefcase/run_installation.bat
+++ b/constructor/briefcase/run_installation.bat
@@ -211,6 +211,28 @@ if "%OPTION_POST_INSTALL_SCRIPT%"=="1" (
 {%- endif %}
 {%- endif %}
 
+{%- if conda_ship_runtime %}
+{{ tee("Recording conda-ship runtime installation...") }}
+set "CONDA_SHIP_INTERNAL_UPDATE=v1/record-installation"
+set "CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP={{ conda_ship_runtime.ownership }}"
+set "CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION={{ conda_ship_runtime.installation }}"
+set "CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE=%BASE_PATH%\{{ conda_ship_runtime.executable }}"
+set "CONDA_SHIP_PREFIX=%BASE_PATH%\{{ conda_ship_runtime.managed_prefix }}"
+{%- if conda_ship_runtime.instruction %}
+set "CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION={{ conda_ship_runtime.instruction }}"
+{%- else %}
+set "CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION="
+{%- endif %}
+"%BASE_PATH%\{{ conda_ship_runtime.executable }}" >nul
+if errorlevel 1 ( exit /b 1 )
+set "CONDA_SHIP_INTERNAL_UPDATE="
+set "CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP="
+set "CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION="
+set "CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE="
+set "CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION="
+set "CONDA_SHIP_PREFIX="
+{%- endif %}
+
 rem Clear the package cache if the option was selected
 if "%OPTION_CLEAR_PACKAGE_CACHE%"=="1" (
     {{ tee("Clearing package cache...") }}

--- a/constructor/conda_ship.py
+++ b/constructor/conda_ship.py
@@ -1,0 +1,167 @@
+"""Helpers for recording conda-ship runtime installations."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import PurePosixPath, PureWindowsPath
+
+from ._schema import InstallerTypes
+from .utils import bat_env_var_esc, win_str_esc
+
+
+def _single_line(name: str, value: str) -> str:
+    if "\0" in value or "\n" in value or "\r" in value:
+        raise ValueError(f"conda_ship_runtime.{name} must be a single line")
+    return value
+
+
+def _relative_path(name: str, value: str) -> str:
+    _single_line(name, value)
+    if PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute():
+        raise ValueError(f"conda_ship_runtime.{name} must be relative to the constructor prefix")
+    if ".." in PurePosixPath(value.replace("\\", "/")).parts:
+        raise ValueError(f"conda_ship_runtime.{name} must not contain '..'")
+    return value
+
+
+def _relative_parts(value: str) -> tuple[str, ...]:
+    return tuple(
+        part.casefold() for part in PurePosixPath(value.replace("\\", "/")).parts if part != "."
+    )
+
+
+def validate_runtime_installation(info: dict, installer_types: tuple[InstallerTypes, ...]) -> None:
+    """Validate the optional conda-ship runtime installation configuration."""
+    runtime = info.get("conda_ship_runtime")
+    if runtime is None:
+        return
+
+    if InstallerTypes.DOCKER in installer_types:
+        raise ValueError("conda_ship_runtime is not supported for Docker outputs")
+
+    executable = _relative_path("executable", runtime["executable"])
+    managed_prefix = runtime.get("managed_prefix")
+    if managed_prefix:
+        _relative_path("managed_prefix", managed_prefix)
+        executable_parts = _relative_parts(executable)
+        managed_prefix_parts = _relative_parts(managed_prefix)
+        if not managed_prefix_parts or executable_parts[: len(managed_prefix_parts)] == (
+            managed_prefix_parts
+        ):
+            raise ValueError(
+                "conda_ship_runtime.managed_prefix must not contain the runtime executable"
+            )
+    elif any(
+        installer_type in installer_types
+        for installer_type in (InstallerTypes.PKG, InstallerTypes.EXE, InstallerTypes.MSI)
+    ):
+        raise ValueError(
+            "conda_ship_runtime.managed_prefix is required for PKG, EXE, and MSI outputs"
+        )
+
+    ownership = runtime.get("ownership", "direct")
+    instruction = runtime.get("instruction")
+    installation = _single_line("installation", runtime.get("installation", "constructor"))
+    if (
+        not installation
+        or len(installation) > 64
+        or not installation[0].isascii()
+        or not (installation[0].islower() or installation[0].isdigit())
+        or any(
+            not byte.isascii() or not (byte.islower() or byte.isdigit() or byte == "-")
+            for byte in installation[1:]
+        )
+    ):
+        raise ValueError("conda_ship_runtime.installation must be a lowercase ASCII identifier")
+    if instruction:
+        _single_line("instruction", instruction)
+    if instruction is not None and not instruction.strip():
+        raise ValueError("conda_ship_runtime.instruction must not be empty")
+    if ownership == "direct" and instruction is not None:
+        raise ValueError(
+            "conda_ship_runtime.instruction is only valid when ownership is 'external'"
+        )
+    if ownership == "external" and not instruction:
+        raise ValueError("conda_ship_runtime.instruction is required when ownership is 'external'")
+
+    windows_values = [
+        runtime["executable"],
+        runtime.get("managed_prefix"),
+        runtime.get("installation", "constructor"),
+        instruction,
+    ]
+    if InstallerTypes.EXE in installer_types and any(
+        quote in value for value in windows_values if value is not None for quote in ("'", '"')
+    ):
+        raise ValueError(
+            "conda_ship_runtime values must not contain single or double quotes for EXE outputs"
+        )
+    if InstallerTypes.MSI in installer_types and any(
+        '"' in value for value in windows_values if value is not None
+    ):
+        raise ValueError("conda_ship_runtime values must not contain double quotes for MSI outputs")
+
+
+def _runtime(info: dict) -> dict | None:
+    runtime = info.get("conda_ship_runtime")
+    if runtime is None:
+        return None
+    return {
+        "executable": runtime["executable"],
+        "managed_prefix": runtime.get("managed_prefix"),
+        "ownership": runtime.get("ownership", "direct"),
+        "installation": runtime.get("installation", "constructor"),
+        "instruction": runtime.get("instruction"),
+    }
+
+
+def unix_runtime_installation(info: dict) -> dict | None:
+    """Return shell-safe values for a Unix installer template."""
+    runtime = _runtime(info)
+    if runtime is None:
+        return None
+
+    return {
+        key: shlex.quote(value.replace("\\", "/")) if value is not None else None
+        for key, value in runtime.items()
+    }
+
+
+def batch_runtime_installation(info: dict) -> dict | None:
+    """Return batch-safe values for the MSI installer template."""
+    runtime = _runtime(info)
+    if runtime is None:
+        return None
+
+    return {
+        key: bat_env_var_esc(value.replace("/", "\\"))
+        if key in {"executable", "managed_prefix"} and value is not None
+        else bat_env_var_esc(value)
+        if value is not None
+        else None
+        for key, value in runtime.items()
+    }
+
+
+def nsis_runtime_installation(info: dict) -> dict | None:
+    """Return NSIS-safe values for the EXE installer template."""
+    runtime = _runtime(info)
+    if runtime is None:
+        return None
+
+    executable = runtime["executable"].replace("/", "\\")
+    managed_prefix = runtime["managed_prefix"]
+    if managed_prefix is not None:
+        managed_prefix = managed_prefix.replace("/", "\\")
+
+    return {
+        "executable": win_str_esc(executable)[1:-1],
+        "managed_prefix": (
+            win_str_esc(managed_prefix)[1:-1] if managed_prefix is not None else None
+        ),
+        "ownership": win_str_esc(runtime["ownership"]),
+        "installation": win_str_esc(runtime["installation"]),
+        "instruction": (
+            win_str_esc(runtime["instruction"]) if runtime["instruction"] is not None else None
+        ),
+    }

--- a/constructor/data/construct.schema.json
+++ b/constructor/data/construct.schema.json
@@ -43,6 +43,69 @@
       "title": "CondaInitialization",
       "type": "string"
     },
+    "CondaShipRuntime": {
+      "additionalProperties": false,
+      "properties": {
+        "executable": {
+          "description": "Path to the conda-ship stamped executable, relative to the constructor prefix.",
+          "minLength": 1,
+          "title": "Executable",
+          "type": "string"
+        },
+        "installation": {
+          "default": "constructor",
+          "description": "Installation kind recorded in the conda-ship runtime metadata.",
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "title": "Installation",
+          "type": "string"
+        },
+        "instruction": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Update instruction shown for an externally owned installation. Required when `ownership` is `external` and not valid for `direct`.",
+          "title": "Instruction"
+        },
+        "managed_prefix": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional path to the runtime's managed prefix, relative to the constructor prefix. When omitted, the executable uses its stamped default.",
+          "title": "Managed Prefix"
+        },
+        "ownership": {
+          "default": "direct",
+          "description": "Who updates the installed executable. Constructor installations normally use `direct`. Use `external` only when the installer is maintained by an external updater.",
+          "enum": [
+            "direct",
+            "external"
+          ],
+          "title": "Ownership",
+          "type": "string"
+        }
+      },
+      "required": [
+        "executable"
+      ],
+      "title": "CondaShipRuntime",
+      "type": "object"
+    },
     "ExtraEnv": {
       "additionalProperties": false,
       "properties": {
@@ -554,6 +617,18 @@
       },
       "title": "Conda Default Channels",
       "type": "array"
+    },
+    "conda_ship_runtime": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CondaShipRuntime"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Record a conda-ship stamped executable as part of the mandatory installer transaction. The executable must already be included in the installed prefix, either through a package or `extra_files`.\nConstructor records `direct` ownership and the `constructor` installation kind by default. Set `managed_prefix` to a separate subdirectory of the constructor prefix. The runtime executable must live outside that subdirectory so it can bootstrap the managed prefix. SH installers may omit `managed_prefix` to initialize the runtime's stamped per-user default. PKG, EXE, and MSI installers require it because their mandatory installation steps may run with elevated credentials. An installer with its own ongoing updater may instead set `ownership` to `external` and provide an `instruction`. EXE runtime values cannot contain single or double quotes. MSI runtime values cannot contain double quotes.\n```\nconda_ship_runtime:\n  executable: conda\n  managed_prefix: runtime\n```\nSupported for SH, PKG, EXE, and MSI installers. It is not a `post_install` script and cannot be skipped with the user-script options."
     },
     "condarc": {
       "anyOf": [

--- a/constructor/header.sh
+++ b/constructor/header.sh
@@ -694,6 +694,28 @@ else
 fi
 {%- endif %}
 
+{%- if conda_ship_runtime %}
+printf "Recording conda-ship runtime installation...\n"
+if ! (
+unset CONDA_SHIP_PREFIX
+unset CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION
+CONDA_SHIP_INTERNAL_UPDATE=v1/record-installation \
+CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP={{ conda_ship_runtime.ownership }} \
+CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION={{ conda_ship_runtime.installation }} \
+CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE="$PREFIX"/{{ conda_ship_runtime.executable }} \
+{% if conda_ship_runtime.managed_prefix -%}
+CONDA_SHIP_PREFIX="$PREFIX"/{{ conda_ship_runtime.managed_prefix }} \
+{% endif -%}
+{% if conda_ship_runtime.instruction -%}
+CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION={{ conda_ship_runtime.instruction }} \
+{% endif -%}
+"$PREFIX"/{{ conda_ship_runtime.executable }} > /dev/null
+); then
+    printf "ERROR: recording the conda-ship runtime installation failed\n" >&2
+    exit 1
+fi
+{%- endif %}
+
 if [ -f "$MSGS" ]; then
   cat "$MSGS"
 fi

--- a/constructor/main.py
+++ b/constructor/main.py
@@ -27,6 +27,7 @@ from ._schema import InstallerTypes
 from .build_outputs import process_build_outputs
 from .conda_interface import SUPPORTED_PLATFORMS, cc_platform
 from .conda_interface import VersionOrder as Version
+from .conda_ship import validate_runtime_installation
 from .construct import SCHEMA_PATH, ns_platform
 from .construct import parse as construct_parse
 from .construct import render as construct_render
@@ -253,6 +254,10 @@ def main_build(
     try:
         itypes = get_installer_type(info)
     except InvalidInstallerTypeError as e:
+        sys.exit(f"Error: {e}")
+    try:
+        validate_runtime_installation(info, itypes)
+    except ValueError as e:
         sys.exit(f"Error: {e}")
 
     if InstallerTypes.DOCKER in itypes:

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1261,7 +1261,8 @@ FunctionEnd
 
     Function ${un}AbortRetryNSExecWait
         # This function expects three arguments in the stack
-        # $R1: 'WithLog' or 'NoLog': Use ExecToLog or just Exec, respectively
+        # $R1: 'WithLog', 'WithLogMandatory', or 'NoLog'
+        # Use ExecToLog for either WithLog mode and Exec for NoLog
         # $R2: The message to show if an error occurred
         # $R3: The command to run, quoted
         # Note that the args need to be pushed to the stack in reverse order!
@@ -1278,15 +1279,16 @@ FunctionEnd
             # parse time.
             StrCpy $R3 '"$CMD_EXE" /V:ON /D /C "$R3"'
             ${If} $R1 == "WithLog"
+            ${OrIf} $R1 == "WithLogMandatory"
                 nsExec::ExecToLog $R3
             ${ElseIf} $R1 == "NoLog"
                 nsExec::Exec $R3
             ${Else}
-                ${Print} "::error:: AbortRetryNSExecWait: 1st argument must be 'WithLog' or 'NoLog'. You used: $R1"
+                ${Print} "::error:: AbortRetryNSExecWait: 1st argument must be 'WithLog', 'WithLogMandatory', or 'NoLog'. You used: $R1"
                 Abort
             ${EndIf}
             pop $R0
-            ${If} $R1 == "WithLog"
+            ${If} $R1 != "NoLog"
             ${AndIf} ${FileExists} "${STEP_LOG}"
                 ${If} ${Silent}
                     push "both"
@@ -1304,11 +1306,16 @@ FunctionEnd
                     Call ${un}PrintFromStepLog
                 ${EndIf}
                 ${Print} "::error:: $R2"
-                MessageBox MB_ABORTRETRYIGNORE|MB_ICONEXCLAMATION|MB_DEFBUTTON1 \
-                        $R2 /SD IDABORT IDABORT abort IDRETRY retry
-                ; IDIGNORE: Continue anyway
-                StrCpy $R0 "0"
-                goto retry
+                ${If} $R1 == "WithLogMandatory"
+                    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION|MB_DEFBUTTON2 \
+                            $R2 /SD IDCANCEL IDCANCEL abort IDRETRY retry
+                ${Else}
+                    MessageBox MB_ABORTRETRYIGNORE|MB_ICONEXCLAMATION|MB_DEFBUTTON1 \
+                            $R2 /SD IDABORT IDABORT abort IDRETRY retry
+                    ; IDIGNORE: Continue anyway
+                    StrCpy $R0 "0"
+                    goto retry
+                ${EndIf}
             abort:
                 ; Abort installation
                 Abort
@@ -1667,6 +1674,30 @@ Section "Install"
             call AbortRetryNSExecWait
         ${EndIf}
     ${EndIf}
+
+{%- if CONDA_SHIP_RUNTIME %}
+    ${Print} "Recording conda-ship runtime installation..."
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE", "v1/record-installation")'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP", {{ CONDA_SHIP_RUNTIME.ownership }})'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION", {{ CONDA_SHIP_RUNTIME.installation }})'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE", "$INSTDIR\{{ CONDA_SHIP_RUNTIME.executable }}")'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_PREFIX", "$INSTDIR\{{ CONDA_SHIP_RUNTIME.managed_prefix }}")'
+{%- if CONDA_SHIP_RUNTIME.instruction %}
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION", {{ CONDA_SHIP_RUNTIME.instruction }})'
+{%- else %}
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION", i 0)'
+{%- endif %}
+    push '"$INSTDIR\{{ CONDA_SHIP_RUNTIME.executable }}" > NUL'
+    push 'Failed to record conda-ship runtime installation'
+    push 'WithLogMandatory'
+    call AbortRetryNSExecWait
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE", i 0)'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP", i 0)'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION", i 0)'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE", i 0)'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION", i 0)'
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDA_SHIP_PREFIX", i 0)'
+{%- endif %}
 
     ${If} $Ana_ClearPkgCache_State = ${BST_CHECKED}
         ${Print} "Clearing package cache..."

--- a/constructor/osx/run_installation.sh
+++ b/constructor/osx/run_installation.sh
@@ -112,6 +112,26 @@ for env_pkgs in "${PREFIX}"/pkgs/envs/*/; do
     mv "$PREFIX/envs/$env_name/conda-meta/history.bak" "$PREFIX/envs/$env_name/conda-meta/history"
 done
 
+{%- if conda_ship_runtime %}
+notify "Recording conda-ship runtime installation."
+if ! (
+unset CONDA_SHIP_PREFIX
+unset CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION
+CONDA_SHIP_INTERNAL_UPDATE=v1/record-installation \
+CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP={{ conda_ship_runtime.ownership }} \
+CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION={{ conda_ship_runtime.installation }} \
+CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE="$PREFIX"/{{ conda_ship_runtime.executable }} \
+CONDA_SHIP_PREFIX="$PREFIX"/{{ conda_ship_runtime.managed_prefix }} \
+{% if conda_ship_runtime.instruction -%}
+CONDA_SHIP_INTERNAL_UPDATE_INSTRUCTION={{ conda_ship_runtime.instruction }} \
+{% endif -%}
+"$PREFIX"/{{ conda_ship_runtime.executable }} > /dev/null
+); then
+    echo "ERROR: recording the conda-ship runtime installation failed"
+    exit 1
+fi
+{%- endif %}
+
 # Cleanup!
 find "$PREFIX/pkgs" -type d -empty -exec rmdir {} \; 2>/dev/null || :
 

--- a/constructor/osxpkg.py
+++ b/constructor/osxpkg.py
@@ -17,6 +17,7 @@ from tempfile import NamedTemporaryFile
 from . import preconda
 from ._schema import InstallerTypes
 from .conda_interface import conda_context
+from .conda_ship import unix_runtime_installation
 from .construct import ns_platform, parse
 from .imaging import write_images
 from .jinja import render_template
@@ -407,6 +408,7 @@ def move_script(src, dst, info, ensure_shebang=False, user_script_type=None):
     variables["script_env_variables"] = info.get("script_env_variables", {})
     variables["initialize_conda"] = info.get("initialize_conda", "classic")
     variables["conda_exe_name"] = format_conda_exe_name(info["_conda_exe"])
+    variables["conda_ship_runtime"] = unix_runtime_installation(info)
 
     data = render_template(data, **variables)
 

--- a/constructor/shar.py
+++ b/constructor/shar.py
@@ -20,6 +20,7 @@ from contextlib import nullcontext
 from io import BytesIO
 from os.path import basename, dirname, getsize, isdir, join, relpath
 
+from .conda_ship import unix_runtime_installation
 from .construct import ns_platform
 from .jinja import render_template
 from .preconda import copy_extra_files
@@ -114,6 +115,7 @@ def get_header(conda_exec, tarball, info):
     variables["min_glibc_version"] = min_glibc_version
 
     variables["script_env_variables"] = info.get("script_env_variables", {})
+    variables["conda_ship_runtime"] = unix_runtime_installation(info)
 
     return render_template(read_header_template(), **variables)
 

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from subprocess import check_output, run
 from typing import TYPE_CHECKING
 
+from .conda_ship import nsis_runtime_installation
 from .construct import ns_platform
 from .imaging import write_images
 from .jinja import render_template
@@ -309,6 +310,7 @@ def make_nsi(
     variables["VIRTUAL_SPECS_DEBUG"] = " ".join([spec for spec in info.get("virtual_specs", ())])
     variables["LICENSEFILENAME"] = basename(info.get("license_file", "placeholder_license.txt"))
     variables["NO_RCS_ARG"] = info.get("_ignore_condarcs_arg", "")
+    variables["CONDA_SHIP_RUNTIME"] = nsis_runtime_installation(info)
 
     data = render_template(read_nsi_tmpl(info), **variables)
     if info["_platform"].startswith("win") and sys.platform != "win32":

--- a/docs/source/construct-yaml.md
+++ b/docs/source/construct-yaml.md
@@ -312,6 +312,32 @@ a dictionary, which will be converted to a YAML string for writing. _Note:_ if t
 option is used, then all other options related to the construction of a `.condarc`
 file (`write_condarc`, `conda_default_channels`, etc.) are ignored.
 
+### `conda_ship_runtime`
+
+Record a conda-ship stamped executable as part of the mandatory installer
+transaction. The executable must already be included in the installed
+prefix, either through a package or `extra_files`.
+
+Constructor records `direct` ownership and the `constructor` installation
+kind by default. Set `managed_prefix` to a separate subdirectory of the
+constructor prefix. The runtime executable must live outside that
+subdirectory so it can bootstrap the managed prefix. SH installers may
+omit `managed_prefix` to initialize the runtime's stamped per-user default.
+PKG, EXE, and MSI installers require it because their mandatory
+installation steps may run with elevated credentials. An installer with
+its own ongoing updater may instead set `ownership` to `external` and
+provide an `instruction`. EXE runtime values cannot contain single or
+double quotes. MSI runtime values cannot contain double quotes.
+
+```
+conda_ship_runtime:
+  executable: conda
+  managed_prefix: runtime
+```
+
+Supported for SH, PKG, EXE, and MSI installers. It is not a
+`post_install` script and cannot be skipped with the user-script options.
+
 ### `company`
 
 Name of the company/entity responsible for the installer.

--- a/news/1299.md
+++ b/news/1299.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Added mandatory installed runtime ownership initialization for conda-ship stamped runtimes. (#1299)

--- a/tests/test_briefcase.py
+++ b/tests/test_briefcase.py
@@ -921,6 +921,29 @@ def test_render_templates_installer_metadata(template_name):
     assert 'set "INSTALLER_TYPE=MSI"' in text
 
 
+def test_render_templates_conda_ship_runtime():
+    info = mock_info.copy()
+    info["conda_ship_runtime"] = {
+        "executable": "conda.exe",
+        "managed_prefix": "runtime",
+        "ownership": "direct",
+        "installation": "constructor",
+    }
+    payload = Payload(info)
+    rendered_templates = payload.render_templates()
+
+    run_installation = next(f for f in rendered_templates if f.name == "run_installation.bat")
+    text = run_installation.read_text(encoding="utf-8")
+
+    assert 'set "CONDA_SHIP_INTERNAL_UPDATE=v1/record-installation"' in text
+    assert 'set "CONDA_SHIP_INTERNAL_UPDATE_OWNERSHIP=direct"' in text
+    assert 'set "CONDA_SHIP_INTERNAL_UPDATE_INSTALLATION=constructor"' in text
+    assert 'set "CONDA_SHIP_INTERNAL_UPDATE_EXECUTABLE=%BASE_PATH%\\conda.exe"' in text
+    assert 'set "CONDA_SHIP_PREFIX=%BASE_PATH%\\runtime"' in text
+    assert '"%BASE_PATH%\\conda.exe"' in text
+    assert "if errorlevel 1 ( exit /b 1 )" in text
+
+
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
 @pytest.mark.parametrize(
     "script_type,has_desc",

--- a/tests/test_conda_ship.py
+++ b/tests/test_conda_ship.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+
+from constructor._schema import InstallerTypes
+from constructor.conda_ship import (
+    batch_runtime_installation,
+    nsis_runtime_installation,
+    unix_runtime_installation,
+    validate_runtime_installation,
+)
+
+
+def runtime_info(**overrides):
+    runtime = {
+        "executable": "conda",
+        "ownership": "direct",
+        "installation": "constructor",
+    }
+    runtime.update(overrides)
+    return {"conda_ship_runtime": runtime}
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/usr/local/bin/conda",
+        "../conda",
+        "bin/../../conda",
+        r"C:\Program Files\conda.exe",
+        r"\\server\share\conda.exe",
+    ),
+)
+def test_runtime_executable_must_be_relative(path):
+    with pytest.raises(ValueError, match="conda_ship_runtime.executable"):
+        validate_runtime_installation(
+            runtime_info(executable=path),
+            (InstallerTypes.SH,),
+        )
+
+
+def test_external_runtime_requires_instruction():
+    with pytest.raises(ValueError, match="instruction is required"):
+        validate_runtime_installation(
+            runtime_info(ownership="external"),
+            (InstallerTypes.SH,),
+        )
+
+
+def test_direct_runtime_rejects_instruction():
+    with pytest.raises(ValueError, match="only valid when ownership is 'external'"):
+        validate_runtime_installation(
+            runtime_info(instruction="Run vendor update"),
+            (InstallerTypes.SH,),
+        )
+
+
+@pytest.mark.parametrize("installation", ("", "Constructor", "constructor_plugin", "é"))
+def test_installation_must_match_runtime_contract(installation):
+    with pytest.raises(ValueError, match="lowercase ASCII identifier"):
+        validate_runtime_installation(
+            runtime_info(installation=installation),
+            (InstallerTypes.SH,),
+        )
+
+
+@pytest.mark.parametrize(
+    "installer_type",
+    (InstallerTypes.PKG, InstallerTypes.EXE, InstallerTypes.MSI),
+)
+def test_elevated_installer_requires_managed_prefix(installer_type):
+    with pytest.raises(ValueError, match="managed_prefix is required"):
+        validate_runtime_installation(runtime_info(), (installer_type,))
+
+
+@pytest.mark.parametrize(
+    ("executable", "managed_prefix"),
+    (
+        ("conda", "."),
+        ("runtime/conda", "runtime"),
+        (r"runtime\conda.exe", "runtime"),
+    ),
+)
+def test_managed_prefix_must_not_contain_runtime_executable(
+    executable,
+    managed_prefix,
+):
+    with pytest.raises(ValueError, match="must not contain the runtime executable"):
+        validate_runtime_installation(
+            runtime_info(executable=executable, managed_prefix=managed_prefix),
+            (InstallerTypes.SH,),
+        )
+
+
+def test_docker_output_is_not_supported():
+    with pytest.raises(ValueError, match="not supported for Docker"):
+        validate_runtime_installation(
+            runtime_info(managed_prefix="."),
+            (InstallerTypes.SH, InstallerTypes.DOCKER),
+        )
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    (
+        "Run vendor's updater",
+        'Run "vendor" updater',
+    ),
+)
+def test_exe_values_reject_quotes(instruction):
+    with pytest.raises(ValueError, match="single or double quotes"):
+        validate_runtime_installation(
+            runtime_info(
+                managed_prefix="runtime",
+                ownership="external",
+                instruction=instruction,
+            ),
+            (InstallerTypes.EXE,),
+        )
+
+
+def test_msi_values_allow_single_quotes():
+    validate_runtime_installation(
+        runtime_info(
+            managed_prefix="runtime",
+            ownership="external",
+            instruction="Run vendor's updater",
+        ),
+        (InstallerTypes.MSI,),
+    )
+
+
+def test_runtime_template_values():
+    info = runtime_info(
+        executable="bin/conda runtime",
+        managed_prefix="managed prefix",
+        ownership="external",
+        installation="vendor-installer",
+        instruction="Run vendor update",
+    )
+    validate_runtime_installation(info, (InstallerTypes.SH,))
+
+    assert unix_runtime_installation(info) == {
+        "executable": "'bin/conda runtime'",
+        "managed_prefix": "'managed prefix'",
+        "ownership": "external",
+        "installation": "vendor-installer",
+        "instruction": "'Run vendor update'",
+    }
+    assert batch_runtime_installation(info) == {
+        "executable": r"bin\conda runtime",
+        "managed_prefix": "managed prefix",
+        "ownership": "external",
+        "installation": "vendor-installer",
+        "instruction": "Run vendor update",
+    }
+    assert nsis_runtime_installation(info) == {
+        "executable": r"bin\conda runtime",
+        "managed_prefix": "managed prefix",
+        "ownership": '"external"',
+        "installation": '"vendor-installer"',
+        "instruction": '"Run vendor update"',
+    }

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -44,9 +44,22 @@ def run_shellcheck(script):
 @pytest.mark.parametrize("arch", ["x86_64", "arm64"])
 @pytest.mark.parametrize("check_path_spaces", [False, True])
 @pytest.mark.parametrize(
+    "conda_ship_runtime",
+    [
+        None,
+        {
+            "executable": "conda",
+            "managed_prefix": "'runtime'",
+            "ownership": "direct",
+            "installation": "constructor",
+            "instruction": None,
+        },
+    ],
+)
+@pytest.mark.parametrize(
     "script", [pytest.param(path, id=str(path)) for path in sorted(Path(OSX_DIR).glob("*.sh"))]
 )
-def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
+def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, conda_ship_runtime, script):
     with script.open() as f:
         data = f.read()
     processed = render_template(
@@ -71,6 +84,7 @@ def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
         script_env_variables={},
         initialize_conda="condabin",
         conda_exe_name="_conda",
+        conda_ship_runtime=conda_ship_runtime,
     )
 
     findings, returncode = run_shellcheck(processed)
@@ -97,6 +111,19 @@ def test_osxpkg_scripts_shellcheck(arch, check_path_spaces, script):
 @pytest.mark.parametrize("min_glibc_version", ["2.17"])
 @pytest.mark.parametrize("min_osx_version", ["10.13"])
 @pytest.mark.parametrize("conda_exe_payloads_and_size", [({"path": (0, 10, False)}, 10)])
+@pytest.mark.parametrize(
+    "conda_ship_runtime",
+    [
+        None,
+        {
+            "executable": "conda",
+            "managed_prefix": "'runtime'",
+            "ownership": "direct",
+            "installation": "constructor",
+            "instruction": None,
+        },
+    ],
+)
 def test_template_shellcheck(
     osx,
     arch,
@@ -115,6 +142,7 @@ def test_template_shellcheck(
     min_glibc_version,
     min_osx_version,
     conda_exe_payloads_and_size,
+    conda_ship_runtime,
 ):
     template = read_header_template()
     processed = render_template(
@@ -165,6 +193,7 @@ def test_template_shellcheck(
             "conda_exe_payloads": conda_exe_payloads_and_size[0],
             "conda_exe_payloads_size": conda_exe_payloads_and_size[1],
             "conda_exe_name": "_conda",
+            "conda_ship_runtime": conda_ship_runtime,
         },
     )
 


### PR DESCRIPTION
### Description

Add the optional `conda_ship_runtime` construct setting for SH, PKG, EXE, and MSI installers.

The mandatory installer path invokes `v1/record-installation` on the stamped executable after package installation. It records ownership, installation kind, stable executable path, and an optional external instruction in the existing runtime metadata file.

This is not a user post-install script and cannot be skipped through user-script options.

Depends on jezdez/conda-ship#94.

Closes #1299.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for inclusion in the next release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?