### PR TITLE
Switch from PrefixRecord to PackageRecord

### DIFF
--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -15,7 +15,6 @@ from conda.base.constants import UNKNOWN_CHANNEL
 from conda.common.url import remove_auth, split_anaconda_token
 from conda.core.prefix_data import PrefixData, PrefixGraph
 from conda.exports import default_prefix
-from conda.models.records import PackageRecord
 
 from . import __version__
 from .conda_interface import VersionOrder
@@ -33,11 +32,21 @@ def get_build_env_records(prefix=None):
     """
     if prefix is None:
         prefix = default_prefix
+
+    # Define a set of keys that we don't need to include in info.json.
+    # The result of excluding these is a much smaller info.json (up to 70x).
+    to_exclude = (
+        "extracted_package_dir",
+        "files",
+        "link",
+        "package_tarball_full_path",
+        "paths_data",
+    )
     # interoperability=True also picks up pip-installed packages, not just conda ones.
     prefix_records = PrefixData(prefix, interoperability=True).iter_records()
-    # PrefixRecord carries per-file installation data (files, paths_data) that isn't
-    # relevant here and bloats info.json; PackageRecord drops it but keeps package metadata.
-    return [PackageRecord(**record.dump()) for record in prefix_records]
+    return [
+        {k: v for k, v in record.dump().items() if k not in to_exclude} for record in prefix_records
+    ]
 
 
 def _validate_output(output):

--- a/constructor/build_outputs.py
+++ b/constructor/build_outputs.py
@@ -15,6 +15,7 @@ from conda.base.constants import UNKNOWN_CHANNEL
 from conda.common.url import remove_auth, split_anaconda_token
 from conda.core.prefix_data import PrefixData, PrefixGraph
 from conda.exports import default_prefix
+from conda.models.records import PackageRecord
 
 from . import __version__
 from .conda_interface import VersionOrder
@@ -33,7 +34,10 @@ def get_build_env_records(prefix=None):
     if prefix is None:
         prefix = default_prefix
     # interoperability=True also picks up pip-installed packages, not just conda ones.
-    return list(PrefixData(prefix, interoperability=True).iter_records())
+    prefix_records = PrefixData(prefix, interoperability=True).iter_records()
+    # PrefixRecord carries per-file installation data (files, paths_data) that isn't
+    # relevant here and bloats info.json; PackageRecord drops it but keeps package metadata.
+    return [PackageRecord(**record.dump()) for record in prefix_records]
 
 
 def _validate_output(output):

--- a/news/1314-build-environment-info
+++ b/news/1314-build-environment-info
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add `_build_environment_packages` to `info.json`, listing the packages (including pip-installed ones) present in the environment used to build the installer. (#1314)
+* Add `_build_environment_packages` to `info.json`, listing the packages (including pip-installed ones) present in the environment used to build the installer. (#1314, #1325)
 
 ### Bug fixes
 

--- a/tests/test_conda_interface.py
+++ b/tests/test_conda_interface.py
@@ -79,6 +79,7 @@ def test_get_build_env_records_with_explicit_prefix(tmp_path, patch_prefix_data,
     result = get_build_env_records(prefix=str(tmp_path))
 
     assert sorted(rec.name for rec in result) == sorted(rec.name for rec in records)
+    assert all(type(rec) is PackageRecord for rec in result)
 
 
 def test_get_build_env_records_defaults_to_active_environment(

--- a/tests/test_conda_interface.py
+++ b/tests/test_conda_interface.py
@@ -78,8 +78,8 @@ def test_get_build_env_records_with_explicit_prefix(tmp_path, patch_prefix_data,
 
     result = get_build_env_records(prefix=str(tmp_path))
 
-    assert sorted(rec.name for rec in result) == sorted(rec.name for rec in records)
-    assert all(type(rec) is PackageRecord for rec in result)
+    assert sorted(rec["name"] for rec in result) == sorted(rec.name for rec in records)
+    assert all(isinstance(rec, dict) for rec in result)
 
 
 def test_get_build_env_records_defaults_to_active_environment(
@@ -93,7 +93,7 @@ def test_get_build_env_records_defaults_to_active_environment(
 
     result = get_build_env_records()
 
-    assert [rec.name for rec in result] == ["foobar"]
+    assert [rec["name"] for rec in result] == ["foobar"]
 
 
 def test_get_build_env_records_includes_pip_installed_packages(tmp_path):
@@ -125,4 +125,7 @@ def test_get_build_env_records_includes_pip_installed_packages(tmp_path):
 
     result = get_build_env_records(prefix=str(tmp_path))
 
-    assert sorted(rec.name for rec in result) == ["fakepkg", "python"]
+    assert sorted(rec["name"] for rec in result) == ["fakepkg", "python"]
+    python_rec = next(rec for rec in result if rec["name"] == "python")
+    assert "files" not in python_rec
+    assert "paths_data" not in python_rec


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR improves the changes added in https://github.com/conda/constructor/pull/1314. It was noticed that `PrefixRecord` added much more metadata than necessary which bloated the `info.json` file. Comparing the two `info.json` (before/after this implementation) shows about a 70x reduction in file size when using `PackageRecord`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
