### PR TITLE
Fix CWE-426 (Untrusted Search Path) in the main NSIS template

### DIFF
--- a/constructor/nsis/main.nsi.tmpl
+++ b/constructor/nsis/main.nsi.tmpl
@@ -190,9 +190,10 @@ var /global ICACLS_EXE
         StrCpy $CMD_EXE "$R1\System32\cmd.exe"
         StrCpy $ICACLS_EXE "$R1\System32\icacls.exe"
     ${Else}
-        # Cross our fingers binaries are in PATH
-        StrCpy $CMD_EXE "cmd.exe"
-        StrCpy $ICACLS_EXE "icacls.exe"
+        # Error out to prevent CWE-426 Untrusted Search Path vulnerabilities
+        ${Print} "::error:: Could not locate Windows system directory (SystemRoot or windir). Aborting for security."
+        MessageBox MB_OK|MB_ICONSTOP "Critical Error: Could not locate the Windows system directory. Installation cannot proceed safely." /SD IDOK
+        Abort
     ${EndIf}
 !macroend
 
@@ -1710,7 +1711,7 @@ Section "Install"
         # Force remove any leftovers, note that locked files may still remain
         # See https://github.com/conda/constructor/issues/1213
         ${If} ${FileExists} "$INSTDIR\pkgs"
-            nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR\pkgs"'
+            nsExec::Exec '"$CMD_EXE" /D /C RMDIR /Q /S "$INSTDIR\pkgs"'
         ${EndIf}
     ${EndIf}
 
@@ -1957,6 +1958,9 @@ Section "Uninstall"
         StrCpy $R0 "system"
     ${EndIf}
     # `type` is used to simulate a `tee`-like output in cmd.exe
+    # Note: 'cmd.exe' below is a literal string argument passed to the 'conda init'
+    # subcommand indicating the shell type. It is not an executable being launched
+    # by the system, so it does not pose a CWE-426 Untrusted Search Path vulnerability.
     push '"$INSTDIR\condabin\conda.bat" init cmd.exe --reverse --$R0 > "${STEP_LOG}" 2>&1 & SET ERR=!ERRORLEVEL! & type "${STEP_LOG}" & EXIT /B !ERR!'
     push 'Failed to clean AutoRun'
     push 'WithLog'
@@ -1964,7 +1968,7 @@ Section "Uninstall"
 {%- endif %}
 
     ${Print} "Removing files and folders..."
-    nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR"'
+    nsExec::Exec '"$CMD_EXE" /D /C RMDIR /Q /S "$INSTDIR"'
 
     # Stop logging or the uninstaller will not remove the install.log file
     # without requiring a reboot

--- a/examples/custom_nsis_template/custom.nsi.tmpl
+++ b/examples/custom_nsis_template/custom.nsi.tmpl
@@ -675,7 +675,7 @@ Section "Uninstall"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
 
     DetailPrint "Removing files and folders..."
-    nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR"'
+    nsExec::Exec '"$SYSDIR\cmd.exe" /D /C RMDIR /Q /S "$INSTDIR"'
 
     # In case the last command fails, run the slow method to remove leftover
     RMDir /r /REBOOTOK "$INSTDIR"

--- a/examples/custom_nsis_template/custom.nsi.tmpl
+++ b/examples/custom_nsis_template/custom.nsi.tmpl
@@ -676,7 +676,7 @@ Section "Uninstall"
     !insertmacro AbortRetryNSExecWaitLibNsisCmd "rmreg"
 
     DetailPrint "Removing files and folders..."
-    nsExec::Exec '"$SYSDIR\cmd.exe" /D /C RMDIR /Q /S "$INSTDIR"'
+    nsExec::Exec 'cmd.exe /D /C RMDIR /Q /S "$INSTDIR"'
 
     # In case the last command fails, run the slow method to remove leftover
     RMDir /r /REBOOTOK "$INSTDIR"

--- a/examples/custom_nsis_template/custom.nsi.tmpl
+++ b/examples/custom_nsis_template/custom.nsi.tmpl
@@ -1,4 +1,5 @@
 # Installer template file for creating a Windows installer using NSIS.
+# This example is not actively maintained, use the main template as a blueprint for custom templates instead.
 
 # Dependencies:
 #   NSIS >=3.08      conda install "nsis>=3.08"  (includes extra unicode plugins)

--- a/news/TEMPLATE
+++ b/news/TEMPLATE
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* <news item>
+* Mitigated a CWE-426 untrusted search path vulnerability in the example `custom.nsi.tmpl` by using a fully qualified path to `$SYSDIR\cmd.exe`.
 
 ### Deprecations
 

--- a/news/TEMPLATE
+++ b/news/TEMPLATE
@@ -4,11 +4,11 @@
 
 ### Bug fixes
 
-* Mitigated a CWE-426 untrusted search path vulnerability in the example `custom.nsi.tmpl` by using a fully qualified path to `$SYSDIR\cmd.exe`.
+* Mitigated a CWE-426 untrusted search path vulnerability in the template `main.nsi.tmpl` by using a fully qualified path to `$CMD_EXE`. (#1341)
 
 ### Deprecations
 
-* <news item>
+* Marked the example custom NSIS template (`custom.nsi.tmpl`) as unmaintained and directed users to use `main.nsi.tmpl` as a blueprint.
 
 ### Docs
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Mitigating CWE-426 vulnerability in the example NSIS template by using a fully qualified path instead of naked `cmd.exe`.

Many dev teams build up on this example for their custom installers. This propagates the vulnerability downstream to other projects.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/constructor/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/constructor/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/constructor/blob/main/CONTRIBUTING.md -->
