### PR TITLE
Only warn when attempting to install an AMD64 EXE installer on ARM64

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -658,22 +658,39 @@ Function .onInit
     # on whether it's a 32-bit or 64-bit installer
     SetRegView {{ BITS }}
 {%- if win64 %}
-    # Make sure we're not on 32-bit or native ARM64 Windows (the latter would
-    # otherwise silently run this x64 installer under x64 emulation).
-    ${IfNot} ${IsNativeAMD64}
+    ${If} ${IsNativeARM64}
+        # Warn if not running on AMD64, but do not abort since ARM64 can still run
+        # AMD64 programs with emulation.
+        ${Print} "This installer is for the 64-bit AMD (x86_64) version of ${NAME} \
+                  but your system is ARM64. It is recommended to use an installer \
+                  that matches your system's architecture."
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+            "This installer is for the 64-bit AMD (x86_64) version of ${NAME} \
+            but your system is ARM64. It is recommended to use an installer \
+            that matches your system's architecture." \
+            /SD IDOK IDOK +2
+            Abort
+    ${ElseIfNot} ${RunningX64}
+        # If we're a 64-bit installer, make sure it's 64-bit Windows
+        ${Print} "::error:: This installer is for a 64-bit version for ${NAME} \
+                  but your system is 32-bit. Please use the 32-bit Windows \
+                  ${NAME} installer."
         MessageBox MB_OK|MB_ICONEXCLAMATION \
-            "This installer is for the 64-bit (x86_64) version of ${NAME}$\n\
-            but your system is not x86_64. Please use the installer that$\n\
-            matches your system's architecture." \
+            "This installer is for a 64-bit version for ${NAME} \
+            but your system is 32-bit. Please use the 32-bit Windows \
+            ${NAME} installer." \
             /SD IDOK
         Abort
     ${EndIf}
 {%- elif win_arm64 %}
     # Make sure we're actually on native ARM64 Windows.
     ${IfNot} ${IsNativeARM64}
+        ${Print} "::error::This installer is for the ARM64 version of ${NAME} \
+                  but your system is not ARM64. Please use the installer that \
+                  matches your system's architecture."
         MessageBox MB_OK|MB_ICONEXCLAMATION \
-            "This installer is for the ARM64 version of ${NAME}$\n\
-            but your system is not ARM64. Please use the installer that$\n\
+            "This installer is for the ARM64 version of ${NAME} \
+            but your system is not ARM64. Please use the installer that \
             matches your system's architecture." \
             /SD IDOK
         Abort

--- a/news/1337-windows-arch-check-warnings
+++ b/news/1337-windows-arch-check-warnings
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* EXE installers: only warn when attempting to install a Windows AMD64 installer on ARM64. (#1337)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

The architecture checks introduced in #1323 for EXE installers prevent the installation of an AMD64 EXE installer onto an ARM64 system. ARM64, however, can run AMD64 executables with emulation. Instead of aborting, issue a warning to the user. Non-interactive installations will continue whereas the user is presented with a choice about whether they wish to continue (see screenshots).

I also used the opportunity to add output for non-interactive installations for the other checks and remove hard-coded line breaks (NSIS does it automatically).

<img width="408" height="153" alt="Screenshot 2026-08-27 104545" src="https://github.com/user-attachments/assets/bf77fd59-0d3d-430b-b88a-d391b45a2f98" />
<img width="912" height="78" alt="Screenshot 2026-08-27 104654" src="https://github.com/user-attachments/assets/a3049684-0307-43ca-8caa-254f0ba27f9a" />

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?