### PR TITLE
Unset CONDARC for Windows uninstallations

### DIFF
--- a/constructor/briefcase/pre_uninstall.bat
+++ b/constructor/briefcase/pre_uninstall.bat
@@ -27,6 +27,8 @@ set "PAYLOAD_TAR=%INSTDIR%\{{ archive_name }}"
 set "CONDA_ROOT_PREFIX=%BASE_PATH%"
 rem Set CONDA_QUIET primarily to disable the spinners
 set CONDA_QUIET={{ 0 if add_debug else 1 }}
+rem Uninstaller should ignore system configuration files
+set CONDARC=
 
 rem Get the name of the install directory
 for %%I in ("%INSTDIR%") do set "APPNAME=%%~nxI"

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1848,6 +1848,11 @@ Section "Uninstall"
 {%- endfor %}
 
 {%- if uninstall_with_conda_exe %}
+    # Uninstallers should ignore pre-existing configuration files.
+    # Note: We want to _unset_ these environment variables, not set them to `0`.
+    # This requires passing `0` as an integer, hence the `i` in front.
+    System::Call 'kernel32::SetEnvironmentVariable(t,t)i("CONDARC", i 0)'
+
     # Parse uninstall options
     var /global UninstOptions
     StrCpy $UninstOptions ""

--- a/news/1313-unset-condarc-uninstallation
+++ b/news/1313-unset-condarc-uninstallation
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Unset `CONDARC` environment variable for uninstallations with `conda-standalone`. (#1313)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

`.condarc` files can interfere with the installation process with broken configurations. `conda-standalone` and `micromamba` contain the `--no-rc` flag to avoid reading configuration files. #962 introduced a fix for the installation process that also unset `CONDARC` and `MAMBARC` so that environment variables do not accidentally feed these parameters into the process.

Add the same fix to the uninstallation. This only applies to uninstallations with `conda-standalone`, so `MAMBARC` does not need to be touched.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
