### PR TITLE
Fix deprecation warning since conda 26.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+# From pytest-split
+.test_durations
 
 # Translations
 *.mo

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -102,15 +102,9 @@ if conda_interface_type == "conda":
     distro = None
     if sys.platform.startswith("linux"):
         try:
-            import distro
+            import distro  # noqa: F401  # re-exported for use in preconda.py
         except ImportError:
             pass
-
-        if distro is None:
-            try:
-                from conda._vendor import distro
-            except ImportError:
-                pass
 
     def get_repodata(url):
         if CONDA_MAJOR_MINOR >= (23, 5):

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -102,9 +102,15 @@ if conda_interface_type == "conda":
     distro = None
     if sys.platform.startswith("linux"):
         try:
-            import distro  # noqa
+            import distro
         except ImportError:
             pass
+
+        if distro is None:
+            try:
+                from conda._vendor import distro
+            except ImportError:
+                pass
 
     def get_repodata(url):
         if CONDA_MAJOR_MINOR >= (23, 5):

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -102,7 +102,7 @@ if conda_interface_type == "conda":
     distro = None
     if sys.platform.startswith("linux"):
         try:
-            from conda._vendor import distro  # noqa
+            import distro  # noqa
         except ImportError:
             pass
 

--- a/constructor/conda_interface.py
+++ b/constructor/conda_interface.py
@@ -9,7 +9,6 @@ import json
 import os
 import sys
 from copy import deepcopy
-from itertools import chain
 from os.path import join
 
 from conda.gateways.disk import mkdir_p_sudo_safe
@@ -37,7 +36,7 @@ SUPPORTED_PLATFORMS = [
 ]
 
 try:
-    from conda import __version__ as CONDA_INTERFACE_VERSION
+    from conda import __version__ as CONDA_INTERFACE_VERSION  # noqa
 
     conda_interface_type = "conda"
 except ImportError:
@@ -47,11 +46,6 @@ except ImportError:
 
 if conda_interface_type == "conda":
     # This import path has been stable since 2016
-    from conda.models.version import VersionOrder
-
-    _conda_version = VersionOrder(CONDA_INTERFACE_VERSION).version
-    # Flatten VersionOrder.version, skip epoch, and keep only major and minor
-    CONDA_MAJOR_MINOR = tuple(chain.from_iterable(_conda_version))[1:3]
 
     from conda.api import SubdirData  # noqa
     from conda.base.context import context as _conda_context
@@ -61,14 +55,15 @@ if conda_interface_type == "conda":
     from conda.core.package_cache_data import PackageCacheData as _PackageCacheData
     from conda.core.package_cache_data import ProgressiveFetchExtract as _ProgressiveFetchExtract
     from conda.core.prefix_data import PrefixData as _PrefixData
+    from conda.core.subdir_data import SubdirData as _SubdirData
     from conda.exports import MatchSpec as _MatchSpec
     from conda.exports import default_prefix as _default_prefix
     from conda.exports import download as _download
     from conda.gateways.disk.read import read_paths_json as _read_paths_json
-    from conda.models.channel import all_channel_urls as _all_channel_urls
+    from conda.models.channel import all_channel_urls as _all_channel_urls, Channel
     from conda.models.dist import Dist as _Dist
     from conda.models.prefix_graph import PrefixGraph as _PrefixGraph
-    from conda.models.version import VersionOrder
+    from conda.models.version import VersionOrder  # noqa
 
     try:
         from conda.models.records import PackageCacheRecord as _PackageCacheRecord
@@ -107,17 +102,8 @@ if conda_interface_type == "conda":
             pass
 
     def get_repodata(url):
-        if CONDA_MAJOR_MINOR >= (23, 5):
-            from conda.core.subdir_data import SubdirData as _SubdirData
-            from conda.models.channel import Channel
-
-            subdir_data = _SubdirData(Channel(url))
-            raw_repodata_str, _ = subdir_data.repo_fetch.fetch_latest()
-        else:
-            # Backwards compatibility: for conda 4.6+
-            from conda.core.subdir_data import fetch_repodata_remote_request
-
-            raw_repodata_str = fetch_repodata_remote_request(url, None, None)
+        subdir_data = _SubdirData(Channel(url))
+        raw_repodata_str, _ = subdir_data.repo_fetch.fetch_latest()
 
         # noarch-only repos are valid. if the native subdir is not present,
         # we might get an empty repodata back. In that case, we need to add the minimal

--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -129,7 +129,7 @@ def system_info():
         out["extra"] = platform.mac_ver()
     elif sys.platform.startswith("linux"):
         if conda_distro is not None:
-            out["extra"] = conda_distro.linux_distribution(full_distribution_name=False)
+            out["extra"] = (conda_distro.id(), conda_distro.version(), conda_distro.codename())
         elif hasattr(platform, "dist"):
             out["extra"] = platform.dist()
     elif sys.platform.startswith("win"):

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - pip
-  - conda >=4.6
+  - conda >=24.1
   - ruamel.yaml >=0.11.14,<0.19
   - conda-standalone # >=23.11.0
   - pillow >=3.1  # [osx or win]

--- a/news/1316-fix-distro-vendor-deprecation
+++ b/news/1316-fix-distro-vendor-deprecation
@@ -16,4 +16,4 @@
 
 ### Other
 
-* <news item>
+* Raise the minimum supported `conda` version to 24.1. (#1315 via #1316)

--- a/news/1316-fix-distro-vendor-deprecation
+++ b/news/1316-fix-distro-vendor-deprecation
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Replace deprecated use of `conda._vendor.distro`, which also restores the Linux distribution info in `info.json`. (#1315 via #1316)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dynamic = [
 ]
 dependencies = [
     "conda >=4.6",
+    "distro ; platform_system=='Linux'",
     "ruamel.yaml >=0.11.14,<0.19",
     "pillow >=3.1 ; platform_system=='Windows' or platform_system=='Darwin'",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "conda >=4.6",
+    "conda >=24.1",
     "distro ; platform_system=='Linux'",
     "ruamel.yaml >=0.11.14,<0.19",
     "pillow >=3.1 ; platform_system=='Windows' or platform_system=='Darwin'",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - conda >=4.6
     - python  # >=3.10
+    - distro  # [linux]
     - ruamel.yaml >=0.11.14,<0.19
     - conda-standalone >=24.11.0
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools >=70.1
     - setuptools_scm >=6.2
   run:
-    - conda >=4.6
+    - conda >=24.1
     - python  # >=3.10
     - distro  # [linux]
     - ruamel.yaml >=0.11.14,<0.19

--- a/tests/test_preconda.py
+++ b/tests/test_preconda.py
@@ -1,4 +1,8 @@
-from constructor.preconda import write_condarc
+import sys
+
+import pytest
+
+from constructor.preconda import system_info, write_condarc
 
 
 def test_write_condarc_with_condarc_dict(tmp_path):
@@ -56,3 +60,15 @@ def test_write_condarc_write_condarc_without_channels(tmp_path):
 
     condarc_file = tmp_path / ".condarc"
     assert not condarc_file.exists()
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux-only distro info")
+def test_system_info_includes_linux_distro():
+    """system_info() should report actual distro info on Linux. Previously conda_distro was imported from
+    the now-removed conda._vendor.distro, so the import silently failed and
+    'extra' was never set (see GitHub issue 1315)."""
+    import distro
+
+    info = system_info()
+
+    assert info["extra"] == (distro.id(), distro.version(), distro.codename())


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR fixes https://github.com/conda/constructor/issues/1315.

As of right now I only added `distro` to Linux to mimic the old behavior. However, let me know if we rather add it for all the platforms so I can remove the conditional imports which I'm personally not a big fan of.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
