### PR TITLE
Improve how ACLs are set to improve runtime performance

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1519,7 +1519,6 @@ Section "Install"
     SetOutPath "$INSTDIR"
     File {{ conda_exe }}
     File {{ pre_uninstall }}
-    File {{ fix_launcher_acls }}
     File {{ installer_info }}
 
 {%- for path, files in EXTRA_FILES | items %}
@@ -1749,14 +1748,12 @@ Section "Install"
 
     ${Print} "Setting installation directory permissions..."
     # `type` is used to simulate a `tee`-like output in cmd.exe.
-    {%- set icacls_args = ['"$ICACLS_EXE"'] -%}
-    {%- for env in SETUP_ENVS -%}
-    {%- set _ = icacls_args.append('"' ~ env.prefix ~ '\\Scripts\\*"') -%}
-    {%- endfor %}
-    push '"$INSTDIR\fix_launcher_acls.bat" {{ icacls_args|join(" ") }} > "${STEP_LOG}" 2>&1 & SET ERR=!ERRORLEVEL! & type "${STEP_LOG}" & EXIT /B !ERR!'
-    push 'Failed to enable inheritance for the entry point launchers.'
+    {%- for env in SETUP_ENVS %}
+    push '"$ICACLS_EXE" "{{ env.prefix }}\Scripts\*" /inheritance:e /T /C /Q > "${STEP_LOG}" 2>&1 & SET ERR=!ERRORLEVEL! & type "${STEP_LOG}" & EXIT /B !ERR!'
+    push 'Failed to update ACLs in environment "{{ env.name }}".'
     push 'WithLog'
     call AbortRetryNSExecWait
+    {%- endfor %}
     ${Print} "Done!"
 SectionEnd
 

--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -1519,6 +1519,7 @@ Section "Install"
     SetOutPath "$INSTDIR"
     File {{ conda_exe }}
     File {{ pre_uninstall }}
+    File {{ fix_launcher_acls }}
     File {{ installer_info }}
 
 {%- for path, files in EXTRA_FILES | items %}
@@ -1747,12 +1748,13 @@ Section "Install"
     ${EndIf}
 
     ${Print} "Setting installation directory permissions..."
-    # Enable inheritance on all files inside $INSTDIR.
-    # Use icacls because it is much faster than custom NSIS solutions.
-    # We continue on error because icacls fails on broken links.
-    # `type` is used to simulate a `tee`-like output in cmd.exe
-    push '"$ICACLS_EXE" "$INSTDIR\*" /inheritance:e /T /C /Q > "${STEP_LOG}" 2>&1 & SET ERR=!ERRORLEVEL! & type "${STEP_LOG}" & EXIT /B !ERR!'
-    push 'Failed to enable inheritance for all files in the installation directory.'
+    # `type` is used to simulate a `tee`-like output in cmd.exe.
+    {%- set icacls_args = ['"$ICACLS_EXE"'] -%}
+    {%- for env in SETUP_ENVS -%}
+    {%- set _ = icacls_args.append('"' ~ env.prefix ~ '\\Scripts\\*"') -%}
+    {%- endfor %}
+    push '"$INSTDIR\fix_launcher_acls.bat" {{ icacls_args|join(" ") }} > "${STEP_LOG}" 2>&1 & SET ERR=!ERRORLEVEL! & type "${STEP_LOG}" & EXIT /B !ERR!'
+    push 'Failed to enable inheritance for the entry point launchers.'
     push 'WithLog'
     call AbortRetryNSExecWait
     ${Print} "Done!"

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -144,46 +144,6 @@ def setup_envs_commands(info, dir_path):
     return environments
 
 
-FIX_LAUNCHER_ACLS_BAT = """\
-SET ERR=0
-SET ICACLS=%1
-SHIFT
-:loop
-IF "%~1"=="" GOTO :done
-IF EXIST "%~1" (
-    %ICACLS% "%~1" /inheritance:e /T /C /Q
-    IF ERRORLEVEL 1 (
-        ECHO Failed to enable inheritance for entry point launchers in "%~1"
-        SET ERR=1
-    )
-)
-SHIFT
-GOTO :loop
-:done
-EXIT /B %ERR%
-"""
-
-
-def write_fix_launcher_acls_bat(dir_path: str) -> None:
-    """Write a batch script that re-enables ACL inheritance on entry point launchers.
-
-    Entry point launchers are hard links to a stub exe with inheritance disabled (see
-    the .nsi template's "Setting installation directory permissions" install step),
-    and hard links share one ACL. This script takes icacls.exe's path as its first
-    argument, followed by one `Scripts` glob per environment, and reports which
-    glob(s), if any, it failed to fix.
-
-    This is a standalone file (its args, including $INSTDIR-based paths only known at
-    install time, are filled in by the .nsi template) rather than an inlined nsExec
-    one-liner, because cmd.exe's quote-stripping when invoked via `cmd /C "..."`
-    mangles a one-liner with several `if`/`&`-chained statements once there's more
-    than one environment. The script itself has no per-env logic, so it doesn't need
-    regenerating when the number of environments changes.
-    """
-    with open(join(dir_path, "fix_launcher_acls.bat"), "w", newline="\r\n") as fo:
-        fo.write(FIX_LAUNCHER_ACLS_BAT)
-
-
 def make_nsi(
     info: dict,
     dir_path: str,
@@ -210,7 +170,6 @@ def make_nsi(
     info["post_install_desc"] = info.get("post_install_desc", "")
 
     setup_envs = setup_envs_commands(info, dir_path)
-    write_fix_launcher_acls_bat(dir_path)
 
     variables = {
         "installer_name": name,
@@ -243,7 +202,6 @@ def make_nsi(
         "pre_install": "@pre_install.bat",
         "post_install": "@post_install.bat",
         "pre_uninstall": "@pre_uninstall.bat",
-        "fix_launcher_acls": "@fix_launcher_acls.bat",
         "installer_info": "@.installer.info",
         "index_cache": "@" + join("pkgs", "cache"),
         "repodata_record": "@" + join("pkgs", "repodata_record.json"),

--- a/constructor/winexe.py
+++ b/constructor/winexe.py
@@ -144,6 +144,46 @@ def setup_envs_commands(info, dir_path):
     return environments
 
 
+FIX_LAUNCHER_ACLS_BAT = """\
+SET ERR=0
+SET ICACLS=%1
+SHIFT
+:loop
+IF "%~1"=="" GOTO :done
+IF EXIST "%~1" (
+    %ICACLS% "%~1" /inheritance:e /T /C /Q
+    IF ERRORLEVEL 1 (
+        ECHO Failed to enable inheritance for entry point launchers in "%~1"
+        SET ERR=1
+    )
+)
+SHIFT
+GOTO :loop
+:done
+EXIT /B %ERR%
+"""
+
+
+def write_fix_launcher_acls_bat(dir_path: str) -> None:
+    """Write a batch script that re-enables ACL inheritance on entry point launchers.
+
+    Entry point launchers are hard links to a stub exe with inheritance disabled (see
+    the .nsi template's "Setting installation directory permissions" install step),
+    and hard links share one ACL. This script takes icacls.exe's path as its first
+    argument, followed by one `Scripts` glob per environment, and reports which
+    glob(s), if any, it failed to fix.
+
+    This is a standalone file (its args, including $INSTDIR-based paths only known at
+    install time, are filled in by the .nsi template) rather than an inlined nsExec
+    one-liner, because cmd.exe's quote-stripping when invoked via `cmd /C "..."`
+    mangles a one-liner with several `if`/`&`-chained statements once there's more
+    than one environment. The script itself has no per-env logic, so it doesn't need
+    regenerating when the number of environments changes.
+    """
+    with open(join(dir_path, "fix_launcher_acls.bat"), "w", newline="\r\n") as fo:
+        fo.write(FIX_LAUNCHER_ACLS_BAT)
+
+
 def make_nsi(
     info: dict,
     dir_path: str,
@@ -168,6 +208,9 @@ def make_nsi(
     display_arch, arch = parse_arch(info["_platform"])
     info["pre_install_desc"] = info.get("pre_install_desc", "")
     info["post_install_desc"] = info.get("post_install_desc", "")
+
+    setup_envs = setup_envs_commands(info, dir_path)
+    write_fix_launcher_acls_bat(dir_path)
 
     variables = {
         "installer_name": name,
@@ -200,6 +243,7 @@ def make_nsi(
         "pre_install": "@pre_install.bat",
         "post_install": "@post_install.bat",
         "pre_uninstall": "@pre_uninstall.bat",
+        "fix_launcher_acls": "@fix_launcher_acls.bat",
         "installer_info": "@.installer.info",
         "index_cache": "@" + join("pkgs", "cache"),
         "repodata_record": "@" + join("pkgs", "repodata_record.json"),
@@ -290,7 +334,7 @@ def make_nsi(
     variables["BITS"] = str(arch)
     variables["DISTS"] = [win_str_esc(join(download_dir, dist)) for dist in dists]
     variables["SIGNTOOL_COMMAND"] = signing_tool.get_signing_command() if signing_tool else ""
-    variables["SETUP_ENVS"] = setup_envs_commands(info, dir_path)
+    variables["SETUP_ENVS"] = setup_envs
     variables["SIZE"] = approx_pkgs_size_kb
     variables["UNINSTALL_NAME"] = info.get("uninstall_name", default_uninstall_name)
     variables["EXTRA_FILES"] = get_extra_files(extra_files, dir_path)

--- a/news/828-fast-entry-point-acl-fix
+++ b/news/828-fast-entry-point-acl-fix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* EXE: Speed up the "Setting installation directory permissions..." step of Windows installers considerably. (#828 via #1335)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -844,8 +844,6 @@ def _check_permission_inheritance(install_dir: Path):
     scoped to), the tree-wide scan below will still catch the resulting broken
     inheritance regardless of location.
     """
-    prefixes = [install_dir, *install_dir.glob("envs/*")]
-
     protected = []
     not_inherited = []
     for file in install_dir.glob("**/*"):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -69,7 +69,7 @@ pytestmark = pytest.mark.examples
 REPO_DIR = Path(__file__).parent.parent
 ON_CI = bool(os.environ.get("CI")) and os.environ.get("CI") != "0"
 CONSTRUCTOR_CONDA_EXE = os.environ.get("CONSTRUCTOR_CONDA_EXE")
-CONSTRUCTOR_VERBOSE = os.environ.get("CONSTRUCTOR_VERBOSE")
+CONSTRUCTOR_VERBOSE = os.environ.get("CONSTRUCTOR_VERBOSE", "").lower() in ("1", "true", "yes")
 CONDA_EXE, CONDA_EXE_VERSION = identify_conda_exe(CONSTRUCTOR_CONDA_EXE)
 if CONDA_EXE_VERSION is not None:
     CONDA_EXE_VERSION = Version(CONDA_EXE_VERSION)
@@ -822,6 +822,53 @@ def _is_micromamba(path) -> bool:
     return name == StandaloneExe.MAMBA
 
 
+def _entry_point_launchers(prefix: Path) -> list[Path]:
+    """Collect the entry point launchers conda hard linked from a shared stub exe.
+
+    The stub has inheritance disabled and hard links share one ACL, so the installer
+    has to re-enable inheritance for these files.
+    """
+    launchers = []
+    for record in prefix.glob("conda-meta/*.json"):
+        paths_data = json.loads(record.read_text()).get("paths_data", {})
+        launchers.extend(
+            prefix / path["_path"]
+            for path in paths_data.get("paths", [])
+            if path.get("path_type") == "windows_python_entry_point_exe"
+        )
+    return launchers
+
+
+def _check_permission_inheritance(install_dir: Path):
+    """Ensure every file in an installation inherits permissions from its parent.
+
+    The installer only fixes each environment's `Scripts` directory, so also verify that
+    conda still puts the entry point launchers there.
+    """
+    prefixes = [install_dir, *install_dir.glob("envs/*")]
+    launchers = [launcher for prefix in prefixes for launcher in _entry_point_launchers(prefix)]
+    assert launchers, "Installation must contain entry point launchers"
+    outside_scripts = [launcher for launcher in launchers if launcher.parent.name != "Scripts"]
+    assert outside_scripts == [], (
+        "Entry point launchers must be in a Scripts directory, "
+        "otherwise the installer does not fix their permissions"
+    )
+
+    protected = []
+    not_inherited = []
+    for file in install_dir.glob("**/*"):
+        security_descriptor = win32security.GetFileSecurity(
+            str(file), win32security.DACL_SECURITY_INFORMATION
+        )
+        dacl_flags = security_descriptor.GetSecurityDescriptorControl()[0]
+        if dacl_flags & win32security.SE_DACL_PROTECTED:
+            protected.append(file)
+        if not dacl_flags & win32security.SE_DACL_AUTO_INHERITED:
+            not_inherited.append(file)
+    assert protected == [], "Files must not be protected from inheriting permissions"
+    assert not_inherited == [], "Files must inherit from installation directory"
+
+
 def test_installer_types_for_example_matches_platform():
     """Validate any example with 'installer_type: all'; and that the resolved types match the platform set."""
     types = installer_types_for_example(_example_path("miniforge"))
@@ -904,6 +951,7 @@ def test_example_extra_envs(tmp_path, request, installer_type):
         if installer_type == InstallerTypes.MSI:
             _run_uninstaller_msi(installer, install_dir)
         else:
+            _check_permission_inheritance(base)
             _run_uninstaller_exe(install_dir=install_dir)
 
 
@@ -1719,9 +1767,8 @@ def test_allusers_exe(tmp_path, request, installer_type):
         sd = win32security.GetFileSecurity(str(filepath), win32security.DACL_SECURITY_INFORMATION)
         dacl_flags = sd.GetSecurityDescriptorControl()[0]
         dacl_info = {
-            "protected": bool(dacl_flags & win32security.SE_DACL_PROTECTED),
-            "inherited": bool(dacl_flags & win32security.SE_DACL_AUTO_INHERITED),
             "permissions": {},
+            "protected": bool(dacl_flags & win32security.SE_DACL_PROTECTED),
         }
         dacl = sd.GetSecurityDescriptorDacl()
         for a in range(dacl.GetAceCount()):
@@ -1779,19 +1826,14 @@ def test_allusers_exe(tmp_path, request, installer_type):
         )
 
     # Test all files inside installation directory
+    _check_permission_inheritance(install_dir)
     incorrect_permissions = {
-        "protected": [],
-        "not_inherited": [],
         "write_access": {acct: [] for acct in SDDL_ABBREVIATIONS},
         "bad_read_exec": {acct: [] for acct in SDDL_ABBREVIATIONS if acct != "AU"},
         "not_set": [],
     }
     for file in install_dir.glob("**/*"):
         dacl = _get_dacl_information(file)
-        if dacl["protected"]:
-            incorrect_permissions["protected"].append(file)
-        if not dacl["inherited"]:
-            incorrect_permissions["not_inherited"].append(file)
         if len(dacl["permissions"].keys()) == 0:
             incorrect_permissions["not_set"].append(file)
             continue
@@ -1805,12 +1847,6 @@ def test_allusers_exe(tmp_path, request, installer_type):
                 permissions["generic_execute"] and permissions["generic_read"]
             ):
                 files.append(file)
-    assert incorrect_permissions["protected"] == [], (
-        "Files must not be protected from inheriting permissions"
-    )
-    assert incorrect_permissions["not_inherited"] == [], (
-        "Files must inherit from installation directory"
-    )
     assert incorrect_permissions["not_set"] == [], (
         "File permission must include either domain or built-in users"
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -845,8 +845,6 @@ def _check_permission_inheritance(install_dir: Path):
     inheritance regardless of location.
     """
     prefixes = [install_dir, *install_dir.glob("envs/*")]
-    launchers = [launcher for prefix in prefixes for launcher in _entry_point_launchers(prefix)]
-    assert launchers, "Installation must contain entry point launchers"
 
     protected = []
     not_inherited = []

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -826,33 +826,27 @@ def _entry_point_launchers(prefix: Path) -> list[Path]:
     """Collect the entry point launchers conda hard linked from a shared stub exe.
 
     The stub has inheritance disabled and hard links share one ACL, so the installer
-    has to re-enable inheritance for these files.
+    has to re-enable inheritance for these files. Detected by hard link count, since
+    that's the filesystem property the installer's fix actually depends on.
     """
-    launchers = []
-    for record in prefix.glob("conda-meta/*.json"):
-        paths_data = json.loads(record.read_text()).get("paths_data", {})
-        launchers.extend(
-            prefix / path["_path"]
-            for path in paths_data.get("paths", [])
-            if path.get("path_type") == "windows_python_entry_point_exe"
-        )
-    return launchers
+    scripts_dir = prefix / "Scripts"
+    if not scripts_dir.is_dir():
+        return []
+    return [file for file in scripts_dir.glob("*.exe") if file.stat().st_nlink > 1]
 
 
 def _check_permission_inheritance(install_dir: Path):
     """Ensure every file in an installation inherits permissions from its parent.
 
-    The installer only fixes each environment's `Scripts` directory, so also verify that
-    conda still puts the entry point launchers there.
+    Also verify the installation actually contains entry point launchers, so this
+    check cannot silently stop testing anything if a future fixture change drops
+    them. If conda ever moves them outside `Scripts` (where the installer's fix is
+    scoped to), the tree-wide scan below will still catch the resulting broken
+    inheritance regardless of location.
     """
     prefixes = [install_dir, *install_dir.glob("envs/*")]
     launchers = [launcher for prefix in prefixes for launcher in _entry_point_launchers(prefix)]
     assert launchers, "Installation must contain entry point launchers"
-    outside_scripts = [launcher for launcher in launchers if launcher.parent.name != "Scripts"]
-    assert outside_scripts == [], (
-        "Entry point launchers must be in a Scripts directory, "
-        "otherwise the installer does not fix their permissions"
-    )
 
     protected = []
     not_inherited = []

--- a/tests/test_winexe.py
+++ b/tests/test_winexe.py
@@ -19,23 +19,3 @@ def test_parse_arch(platform, expected):
     from constructor.winexe import parse_arch
 
     assert parse_arch(platform) == expected
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_write_fix_launcher_acls_bat(tmp_path):
-    """The script is static (no per-env content baked in), uses CRLF line endings,
-    and takes icacls.exe's path plus a variable number of Scripts globs as args.
-    """
-    from constructor.winexe import write_fix_launcher_acls_bat
-
-    write_fix_launcher_acls_bat(str(tmp_path))
-
-    bat_file = tmp_path / "fix_launcher_acls.bat"
-    assert bat_file.exists()
-
-    content = bat_file.read_bytes().decode()
-    assert content.count("\n") == content.count("\r\n"), "every line must end with CRLF"
-    assert "SET ICACLS=%1" in content
-    assert "SHIFT" in content
-    assert "IF ERRORLEVEL 1" in content
-    assert "EXIT /B %ERR%" in content

--- a/tests/test_winexe.py
+++ b/tests/test_winexe.py
@@ -19,3 +19,23 @@ def test_parse_arch(platform, expected):
     from constructor.winexe import parse_arch
 
     assert parse_arch(platform) == expected
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+def test_write_fix_launcher_acls_bat(tmp_path):
+    """The script is static (no per-env content baked in), uses CRLF line endings,
+    and takes icacls.exe's path plus a variable number of Scripts globs as args.
+    """
+    from constructor.winexe import write_fix_launcher_acls_bat
+
+    write_fix_launcher_acls_bat(str(tmp_path))
+
+    bat_file = tmp_path / "fix_launcher_acls.bat"
+    assert bat_file.exists()
+
+    content = bat_file.read_bytes().decode()
+    assert content.count("\n") == content.count("\r\n"), "every line must end with CRLF"
+    assert "SET ICACLS=%1" in content
+    assert "SHIFT" in content
+    assert "IF ERRORLEVEL 1" in content
+    assert "EXIT /B %ERR%" in content


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The `Setting installation directory permissions...` step runs `icacls /T` over all of `$INSTDIR`, which costs ~170 µs per file (~25 s for 150k files) even though only a few files actually needed fixing. This PR scopes it to one call per environment against that environment's `Scripts` directory.

#### Investigation into `conda`
Only `Scripts` is affected because exactly one conda code path hard links from a shared template: `LinkPathAction.create_python_entry_point_windows_exe_action`, whose target is hard coded to `Scripts/{command}.exe`. That template is the launcher stub inside `conda-standalone`'s `_MEI*` directory, which is created with an explicit user-only ACE and no inheritance; since hard links share one security descriptor, every launcher inherits that broken ACL. All other candidate directories are ruled out in code — `condabin` and `Library\bin` only ever get fresh writes from `conda init`, `Library\usr\bin` never gets generated files at all, and `Scripts\conda.exe` is a `copy()`.

`test_allusers_exe` is our guard for a future regression if conda ever creates launchers elsewhere. Its guard is now extracted and also called from `test_example_extra_envs` to cover the per-environment loop, and it additionally asserts that `windows_python_entry_point_exe` paths exist and all live in a `Scripts` directory, this way the test cannot silently stop testing this.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
