### PR TITLE
Ensure installer option is gated behind install scope

### DIFF
--- a/constructor/briefcase.py
+++ b/constructor/briefcase.py
@@ -308,7 +308,7 @@ def create_install_options_list(info: dict) -> list[dict]:
         options.append(
             {
                 "name": "initialize_conda",
-                "title": "Add installation to my PATH environment variable",
+                "title": "Add installation to my PATH environment variable (single-user installs only)",
                 "description": description,
                 "default": info.get("initialize_by_default", False),
             }

--- a/constructor/briefcase/run_installation.bat
+++ b/constructor/briefcase/run_installation.bat
@@ -160,9 +160,9 @@ rem because MSI expects the file to be there to clean the registry.
 del "%PAYLOAD_TAR%"
 if errorlevel 1 ( exit /b %errorlevel% )
 
-rem Add to PATH / run conda init if the option was selected
+rem Add to PATH / run conda init if the option was selected (single-user installs only)
 {%- set pathflag = "--condabin" if initialize_conda == "condabin" else "--classic" %}
-if "%OPTION_INITIALIZE_CONDA%"=="1" (
+if "%OPTION_INITIALIZE_CONDA%"=="1" if exist "%BASE_PATH%\.nonadmin" (
     {{ tee("Adding to PATH...") }}
     "%CONDA_EXE%" constructor windows path --prepend=user --prefix "%BASE_PATH%" {{ pathflag }} --log-file "%LOG%"
     if errorlevel 1 ( exit /b %errorlevel% )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
I noticed the option to add to path is not gated behind the install scope, and it is not possible to hide an installer option for MSI installers thus this option is displayed even when installing for "All Users". 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
